### PR TITLE
Documentation: include `.` in the example commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ Run `scip-ruby` along with some information about your gem.
 
 ```bash
 # Uses the latest revision as the version - prefer this if you will index every commit
-bundle exec scip-ruby --index-file index.scip --gem-metadata "my-gem-name@$(git rev-parse HEAD)"
+bundle exec scip-ruby --index-file index.scip --gem-metadata "my-gem-name@$(git rev-parse HEAD)" .
 
 # Uses the latest tag as the version - prefer this if you're only indexing specific tags
-bundle exec scip-ruby --index-file index.scip --gem-metadata "my-gem-name@$(git describe --tags --abbrev=0)"
+bundle exec scip-ruby --index-file index.scip --gem-metadata "my-gem-name@$(git describe --tags --abbrev=0)" .
 ```
 
 The generated `index.scip` file can be uploaded
@@ -75,7 +75,7 @@ curl -L "https://github.com/sourcegraph/scip-ruby/releases/latest/download/scip-
 # If using in CI with 'set -e', make sure to wrap the
 # scip-ruby invocation in 'set +e' followed by 'set -e'
 # so that indexing failures are non-blocking.
-./scip-ruby --index-file index.scip --gem-metadata "my-gem-name@M.N.P"
+./scip-ruby --index-file index.scip --gem-metadata "my-gem-name@M.N.P" .
 ```
 
 The generated index can be uploaded to a Sourcegraph instance


### PR DESCRIPTION
I wasn't able to get the typechecking to run without the `.`

```
❯ scip-ruby --index-file index.scip
You must pass either `-e` or at least one folder or ruby file.

Typechecker for Ruby
Usage:
  sorbet [OPTION...] <path 1> <path 2> ...

  -e string      Parse an inline ruby string (default: "")
  -q, --quiet    Silence all non-critical errors
  -v, --verbose  Verbosity level [0-3]
  -h             Show short help
      --help     Show long help
      --version  Show version

❯ echo $?
1
```
