### PR TITLE
cfg: Fix type sizes in release build.

### DIFF
--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -161,7 +161,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Send, 120, 8);
+CheckSize(Send, 144, 8);
 
 INSN(Return) : public Instruction {
 public:
@@ -172,7 +172,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Return, 24, 8);
+CheckSize(Return, 32, 8);
 
 INSN(BlockReturn) : public Instruction {
 public:
@@ -183,7 +183,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(BlockReturn, 32, 8);
+CheckSize(BlockReturn, 40, 8);
 
 INSN(LoadSelf) : public Instruction {
 public:
@@ -282,7 +282,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(YieldLoadArg, 24, 8);
+CheckSize(YieldLoadArg, 32, 8);
 
 INSN(Cast) : public Instruction {
 public:
@@ -300,7 +300,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Cast, 40, 8);
+CheckSize(Cast, 48, 8);
 
 INSN(TAbsurd) : public Instruction {
 public:
@@ -314,7 +314,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(TAbsurd, 16, 8);
+CheckSize(TAbsurd, 24, 8);
 
 class InstructionPtr final {
     using tagged_storage = uint64_t;

--- a/scip-ruby.md
+++ b/scip-ruby.md
@@ -8,25 +8,37 @@
 
 For more information about configurations, see the main [README](./README.md).
 
-NOTE: In some Ubuntu instances (Ubuntu 22.04 image on Google Cloud),
-there is a known build error with m4.
-This problem doesn't happen with Ubuntu 20.04.
-
 <details>
-  <summary>M4 build error due to sysconf not being defined</summary>
-  
-  ```
-  external/m4_v1.4.18/gnulib/lib/c-stack.c:55:26: error: function-like macro 'sysconf' is not defined
-  #elif HAVE_LIBSIGSEGV && SIGSTKSZ < 16384
-                         ^
-  /usr/include/x86_64-linux-gnu/bits/sigstksz.h:28:19: note: expanded from macro 'SIGSTKSZ'
-  # define SIGSTKSZ sysconf (_SC_SIGSTKSZ)
-                  ^
-  external/m4_v1.4.18/gnulib/lib/c-stack.c:139:8: error: fields must have a constant size: 'variable length array in structure' extension will never be   supported
-    char buffer[SIGSTKSZ];
-         ^
-  2 errors generated.
-  ```
+  <summary>Known build issues</summary>
+
+  1. In some Ubuntu instances (Ubuntu 22.04 image on Google Cloud),
+      there is a known build error with m4.
+      This problem doesn't happen with Ubuntu 20.04.
+      ```
+      external/m4_v1.4.18/gnulib/lib/c-stack.c:55:26: error: function-like macro 'sysconf' is not defined
+      #elif HAVE_LIBSIGSEGV && SIGSTKSZ < 16384
+                               ^
+      /usr/include/x86_64-linux-gnu/bits/sigstksz.h:28:19: note: expanded from macro 'SIGSTKSZ'
+      # define SIGSTKSZ sysconf (_SC_SIGSTKSZ)
+                        ^
+      external/m4_v1.4.18/gnulib/lib/c-stack.c:139:8: error: fields must have a constant size: 'variable length array in structure' extension will never be   supported
+        char buffer[SIGSTKSZ];
+               ^
+      2 errors generated.
+      ```
+  2. A release build (`--config=release-mac`) fails on Apple Silicon Macs,
+     which (I think) is related to this upstream
+     [jemalloc issue](https://github.com/jemalloc/jemalloc/issues/1997),
+     which is mentioned to be caused due to a QEMU bug. It manifests as an error:
+     ```
+     include/jemalloc/internal/rtree.h:118:3: error: constant expression evaluates to -12 which cannot be narrowed to type 'unsigned int' [-Wc++11-narrowing]
+        {RTREE_NSB, RTREE_NHIB + RTREE_NSB}
+         ^~~~~~~~~
+      include/jemalloc/internal/rtree.h:22:19: note: expanded from macro 'RTREE_NSB'
+        #define RTREE_NSB (LG_VADDR - RTREE_NLIB)
+                  ^~~~~~~~~~~~~~~~~~~~~~~
+     ```
+
 </details>
 
 ## IDE Integration


### PR DESCRIPTION
### Motivation

Unbreak the build so that we can use the release config in the release workflow.

### Test plan

Ran the release build locally. It seems wasteful to do a release build in CI because we don't have that many tests and the build becomes more time-consuming + will occupy more cache space.