### PR TITLE
fix: Fix crash when inheriting from class defined in untyped code.

### DIFF
--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -918,7 +918,7 @@ public:
                 status = this->scipState.saveDefinition(gs, file, namedSym, arg.loc);
                 kind = "definition";
             } else {
-                status = this->scipState.saveReference(gs, file, namedSym, arg.loc, referenceRole);
+                status = this->scipState.saveReference(gs, file, namedSym, arg.loc, 0);
                 kind = "reference";
             }
             ENFORCE(status.ok(), "failed to save {} for {}\ncontext:\ninstruction: {}\nlocation: {}\n", kind,

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -912,9 +912,17 @@ public:
                 isMethodFileStaticInit ||
                 method == gs.lookupStaticInitForClass(namedSym.asSymbolRef().asClassOrModuleRef().data(gs)->owner,
                                                       /*allowMissing*/ true);
-            ENFORCE(check);
-            auto status = this->scipState.saveDefinition(gs, file, namedSym, arg.loc);
-            ENFORCE(status.ok());
+            absl::Status status;
+            string kind;
+            if (check) {
+                status = this->scipState.saveDefinition(gs, file, namedSym, arg.loc);
+                kind = "definition";
+            } else {
+                status = this->scipState.saveReference(gs, file, namedSym, arg.loc, 0);
+                kind = "reference";
+            }
+            ENFORCE(status.ok(), "failed to save {} for {}\ncontext:\ninstruction: {}\nlocation: {}\n", kind,
+                    namedSym.showRaw(gs), binding.value.showRaw(gs, cfg), core::Loc(file, arg.loc).showRaw(gs));
             return true;
         };
 

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -918,7 +918,7 @@ public:
                 status = this->scipState.saveDefinition(gs, file, namedSym, arg.loc);
                 kind = "definition";
             } else {
-                status = this->scipState.saveReference(gs, file, namedSym, arg.loc, 0);
+                status = this->scipState.saveReference(gs, file, namedSym, arg.loc, referenceRole);
                 kind = "reference";
             }
             ENFORCE(status.ok(), "failed to save {} for {}\ncontext:\ninstruction: {}\nlocation: {}\n", kind,

--- a/test/scip/testdata/multifile/typed-false-mix/def_untyped.rb
+++ b/test/scip/testdata/multifile/typed-false-mix/def_untyped.rb
@@ -1,0 +1,4 @@
+# typed: false
+
+class C
+end

--- a/test/scip/testdata/multifile/typed-false-mix/def_untyped.snapshot.rb
+++ b/test/scip/testdata/multifile/typed-false-mix/def_untyped.snapshot.rb
@@ -1,0 +1,5 @@
+ # typed: false
+ 
+ class C
+#      ^ definition [..] C#
+ end

--- a/test/scip/testdata/multifile/typed-false-mix/use_untyped.rb
+++ b/test/scip/testdata/multifile/typed-false-mix/use_untyped.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+require 'def_untyped'
+
+module N
+  class D < C
+  end
+end

--- a/test/scip/testdata/multifile/typed-false-mix/use_untyped.snapshot.rb
+++ b/test/scip/testdata/multifile/typed-false-mix/use_untyped.snapshot.rb
@@ -1,0 +1,11 @@
+ # typed: true
+ 
+ require 'def_untyped'
+ 
+ module N
+#       ^ definition [..] N#
+   class D < C
+#        ^ definition [..] N#D#
+#            ^ reference [..] C#
+   end
+ end


### PR DESCRIPTION
Encountered when indexing Homebrew/brew.

### Motivation

Crash == bad.

### Test plan

Added test.