### PR TITLE
hoverdocs: Don't use T.let syntax for hoverdocs.

### DIFF
--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -277,14 +277,14 @@ public:
             case Kind::UndeclaredField: {
                 auto name = this->name.show(gs);
                 CHECK_TYPE(fieldType, name);
-                markdown = fmt::format("{} = T.let(_, {})", name, fieldType.show(gs));
+                markdown = fmt::format("{} ({})", name, fieldType.show(gs));
                 break;
             }
             case Kind::DeclaredField: {
                 auto fieldRef = this->selfOrOwner.asFieldRef();
                 auto name = fieldRef.showFullName(gs);
                 CHECK_TYPE(fieldType, name);
-                markdown = fmt::format("{} = T.let(_, {})", name, fieldType.show(gs));
+                markdown = fmt::format("{} ({})", name, fieldType.show(gs));
                 break;
             }
             case Kind::ClassOrModule: {
@@ -615,7 +615,7 @@ public:
         if (type) {
             auto var = loc.source(gs);
             ENFORCE(var.has_value(), "Failed to find source text for definition of local variable");
-            docStrings.push_back(fmt::format("```ruby\n{} = T.let(_, {})\n```", var.value(), type.show(gs)));
+            docStrings.push_back(fmt::format("```ruby\n{} ({})\n```", var.value(), type.show(gs)));
         }
         return this->saveDefinitionImpl(gs, file, occ.toString(gs, file), loc, docStrings);
     }
@@ -653,7 +653,7 @@ public:
                     core::Loc(file, occ.offsets).toString(gs));
             auto var = loc.source(gs);
             ENFORCE(var.has_value(), "Failed to find source text for definition of local variable");
-            overrideDocs.push_back(fmt::format("```ruby\n{} = T.let(_, {})\n```", var.value(), overrideType->show(gs)));
+            overrideDocs.push_back(fmt::format("```ruby\n{} ({})\n```", var.value(), overrideType->show(gs)));
         }
         this->saveReferenceImpl(gs, file, occ.toString(gs, file), overrideDocs, occ.offsets, symbol_roles);
         return absl::OkStatus();

--- a/test/scip/testdata/freeze_constants.snapshot.rb
+++ b/test/scip/testdata/freeze_constants.snapshot.rb
@@ -5,25 +5,25 @@
 #^ definition [..] X.
 #documentation
 #| ```ruby
-#| ::X = T.let(_, T.untyped)
+#| ::X (T.untyped)
 #| ```
  Y = 'Y'.freeze
 #^ definition [..] Y.
 #documentation
 #| ```ruby
-#| ::Y = T.let(_, T.untyped)
+#| ::Y (T.untyped)
 #| ```
  A = %w[X Y].freeze
 #^ definition [..] A.
 #documentation
 #| ```ruby
-#| ::A = T.let(_, T.untyped)
+#| ::A (T.untyped)
 #| ```
  B = %W[#{X} Y].freeze
 #^ definition [..] B.
 #documentation
 #| ```ruby
-#| ::B = T.let(_, T.untyped)
+#| ::B (T.untyped)
 #| ```
 #         ^ reference [..] X.
  
@@ -37,19 +37,19 @@
 #  ^ definition [..] M#Z.
 #  documentation
 #  | ```ruby
-#  | ::M::Z = T.let(_, T.untyped)
+#  | ::M::Z (T.untyped)
 #  | ```
    A = %w[X Y Z].freeze
 #  ^ definition [..] M#A.
 #  documentation
 #  | ```ruby
-#  | ::M::A = T.let(_, T.untyped)
+#  | ::M::A (T.untyped)
 #  | ```
    B = %W[#{X} Y Z].freeze
 #  ^ definition [..] M#B.
 #  documentation
 #  | ```ruby
-#  | ::M::B = T.let(_, T.untyped)
+#  | ::M::B (T.untyped)
 #  | ```
 #           ^ reference [..] X.
  end

--- a/test/scip/testdata/hoverdocs.snapshot.rb
+++ b/test/scip/testdata/hoverdocs.snapshot.rb
@@ -59,12 +59,12 @@
 #         ^ definition local 1~#2519626513
 #         documentation
 #         | ```ruby
-#         | c = T.let(_, T.untyped)
+#         | c (T.untyped)
 #         | ```
 #            ^ definition local 2~#2519626513
 #            documentation
 #            | ```ruby
-#            | b = T.let(_, T.untyped)
+#            | b (T.untyped)
 #            | ```
      c.m2 || b
 #    ^ reference local 1~#2519626513
@@ -86,7 +86,7 @@
 #         ^^ definition local 1~#2536404132
 #         documentation
 #         | ```ruby
-#         | xs = T.let(_, T.untyped)
+#         | xs (T.untyped)
 #         | ```
      xs[0]
 #    ^^ reference local 1~#2536404132
@@ -138,12 +138,12 @@
 #         ^ definition local 1~#2569959370
 #         documentation
 #         | ```ruby
-#         | c = T.let(_, T.untyped)
+#         | c (T.untyped)
 #         | ```
 #            ^ definition local 2~#2569959370
 #            documentation
 #            | ```ruby
-#            | b = T.let(_, T.untyped)
+#            | b (T.untyped)
 #            | ```
      c.m2 || b
 #    ^ reference local 1~#2569959370
@@ -318,18 +318,18 @@
 #    ^^ definition [..] K1#@x.
 #    documentation
 #    | ```ruby
-#    | @x = T.let(_, T.untyped)
+#    | @x (T.untyped)
 #    | ```
      @@y = 10
 #    ^^^ definition [..] K1#@@y.
 #    documentation
 #    | ```ruby
-#    | @@y = T.let(_, T.untyped)
+#    | @@y (T.untyped)
 #    | ```
 #    ^^^^^^^^ reference [..] K1#@@y.
 #    override_documentation
 #    | ```ruby
-#    | @@y = T.let(_, Integer(10))
+#    | @@y (Integer(10))
 #    | ```
    end
  
@@ -347,12 +347,12 @@
 #    ^^ definition [..] <Class:K1>#@z.
 #    documentation
 #    | ```ruby
-#    | @z = T.let(_, T.untyped)
+#    | @z (T.untyped)
 #    | ```
 #    ^^^^^^^ reference [..] <Class:K1>#@z.
 #    override_documentation
 #    | ```ruby
-#    | @z = T.let(_, Integer(10))
+#    | @z (Integer(10))
 #    | ```
    end
  end
@@ -378,7 +378,7 @@
 #  ^^ definition [..] <Class:K2>#@z.
 #  documentation
 #  | ```ruby
-#  | @z = T.let(_, T.untyped)
+#  | @z (T.untyped)
 #  | ```
 #  documentation
 #  | doc comment on class var ooh
@@ -397,13 +397,13 @@
 #    ^^ definition [..] K2#@x.
 #    documentation
 #    | ```ruby
-#    | @x = T.let(_, T.untyped)
+#    | @x (T.untyped)
 #    | ```
      @@y = 20
 #    ^^^ definition [..] K2#@@y.
 #    documentation
 #    | ```ruby
-#    | @@y = T.let(_, T.untyped)
+#    | @@y (T.untyped)
 #    | ```
      @z += @x
 #    ^^ reference [..] K2#@z.
@@ -412,7 +412,7 @@
 #          ^^ reference [..] K2#@x.
 #          override_documentation
 #          | ```ruby
-#          | @x = T.let(_, Integer(20))
+#          | @x (Integer(20))
 #          | ```
    end
  end

--- a/test/scip/testdata/multifile/basic/use_class1.snapshot.rb
+++ b/test/scip/testdata/multifile/basic/use_class1.snapshot.rb
@@ -7,7 +7,7 @@
 #^ definition local 2~#119448696
 #documentation
 #| ```ruby
-#| b = T.let(_, T::Boolean)
+#| b (T::Boolean)
 #| ```
 #    ^^ reference [..] C1#
 #           ^^ reference [..] C1#m1().

--- a/test/scip/testdata/type_change.snapshot.rb
+++ b/test/scip/testdata/type_change.snapshot.rb
@@ -11,21 +11,21 @@
 #                              ^ definition local 1~#3317016627
 #                              documentation
 #                              | ```ruby
-#                              | b = T.let(_, T.untyped)
+#                              | b (T.untyped)
 #                              | ```
    if b
      x = 1
 #    ^ definition local 2~#3317016627
 #    documentation
 #    | ```ruby
-#    | x = T.let(_, Integer(1))
+#    | x (Integer(1))
 #    | ```
    else
      x = nil
 #    ^ definition local 2~#3317016627
 #    documentation
 #    | ```ruby
-#    | x = T.let(_, Integer(1))
+#    | x (Integer(1))
 #    | ```
    end
    return
@@ -41,27 +41,27 @@
 #                              ^ definition local 1~#2122680152
 #                              documentation
 #                              | ```ruby
-#                              | b = T.let(_, T.untyped)
+#                              | b (T.untyped)
 #                              | ```
    x = 'foo'
 #  ^ definition local 2~#2122680152
 #  documentation
 #  | ```ruby
-#  | x = T.let(_, String("foo"))
+#  | x (String("foo"))
 #  | ```
    if b
      x = 1
 #    ^ reference (write) local 2~#2122680152
 #    override_documentation
 #    | ```ruby
-#    | x = T.let(_, Integer(1))
+#    | x (Integer(1))
 #    | ```
    else
      x = nil
 #    ^ reference (write) local 2~#2122680152
 #    override_documentation
 #    | ```ruby
-#    | x = T.let(_, NilClass)
+#    | x (NilClass)
 #    | ```
    end
    return
@@ -77,19 +77,19 @@
 #                     ^^ definition local 1~#4057334513
 #                     documentation
 #                     | ```ruby
-#                     | bs = T.let(_, T.untyped)
+#                     | bs (T.untyped)
 #                     | ```
    x = nil
 #  ^ definition local 2~#4057334513
 #  documentation
 #  | ```ruby
-#  | x = T.let(_, NilClass)
+#  | x (NilClass)
 #  | ```
    for b in bs
 #      ^ definition local 3~#4057334513
 #      documentation
 #      | ```ruby
-#      | b = T.let(_, T.untyped)
+#      | b (T.untyped)
 #      | ```
 #           ^^ reference local 1~#4057334513
      puts x
@@ -99,24 +99,24 @@
 #      ^ reference (write) local 2~#4057334513
 #      override_documentation
 #      | ```ruby
-#      | x = T.let(_, T.untyped)
+#      | x (T.untyped)
 #      | ```
 #      ^^^^^ reference local 2~#4057334513
 #      override_documentation
 #      | ```ruby
-#      | x = 1 = T.let(_, T.untyped)
+#      | x = 1 (T.untyped)
 #      | ```
      else
        x = 's'
 #      ^ reference (write) local 2~#4057334513
 #      override_documentation
 #      | ```ruby
-#      | x = T.let(_, T.untyped)
+#      | x (T.untyped)
 #      | ```
 #      ^^^^^^^ reference local 2~#4057334513
 #      override_documentation
 #      | ```ruby
-#      | x = 's' = T.let(_, T.untyped)
+#      | x = 's' (T.untyped)
 #      | ```
      end
    end
@@ -133,7 +133,7 @@
 #  ^^ definition [..] <Class:C>#@k.
 #  documentation
 #  | ```ruby
-#  | @k = T.let(_, T.untyped)
+#  | @k (T.untyped)
 #  | ```
  
    def change_type(b)
@@ -146,73 +146,73 @@
 #                  ^ definition local 1~#2066187318
 #                  documentation
 #                  | ```ruby
-#                  | b = T.let(_, T.untyped)
+#                  | b (T.untyped)
 #                  | ```
      @f = nil
 #    ^^ definition [..] C#@f.
 #    documentation
 #    | ```ruby
-#    | @f = T.let(_, T.untyped)
+#    | @f (T.untyped)
 #    | ```
      @@g = nil
 #    ^^^ definition [..] C#@@g.
 #    documentation
 #    | ```ruby
-#    | @@g = T.let(_, T.untyped)
+#    | @@g (T.untyped)
 #    | ```
      @k = nil
 #    ^^ definition [..] C#@k.
 #    documentation
 #    | ```ruby
-#    | @k = T.let(_, T.untyped)
+#    | @k (T.untyped)
 #    | ```
      if b
        @f = 1
 #      ^^ reference (write) [..] C#@f.
 #      override_documentation
 #      | ```ruby
-#      | @f = T.let(_, Integer(1))
+#      | @f (Integer(1))
 #      | ```
        @@g = 1
 #      ^^^ reference (write) [..] C#@@g.
 #      override_documentation
 #      | ```ruby
-#      | @@g = T.let(_, Integer(1))
+#      | @@g (Integer(1))
 #      | ```
        @k = 1
 #      ^^ reference (write) [..] C#@k.
 #      override_documentation
 #      | ```ruby
-#      | @k = T.let(_, Integer(1))
+#      | @k (Integer(1))
 #      | ```
 #      ^^^^^^ reference [..] C#@k.
 #      override_documentation
 #      | ```ruby
-#      | @k = T.let(_, Integer(1))
+#      | @k (Integer(1))
 #      | ```
      else
        @f = 'f'
 #      ^^ reference (write) [..] C#@f.
 #      override_documentation
 #      | ```ruby
-#      | @f = T.let(_, String("f"))
+#      | @f (String("f"))
 #      | ```
        @@g = 'g'
 #      ^^^ reference (write) [..] C#@@g.
 #      override_documentation
 #      | ```ruby
-#      | @@g = T.let(_, String("g"))
+#      | @@g (String("g"))
 #      | ```
        @k = 'k'
 #      ^^ reference (write) [..] C#@k.
 #      override_documentation
 #      | ```ruby
-#      | @k = T.let(_, String("k"))
+#      | @k (String("k"))
 #      | ```
 #      ^^^^^^^^ reference [..] C#@k.
 #      override_documentation
 #      | ```ruby
-#      | @k = T.let(_, String("k"))
+#      | @k (String("k"))
 #      | ```
      end
    end
@@ -239,7 +239,7 @@
 #                  ^ definition local 1~#2066187318
 #                  documentation
 #                  | ```ruby
-#                  | b = T.let(_, T.untyped)
+#                  | b (T.untyped)
 #                  | ```
      if !b
 #        ^ reference local 1~#2066187318
@@ -247,48 +247,48 @@
 #      ^^ definition [..] D#@f.
 #      documentation
 #      | ```ruby
-#      | @f = T.let(_, T.untyped)
+#      | @f (T.untyped)
 #      | ```
        @@g = 1
 #      ^^^ definition [..] D#@@g.
 #      documentation
 #      | ```ruby
-#      | @@g = T.let(_, T.untyped)
+#      | @@g (T.untyped)
 #      | ```
        @k = 1
 #      ^^ definition [..] D#@k.
 #      documentation
 #      | ```ruby
-#      | @k = T.let(_, T.untyped)
+#      | @k (T.untyped)
 #      | ```
 #      ^^^^^^ reference [..] D#@k.
 #      override_documentation
 #      | ```ruby
-#      | @k = T.let(_, Integer(1))
+#      | @k (Integer(1))
 #      | ```
      else
        @f = 'f'
 #      ^^ definition [..] D#@f.
 #      documentation
 #      | ```ruby
-#      | @f = T.let(_, T.untyped)
+#      | @f (T.untyped)
 #      | ```
        @@g = 'g'
 #      ^^^ definition [..] D#@@g.
 #      documentation
 #      | ```ruby
-#      | @@g = T.let(_, T.untyped)
+#      | @@g (T.untyped)
 #      | ```
        @k = 'k'
 #      ^^ definition [..] D#@k.
 #      documentation
 #      | ```ruby
-#      | @k = T.let(_, T.untyped)
+#      | @k (T.untyped)
 #      | ```
 #      ^^^^^^^^ reference [..] D#@k.
 #      override_documentation
 #      | ```ruby
-#      | @k = T.let(_, String("k"))
+#      | @k (String("k"))
 #      | ```
      end
    end

--- a/test/scip/testdata/type_docs.rb
+++ b/test/scip/testdata/type_docs.rb
@@ -1,0 +1,13 @@
+# typed: true
+# options: showDocs
+
+module M
+  extent T::Sig
+
+  sig { params(x: Integer, y: String).returns(String) }
+  def js_add(x, y)
+    xs = x.to_s
+    ret = xs + y
+    return ret
+  end
+end

--- a/test/scip/testdata/type_docs.snapshot.rb
+++ b/test/scip/testdata/type_docs.snapshot.rb
@@ -1,0 +1,61 @@
+ # typed: true
+ # options: showDocs
+ 
+ module M
+#       ^ definition [..] M#
+#       documentation
+#       | ```ruby
+#       | module M
+#       | ```
+   extent T::Sig
+#         ^ reference [..] T#
+#            ^^^ reference [..] T#Sig#
+ 
+   sig { params(x: Integer, y: String).returns(String) }
+#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#Static#
+#                  ^^^^^^^ reference [..] Integer#
+#                              ^^^^^^ reference [..] String#
+#                                              ^^^^^^ reference [..] String#
+   def js_add(x, y)
+#  ^^^^^^^^^^^^^^^^ definition [..] M#js_add().
+#  documentation
+#  | ```ruby
+#  | sig {params(x: Integer, y: String).returns(String)}
+#  | def js_add(x, y)
+#  | ```
+#             ^ definition local 1~#1239553962
+#             documentation
+#             | ```ruby
+#             | x (Integer)
+#             | ```
+#                ^ definition local 2~#1239553962
+#                documentation
+#                | ```ruby
+#                | y (String)
+#                | ```
+     xs = x.to_s
+#    ^^ definition local 3~#1239553962
+#    documentation
+#    | ```ruby
+#    | xs (String)
+#    | ```
+#         ^ reference local 1~#1239553962
+#           ^^^^ reference [..] Integer#to_s().
+     ret = xs + y
+#    ^^^ definition local 4~#1239553962
+#    documentation
+#    | ```ruby
+#    | ret (String)
+#    | ```
+#          ^^ reference local 3~#1239553962
+#             ^ reference [..] String#+().
+#               ^ reference local 2~#1239553962
+     return ret
+#    ^^^^^^^^^^ reference local 4~#1239553962
+#    override_documentation
+#    | ```ruby
+#    | return ret (T.noreturn)
+#    | ```
+   end
+ end


### PR DESCRIPTION
### Motivation

Make output slightly more legible.

### Test plan

Updated tests.