### PR TITLE
cleanup: Minor changes to --help output.

### DIFF
--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -1248,9 +1248,8 @@ class SCIPSemanticExtensionProvider : public SemanticExtensionProvider {
 public:
     void injectOptions(cxxopts::Options &optsBuilder) const override {
         optsBuilder.add_options("indexer")("index-file", "Output SCIP index to a directory, which must already exist",
-                                           cxxopts::value<string>());
-        optsBuilder.add_options("name@version")(
-            "gem-metadata", "Name and version pair to be used for cross-repository code navigation.",
+                                           cxxopts::value<string>())(
+            "gem-metadata", "Metadata in 'name@version' format to be used for cross-repository code navigation.",
             cxxopts::value<string>());
     };
     unique_ptr<SemanticExtension> readOptions(cxxopts::ParseResult &providedOptions) const override {

--- a/test/scip_test_runner.cc
+++ b/test/scip_test_runner.cc
@@ -431,9 +431,8 @@ bool ends_with(const std::string &s, const std::string &suffix) {
 int main(int argc, char *argv[]) {
     cxxopts::Options options("test_corpus_scip", "SCIP test corpus for Sorbet typechecker");
     options.allow_unrecognised_options().add_options()("output", "path to output file or directory",
-                                                       cxxopts::value<std::string>()->default_value(""),
-                                                       "path")("update-snapshots", "");
-    //("--update-snapshots", "should the snapshot files be overwritten if there are changes");
+                                                       cxxopts::value<std::string>()->default_value(""), "path")(
+        "update-snapshots", "should the snapshot files be overwritten if there are changes");
     auto res = options.parse(argc, argv);
 
     for (auto &input : res.unmatched()) {


### PR DESCRIPTION
### Motivation

The `name@version` was acting as a group not an argument placeholder.

### Test plan

n/a