### PR TITLE
ci: Add OS key for Darwin -> macOS in release template.

### DIFF
--- a/.github/workflows/release-template.md
+++ b/.github/workflows/release-template.md
@@ -8,4 +8,9 @@ curl -L "$RELEASE_URL/scip-ruby-x86_64-$OS" -o scip-ruby && \
 chmod +x scip-ruby
 ```
 
-NOTE: The `-debug*` binaries are meant for debugging issues (for example, if you run into a crash with `scip-ruby`), and are not recommended for general use.
+The `-debug*` binaries are meant for debugging issues (for example, if you run into a crash with `scip-ruby`), and are not recommended for general use.
+
+OS key:
+- Darwin 20 ~ macOS 11 Big Sur
+- Darwin 21 ~ macOS 12 Monterey
+- Darwin 22 ~ macOS 13 Ventura


### PR DESCRIPTION
### Motivation

People don't normally have the kernel versions top-of-mind.

### Test plan

n/a