### PR TITLE
ci: Clean up CI workflow for releases.

### DIFF
--- a/.github/workflows/release-template.md
+++ b/.github/workflows/release-template.md
@@ -1,0 +1,13 @@
+Download the binary for your platform using:
+
+```bash
+TAG=TAG_PLACEHOLDER \
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')" \
+RELEASE_URL="https://github.com/sourcegraph/scip-ruby/releases/download/$TAG" \
+curl -L "$RELEASE_URL/scip-ruby-$OS-x86_64" -o scip-ruby && \
+chmod +x scip-ruby
+```
+
+NOTE: The `-debug*` binaries are meant for debugging issues
+(for example, if you run into a crash with `scip-ruby`),
+and are not recommended for general use.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,10 @@ jobs:
         run: |
           TAG="${GITHUB_REF/refs\/tags\//}"
           TITLE="$(echo "$TAG" | sed 's/-v/ v/')"
-          gh release create "$TAG" --title "$TITLE"
+          cat .github/workflows/release-template.md \
+            | sed -e "s/TAG_PLACEHOLDER/$TAG/" \
+            > notes
+          gh release create "$TAG" --title "$TITLE" --notes-file notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -30,12 +33,25 @@ jobs:
       TAG: ${{ github.event.ref }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install Bazel
-        run: |
-          if ! which bazelisk; then
-            sudo npm install --location=global @bazel/bazelisk
-          fi
-      - name: Identify OS
+      - name: "⚙️  Setup Bazel"
+        run: .github/workflows/setup-bazel.sh
+      - name: "🚀 Mount Bazel build cache"
+        uses: actions/cache@v3
+        with:
+          path: ~/bazelcache/build
+          key: bazel-build-${{ runner.os }}
+          restore-keys: |
+            bazel-build-${{ runner.os }}
+            bazel-build-
+      - name: "🚀 Mount Bazel repo cache"
+        uses: actions/cache@v3
+        with:
+          path: ~/bazelcache/repos
+          key: bazel-repos-${{ runner.os }}
+          restore-keys: |
+            bazel-repos-${{ runner.os }}
+            bazel-repos-
+      - name: "🔎 Identify OS"
         run: |
           case "$(uname -s)" in
             Linux*)     os="linux";;
@@ -43,9 +59,11 @@ jobs:
             *)          echo "Unhandled OS type" && exit 1;;
           esac
           echo "OS=$os" >> "$GITHUB_ENV"
-      - name: Run debug build
-        run: bazel build //main:scip-ruby --config=dbg
-      - name: Upload debug binary
+      - name: "🏗 Build (debug)"
+        run: ./bazel build //main:scip-ruby --config=dbg --explain log --verbose_explanations
+      - name: "🪵 Print log"
+        run: cat log && rm log
+      - name: "📦 Upload debug binary"
         run: |
           ls bazel-out
           debugBinaryPath="scip-ruby-debug-$OS-$(uname -m)"
@@ -55,9 +73,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OS: ${{ env.OS }}
-      - name: Run release build
-        run: bazel build //main:scip-ruby
-      - name: Upload release binary
+      - name: "🏗 Build (release)"
+        run: bazel build //main:scip-ruby --explain log --verbose_explanations
+      - name: "🪵 Print log"
+        run: cat log && rm log
+      - name: "📦 Upload release binary"
         run: |
           ls bazel-out
           releaseBinaryPath="scip-ruby-$OS-$(uname -m)"

--- a/scip-ruby.md
+++ b/scip-ruby.md
@@ -148,3 +148,8 @@ gh pr create -R sourcegraph/scip-ruby
 ```
 
 This will correctly use the `scip-ruby/master` branch as the target.
+
+## Cutting a release
+
+Push a tag of the form `scip-ruby-v*` to `scip-ruby/master`.
+See the [release workflow](/.github/workflows/release.yml) for details.


### PR DESCRIPTION
### Motivation

This will use the cache for faster builds. IDK if there's a good way to avoid the duplication related to caching steps between the workflows...

### Test plan

Will try to publish a release after this.
