### PR TITLE
fix: Fix crash with default arguments.

### DIFF
--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -825,7 +825,10 @@ public:
                 }
                 // For aliases, don't emit an occurrence for the LHS; it will be emitted
                 // when the alias is used or separately at the end. See NOTE[alias-handling].
-                if (binding.value.tag() != cfg::Tag::Alias) {
+                //
+                // For ArgPresent instructions (which come up with default arguments), we will
+                // emit defs/refs for direct usages, so don't emit a local for the temporary here.
+                if (binding.value.tag() != cfg::Tag::Alias && binding.value.tag() != cfg::Tag::ArgPresent) {
                     // Emit occurrence information for the LHS
                     auto occ = cfg::LocalOccurrence{binding.bind.variable, lhsLocIfPresent(binding)};
                     this->emitLocalOccurrence(cfg, bb, occ, ValueCategory::LValue);

--- a/test/scip/testdata/args.rb
+++ b/test/scip/testdata/args.rb
@@ -9,3 +9,16 @@ def args(x, y)
   end
   z
 end
+
+def keyword_args(w:, x: 3, y: [], **kwargs)
+  y << w + x
+  y << [a]
+  return
+end
+
+def use_kwargs
+  h = { a: 3 }
+  keyword_args(w: 0, **h)
+  keyword_args(w: 0, x: 1, y: [2], **h)
+  return
+end

--- a/test/scip/testdata/args.snapshot.rb
+++ b/test/scip/testdata/args.snapshot.rb
@@ -23,3 +23,30 @@
    z
 #  ^ reference local 3~#2634721084
  end
+ 
+ def keyword_args(w:, x: 3, y: [], **kwargs)
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO Object#keyword_args().
+#                 ^^ definition local 1~#3526982640
+#                     ^^ definition local 2~#3526982640
+#                           ^^ definition local 3~#3526982640
+   y << w + x
+#  ^ reference local 3~#3526982640
+#       ^ reference local 1~#3526982640
+#           ^ reference local 2~#3526982640
+   y << [a]
+#  ^ reference local 3~#3526982640
+   return
+ end
+ 
+ def use_kwargs
+#^^^^^^^^^^^^^^ definition scip-ruby gem TODO TODO Object#use_kwargs().
+   h = { a: 3 }
+#  ^ definition local 1~#571973038
+   keyword_args(w: 0, **h)
+#  ^^^^^^^^^^^^ reference scip-ruby gem TODO TODO Object#keyword_args().
+#                       ^ reference local 1~#571973038
+   keyword_args(w: 0, x: 1, y: [2], **h)
+#  ^^^^^^^^^^^^ reference scip-ruby gem TODO TODO Object#keyword_args().
+#                                     ^ reference local 1~#571973038
+   return
+ end


### PR DESCRIPTION
Without this patch, we trigger the ENFORCE where multiple local variables
share the same source location for their definition.

### Motivation

Progress towards #1.

### Test plan

See included automated tests.
