### PR TITLE
feat: Add flag to indicate gem name + version.

### DIFF
--- a/test/scip/testdata/gem_metadata.rb
+++ b/test/scip/testdata/gem_metadata.rb
@@ -1,0 +1,11 @@
+# typed: true
+# gem-metadata: leet@1.3.3.7
+
+class C
+  def m
+    n
+  end
+  def n
+    m
+  end
+end

--- a/test/scip/testdata/gem_metadata.snapshot.rb
+++ b/test/scip/testdata/gem_metadata.snapshot.rb
@@ -1,0 +1,16 @@
+ # typed: true
+ # gem-metadata: leet@1.3.3.7
+ 
+ class C
+#      ^ definition scip-ruby gem leet 1.3.3.7 C#
+   def m
+#  ^^^^^ definition scip-ruby gem leet 1.3.3.7 C#m().
+     n
+#    ^ reference scip-ruby gem leet 1.3.3.7 C#n().
+   end
+   def n
+#  ^^^^^ definition scip-ruby gem leet 1.3.3.7 C#n().
+     m
+#    ^ reference scip-ruby gem leet 1.3.3.7 C#m().
+   end
+ end


### PR DESCRIPTION
### Motivation

This allows us to upload an accurate index by at least manually passing this flag.
In the future, we will likely want to infer the configuration without the flag,
but it will be useful to have an override, e.g. for testing.

### Test plan

See included automated tests.
