### PR TITLE
test: Mark write accesses separately.

### DIFF
--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -524,6 +524,10 @@ public:
                             this->emitLocalOccurrence(cfg, bb, send->recv.occurrence(), ValueCategory::RValue);
                         }
 
+                        // TODO:(varun) For arrays, hashes etc., try to identify if the function
+                        // matches a known operator (e.g. []=), and emit an appropriate 'WriteAccess'
+                        // symbol role for it.
+
                         // Emit reference for the method being called
                         if (send->fun.exists() && !isTemporary(gs, core::LocalVariable(send->fun, 1))) {
                             // HACK(varun): We should probably add a helper function to check

--- a/test/scip/testdata/syntax.rb.snapshot
+++ b/test/scip/testdata/syntax.rb.snapshot
@@ -31,13 +31,13 @@
    if x == 2
 #     ^ reference local 1~#2634721084
      z += y
-#    ^ reference local 3~#2634721084
+#    ^ reference (write) local 3~#2634721084
 #    ^ reference local 3~#2634721084
 #         ^ reference local 2~#2634721084
    else
      z += x
 #    ^ reference local 3~#2634721084
-#    ^ reference local 3~#2634721084
+#    ^ reference (write) local 3~#2634721084
 #         ^ reference local 1~#2634721084
    end
    z

--- a/test/scip_test_runner.cc
+++ b/test/scip_test_runner.cc
@@ -188,8 +188,14 @@ void formatSnapshot(const scip::Document &document, std::ostream &out) {
             }
             bool isDefinition = ((unsigned(occ.symbol_roles()) & unsigned(scip::SymbolRole::Definition)) > 0);
 
+            string symbolRole = "";
+            if (!isDefinition && (occ.symbol_roles() & scip::SymbolRole::WriteAccess)) {
+                symbolRole = (occ.symbol_roles() & scip::SymbolRole::ReadAccess) ? "(read+write) " : "(write) ";
+            }
+
             out << '#' << string(range.start.column - 1, ' ') << string(range.end.column - range.start.column, '^')
-                << ' ' << string(isDefinition ? "definition" : "reference") << ' ' << formatSymbol(occ.symbol());
+                << ' ' << string(isDefinition ? "definition" : "reference") << ' ' << symbolRole
+                << formatSymbol(occ.symbol());
             if (!(isDefinition && symbolTable.contains(occ.symbol()))) {
                 out << '\n';
                 occ_i++;


### PR DESCRIPTION
This helps reduce confusion between seemingly duplicate references
(one of them is a write). It also surfaces the bit that we aren't handling
writes for arrays and hashes correctly.

### Test plan

Updated snapshot.