### PR TITLE
feat: Add override_documentation for type changes.

### DIFF
--- a/test/scip/testdata/freeze_constants.rb
+++ b/test/scip/testdata/freeze_constants.rb
@@ -1,0 +1,13 @@
+# typed: true
+# options: showDocs
+
+X = 'X'.freeze
+Y = 'Y'.freeze
+A = %w[X Y].freeze
+B = %W[#{X} Y].freeze
+
+module M
+  Z = 'Z'.freeze
+  A = %w[X Y Z].freeze
+  B = %W[#{X} Y Z].freeze
+end

--- a/test/scip/testdata/freeze_constants.snapshot.rb
+++ b/test/scip/testdata/freeze_constants.snapshot.rb
@@ -1,0 +1,55 @@
+ # typed: true
+ # options: showDocs
+ 
+ X = 'X'.freeze
+#^ definition [..] X.
+#documentation
+#| ```ruby
+#| ::X = T.let(_, T.untyped)
+#| ```
+ Y = 'Y'.freeze
+#^ definition [..] Y.
+#documentation
+#| ```ruby
+#| ::Y = T.let(_, T.untyped)
+#| ```
+ A = %w[X Y].freeze
+#^ definition [..] A.
+#documentation
+#| ```ruby
+#| ::A = T.let(_, T.untyped)
+#| ```
+ B = %W[#{X} Y].freeze
+#^ definition [..] B.
+#documentation
+#| ```ruby
+#| ::B = T.let(_, T.untyped)
+#| ```
+#         ^ reference [..] X.
+ 
+ module M
+#       ^ definition [..] M#
+#       documentation
+#       | ```ruby
+#       | module M
+#       | ```
+   Z = 'Z'.freeze
+#  ^ definition [..] M#Z.
+#  documentation
+#  | ```ruby
+#  | ::M::Z = T.let(_, T.untyped)
+#  | ```
+   A = %w[X Y Z].freeze
+#  ^ definition [..] M#A.
+#  documentation
+#  | ```ruby
+#  | ::M::A = T.let(_, T.untyped)
+#  | ```
+   B = %W[#{X} Y Z].freeze
+#  ^ definition [..] M#B.
+#  documentation
+#  | ```ruby
+#  | ::M::B = T.let(_, T.untyped)
+#  | ```
+#           ^ reference [..] X.
+ end

--- a/test/scip/testdata/hoverdocs.snapshot.rb
+++ b/test/scip/testdata/hoverdocs.snapshot.rb
@@ -327,6 +327,10 @@
 #    | @@y = T.let(_, T.untyped)
 #    | ```
 #    ^^^^^^^^ reference [..] K1#@@y.
+#    override_documentation
+#    | ```ruby
+#    | @@y = T.let(_, Integer(10))
+#    | ```
    end
  
    # lorem ipsum, you get it
@@ -346,6 +350,10 @@
 #    | @z = T.let(_, T.untyped)
 #    | ```
 #    ^^^^^^^ reference [..] <Class:K1>#@z.
+#    override_documentation
+#    | ```ruby
+#    | @z = T.let(_, Integer(10))
+#    | ```
    end
  end
  
@@ -402,5 +410,9 @@
 #    ^^ reference (write) [..] K2#@z.
 #    ^^^^^^^^ reference [..] K2#@z.
 #          ^^ reference [..] K2#@x.
+#          override_documentation
+#          | ```ruby
+#          | @x = T.let(_, Integer(20))
+#          | ```
    end
  end

--- a/test/scip/testdata/type_change.rb
+++ b/test/scip/testdata/type_change.rb
@@ -1,0 +1,67 @@
+# typed: true
+# options: showDocs
+
+def assign_different_branches(b)
+  if b
+    x = 1
+  else
+    x = nil
+  end
+  return
+end
+
+def change_different_branches(b)
+  x = 'foo'
+  if b
+    x = 1
+  else
+    x = nil
+  end
+  return
+end
+
+def loop_type_change(bs)
+  x = nil
+  for b in bs
+    puts x
+    if b
+      x = 1
+    else
+      x = 's'
+    end
+  end
+  return
+end
+
+class C
+  @k = nil
+
+  def change_type(b)
+    @f = nil
+    @@g = nil
+    @k = nil
+    if b
+      @f = 1
+      @@g = 1
+      @k = 1
+    else
+      @f = 'f'
+      @@g = 'g'
+      @k = 'k'
+    end
+  end
+end
+
+class D < C
+  def change_type(b)
+    if !b
+      @f = 1
+      @@g = 1
+      @k = 1
+    else
+      @f = 'f'
+      @@g = 'g'
+      @k = 'k'
+    end
+  end
+end

--- a/test/scip/testdata/type_change.snapshot.rb
+++ b/test/scip/testdata/type_change.snapshot.rb
@@ -1,0 +1,295 @@
+ # typed: true
+ # options: showDocs
+ 
+ def assign_different_branches(b)
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] Object#assign_different_branches().
+#documentation
+#| ```ruby
+#| sig {params(b: T.untyped).returns(T.untyped)}
+#| def assign_different_branches(b)
+#| ```
+#                              ^ definition local 1~#3317016627
+#                              documentation
+#                              | ```ruby
+#                              | b = T.let(_, T.untyped)
+#                              | ```
+   if b
+     x = 1
+#    ^ definition local 2~#3317016627
+#    documentation
+#    | ```ruby
+#    | x = T.let(_, Integer(1))
+#    | ```
+   else
+     x = nil
+#    ^ definition local 2~#3317016627
+#    documentation
+#    | ```ruby
+#    | x = T.let(_, Integer(1))
+#    | ```
+   end
+   return
+ end
+ 
+ def change_different_branches(b)
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] Object#change_different_branches().
+#documentation
+#| ```ruby
+#| sig {params(b: T.untyped).returns(T.untyped)}
+#| def change_different_branches(b)
+#| ```
+#                              ^ definition local 1~#2122680152
+#                              documentation
+#                              | ```ruby
+#                              | b = T.let(_, T.untyped)
+#                              | ```
+   x = 'foo'
+#  ^ definition local 2~#2122680152
+#  documentation
+#  | ```ruby
+#  | x = T.let(_, String("foo"))
+#  | ```
+   if b
+     x = 1
+#    ^ reference (write) local 2~#2122680152
+#    override_documentation
+#    | ```ruby
+#    | x = T.let(_, Integer(1))
+#    | ```
+   else
+     x = nil
+#    ^ reference (write) local 2~#2122680152
+#    override_documentation
+#    | ```ruby
+#    | x = T.let(_, NilClass)
+#    | ```
+   end
+   return
+ end
+ 
+ def loop_type_change(bs)
+#^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] Object#loop_type_change().
+#documentation
+#| ```ruby
+#| sig {params(bs: T.untyped).returns(T.untyped)}
+#| def loop_type_change(bs)
+#| ```
+#                     ^^ definition local 1~#4057334513
+#                     documentation
+#                     | ```ruby
+#                     | bs = T.let(_, T.untyped)
+#                     | ```
+   x = nil
+#  ^ definition local 2~#4057334513
+#  documentation
+#  | ```ruby
+#  | x = T.let(_, NilClass)
+#  | ```
+   for b in bs
+#      ^ definition local 3~#4057334513
+#      documentation
+#      | ```ruby
+#      | b = T.let(_, T.untyped)
+#      | ```
+#           ^^ reference local 1~#4057334513
+     puts x
+#         ^ reference local 2~#4057334513
+     if b
+       x = 1
+#      ^ reference (write) local 2~#4057334513
+#      override_documentation
+#      | ```ruby
+#      | x = T.let(_, T.untyped)
+#      | ```
+#      ^^^^^ reference local 2~#4057334513
+#      override_documentation
+#      | ```ruby
+#      | x = 1 = T.let(_, T.untyped)
+#      | ```
+     else
+       x = 's'
+#      ^ reference (write) local 2~#4057334513
+#      override_documentation
+#      | ```ruby
+#      | x = T.let(_, T.untyped)
+#      | ```
+#      ^^^^^^^ reference local 2~#4057334513
+#      override_documentation
+#      | ```ruby
+#      | x = 's' = T.let(_, T.untyped)
+#      | ```
+     end
+   end
+   return
+ end
+ 
+ class C
+#      ^ definition [..] C#
+#      documentation
+#      | ```ruby
+#      | class C
+#      | ```
+   @k = nil
+#  ^^ definition [..] <Class:C>#@k.
+#  documentation
+#  | ```ruby
+#  | @k = T.let(_, T.untyped)
+#  | ```
+ 
+   def change_type(b)
+#  ^^^^^^^^^^^^^^^^^^ definition [..] C#change_type().
+#  documentation
+#  | ```ruby
+#  | sig {params(b: T.untyped).returns(T.untyped)}
+#  | def change_type(b)
+#  | ```
+#                  ^ definition local 1~#2066187318
+#                  documentation
+#                  | ```ruby
+#                  | b = T.let(_, T.untyped)
+#                  | ```
+     @f = nil
+#    ^^ definition [..] C#@f.
+#    documentation
+#    | ```ruby
+#    | @f = T.let(_, T.untyped)
+#    | ```
+     @@g = nil
+#    ^^^ definition [..] C#@@g.
+#    documentation
+#    | ```ruby
+#    | @@g = T.let(_, T.untyped)
+#    | ```
+     @k = nil
+#    ^^ definition [..] C#@k.
+#    documentation
+#    | ```ruby
+#    | @k = T.let(_, T.untyped)
+#    | ```
+     if b
+       @f = 1
+#      ^^ reference (write) [..] C#@f.
+#      override_documentation
+#      | ```ruby
+#      | @f = T.let(_, Integer(1))
+#      | ```
+       @@g = 1
+#      ^^^ reference (write) [..] C#@@g.
+#      override_documentation
+#      | ```ruby
+#      | @@g = T.let(_, Integer(1))
+#      | ```
+       @k = 1
+#      ^^ reference (write) [..] C#@k.
+#      override_documentation
+#      | ```ruby
+#      | @k = T.let(_, Integer(1))
+#      | ```
+#      ^^^^^^ reference [..] C#@k.
+#      override_documentation
+#      | ```ruby
+#      | @k = T.let(_, Integer(1))
+#      | ```
+     else
+       @f = 'f'
+#      ^^ reference (write) [..] C#@f.
+#      override_documentation
+#      | ```ruby
+#      | @f = T.let(_, String("f"))
+#      | ```
+       @@g = 'g'
+#      ^^^ reference (write) [..] C#@@g.
+#      override_documentation
+#      | ```ruby
+#      | @@g = T.let(_, String("g"))
+#      | ```
+       @k = 'k'
+#      ^^ reference (write) [..] C#@k.
+#      override_documentation
+#      | ```ruby
+#      | @k = T.let(_, String("k"))
+#      | ```
+#      ^^^^^^^^ reference [..] C#@k.
+#      override_documentation
+#      | ```ruby
+#      | @k = T.let(_, String("k"))
+#      | ```
+     end
+   end
+ end
+ 
+ class D < C
+#      ^ definition [..] D#
+#      documentation
+#      | ```ruby
+#      | class D < C
+#      | ```
+#          ^ definition [..] C#
+#          documentation
+#          | ```ruby
+#          | class C
+#          | ```
+   def change_type(b)
+#  ^^^^^^^^^^^^^^^^^^ definition [..] D#change_type().
+#  documentation
+#  | ```ruby
+#  | sig {params(b: T.untyped).returns(T.untyped)}
+#  | def change_type(b)
+#  | ```
+#                  ^ definition local 1~#2066187318
+#                  documentation
+#                  | ```ruby
+#                  | b = T.let(_, T.untyped)
+#                  | ```
+     if !b
+#        ^ reference local 1~#2066187318
+       @f = 1
+#      ^^ definition [..] D#@f.
+#      documentation
+#      | ```ruby
+#      | @f = T.let(_, T.untyped)
+#      | ```
+       @@g = 1
+#      ^^^ definition [..] D#@@g.
+#      documentation
+#      | ```ruby
+#      | @@g = T.let(_, T.untyped)
+#      | ```
+       @k = 1
+#      ^^ definition [..] D#@k.
+#      documentation
+#      | ```ruby
+#      | @k = T.let(_, T.untyped)
+#      | ```
+#      ^^^^^^ reference [..] D#@k.
+#      override_documentation
+#      | ```ruby
+#      | @k = T.let(_, Integer(1))
+#      | ```
+     else
+       @f = 'f'
+#      ^^ definition [..] D#@f.
+#      documentation
+#      | ```ruby
+#      | @f = T.let(_, T.untyped)
+#      | ```
+       @@g = 'g'
+#      ^^^ definition [..] D#@@g.
+#      documentation
+#      | ```ruby
+#      | @@g = T.let(_, T.untyped)
+#      | ```
+       @k = 'k'
+#      ^^ definition [..] D#@k.
+#      documentation
+#      | ```ruby
+#      | @k = T.let(_, T.untyped)
+#      | ```
+#      ^^^^^^^^ reference [..] D#@k.
+#      override_documentation
+#      | ```ruby
+#      | @k = T.let(_, String("k"))
+#      | ```
+     end
+   end
+ end

--- a/test/scip_test_runner.cc
+++ b/test/scip_test_runner.cc
@@ -207,20 +207,26 @@ void formatSnapshot(const scip::Document &document, FormatOptions options, std::
             out << lineStart << string(range.end.column - range.start.column, '^') << ' '
                 << string(isDefinition ? "definition" : "reference") << ' ' << symbolRole << formatSymbol(occ.symbol())
                 << '\n';
-            if (!(isDefinition && symbolTable.contains(occ.symbol()))) {
-                occ_i++;
-                continue;
-            }
-            auto &symbolInfo = symbolTable[occ.symbol()];
-            if (options.showDocs) {
-                for (auto &doc : symbolInfo.documentation()) {
-                    out << lineStart << "documentation" << '\n';
+
+            auto printDocs = [&](auto docs, string header) -> void {
+                if (!options.showDocs)
+                    return;
+                for (auto &doc : docs) {
+                    out << lineStart << header << '\n';
                     auto docstream = istringstream(doc);
                     for (string docline; getline(docstream, docline);) {
                         out << lineStart << "| " << docline << '\n';
                     }
                 }
+            };
+            printDocs(occ.override_documentation(), "override_documentation");
+            if (!(isDefinition && symbolTable.contains(occ.symbol()))) {
+                occ_i++;
+                continue;
             }
+            auto &symbolInfo = symbolTable[occ.symbol()];
+            printDocs(symbolInfo.documentation(), "documentation");
+
             relationships.clear();
             relationships.reserve(symbolInfo.relationships_size());
             for (auto &rel : symbolInfo.relationships()) {


### PR DESCRIPTION
It is not fully correct yet, because in some cases we emit
the SymbolInfo.documentation with wrong type information, and
subsequently add override_documentation with the right type
information.

For such situations, we should overwrite the original docs
instead or not emit it in the first place.

I will fix that in a subsequent PR. https://github.com/sourcegraph/scip-ruby/issues/51

### Motivation

Fixes a crash while indexing Homebrew/brew.

### Test plan

See included automated tests.
