### PR TITLE
fix: Fix crash with duplicate alias locs.

### DIFF
--- a/test/scip/testdata/types.rb
+++ b/test/scip/testdata/types.rb
@@ -3,3 +3,11 @@
 def f()
   T.let(true, T::Boolean)
 end
+
+module M
+  module_function
+  sig { returns(T::Boolean) }
+  def b
+    true
+  end
+end

--- a/test/scip/testdata/types.snapshot.rb
+++ b/test/scip/testdata/types.snapshot.rb
@@ -6,3 +6,21 @@
 #              ^ reference scip-ruby gem TODO TODO T#
 #                 ^^^^^^^ reference scip-ruby gem TODO TODO T#Boolean.
  end
+ 
+ module M
+#       ^ definition scip-ruby gem TODO TODO M#
+   module_function
+   sig { returns(T::Boolean) }
+#  ^^^ reference scip-ruby gem TODO TODO Sorbet#Private#Static#<Class:ResolvedSig>#sig().
+#  ^^^ reference scip-ruby gem TODO TODO Sorbet#Private#Static#<Class:ResolvedSig>#sig().
+#                ^ reference scip-ruby gem TODO TODO T#
+#                   ^^^^^^^ reference scip-ruby gem TODO TODO T#Boolean.
+#                   ^^^^^^^ reference scip-ruby gem TODO TODO T#Boolean.
+#                   ^^^^^^^^^^ reference scip-ruby gem TODO TODO Sorbet#Private#Static#ResolvedSig#
+#                   ^^^^^^^^^^ reference scip-ruby gem TODO TODO Sorbet#Private#Static#ResolvedSig#
+   def b
+#  ^^^^^ definition scip-ruby gem TODO TODO M#b().
+#  ^^^^^ definition scip-ruby gem TODO TODO <Class:M>#b().
+     true
+   end
+ end


### PR DESCRIPTION
### Motivation

This ENFORCE was triggered when trying to index Homebrew/brew.

### Test plan

See included automated tests.
