### PR TITLE
fix: Stop emitting definitions for <static-init>.

### DIFF
--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -809,8 +809,10 @@ public:
         }
 
         auto scipState = this->getSCIPState();
-        auto status = scipState->saveDefinition(gs, file, core::SymbolRef(methodDef.symbol));
-        ENFORCE(status.ok());
+        if (methodDef.name != core::Names::staticInit()) {
+            auto status = scipState->saveDefinition(gs, file, core::SymbolRef(methodDef.symbol));
+            ENFORCE(status.ok());
+        }
         // It looks like Sorbet only stores symbols at the granularity of classes and methods
         // So we need to recompute local variable information from scratch. The LocalVarFinder
         // which is used by the LSP implementation is tailored for finding the local variable

--- a/test/scip/testdata/args.snapshot.rb
+++ b/test/scip/testdata/args.snapshot.rb
@@ -2,7 +2,6 @@
  
  def args(x, y)
 #^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO args().
-#^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
 #         ^ definition local 1~#2634721084
 #            ^ definition local 2~#2634721084
    z = x + y

--- a/test/scip/testdata/arrays.snapshot.rb
+++ b/test/scip/testdata/arrays.snapshot.rb
@@ -2,7 +2,6 @@
  
  def arrays(a, i)
 #^^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO arrays().
-#^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
 #           ^ definition local 1~#513334479
 #              ^ definition local 2~#513334479
    a[0] = 0

--- a/test/scip/testdata/classes.snapshot.rb
+++ b/test/scip/testdata/classes.snapshot.rb
@@ -2,10 +2,8 @@
  
  _ = 0
 #^ definition local 1~#119448696
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
  
  class C1
-#^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
 #      ^^ definition scip-ruby gem TODO TODO C1#
    def f()
 #  ^^^^^^^ definition scip-ruby gem TODO TODO f().
@@ -21,16 +19,13 @@
  end
  
  module M2
-#^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
 #       ^^ definition scip-ruby gem TODO TODO M2#
    class C2
-#  ^^^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
 #        ^^ definition scip-ruby gem TODO TODO C2#
    end
  end
  
  class M3::C3
-#^^^^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
 #      ^^ definition scip-ruby gem TODO TODO M3#
 #          ^^ definition scip-ruby gem TODO TODO C3#
  end
@@ -57,7 +52,6 @@
  end
  
  module M4
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
 #       ^^ definition scip-ruby gem TODO TODO M4#
    K = 0
 #  ^ definition local 1~#119448696
@@ -74,10 +68,8 @@
  end
  
  module M5
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
 #       ^^ definition scip-ruby gem TODO TODO M5#
    module M6
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
 #         ^^ definition scip-ruby gem TODO TODO M6#
      def self.g()
 #    ^^^^^^^^^^^^ definition scip-ruby gem TODO TODO g().
@@ -93,10 +85,8 @@
  end
  
  class C7
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
 #      ^^ definition scip-ruby gem TODO TODO C7#
    module M8
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
 #         ^^ definition scip-ruby gem TODO TODO M8#
      def self.i()
 #    ^^^^^^^^^^^^ definition scip-ruby gem TODO TODO i().

--- a/test/scip/testdata/for.snapshot.rb
+++ b/test/scip/testdata/for.snapshot.rb
@@ -2,7 +2,6 @@
  
  def for_loop()
 #^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO for_loop().
-#^^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
    y = 0
 #  ^ definition local 1~#1120785331
    for x in [1, 2, 3]

--- a/test/scip/testdata/functions.snapshot.rb
+++ b/test/scip/testdata/functions.snapshot.rb
@@ -2,7 +2,6 @@
  
  def globalFn1()
 #^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO globalFn1().
-#^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
    x = 10
 #  ^ definition local 1~#3846536873
    x

--- a/test/scip/testdata/hashes.snapshot.rb
+++ b/test/scip/testdata/hashes.snapshot.rb
@@ -2,7 +2,6 @@
  
  def hashes(h, k)
 #^^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO hashes().
-#^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
 #           ^ definition local 1~#1685166589
 #              ^ definition local 2~#1685166589
    h["hello"] = "world"

--- a/test/scip/testdata/loops_and_conditionals.snapshot.rb
+++ b/test/scip/testdata/loops_and_conditionals.snapshot.rb
@@ -2,7 +2,6 @@
  
  def if_elsif_else()
 #^^^^^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO if_elsif_else().
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO <static-init>().
    x = 0
 #  ^ definition local 1~#2393773952
    y = 0


### PR DESCRIPTION
Should've fixed this earlier; it is needlessly polluting the snapshots.