### PR TITLE
fix: Escape special characters in SCIP symbols.

### DIFF
--- a/scip_indexer/BUILD
+++ b/scip_indexer/BUILD
@@ -21,6 +21,7 @@ cc_library(
     deps = [
         "//proto",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/test/scip/testdata/classes.snapshot.rb
+++ b/test/scip/testdata/classes.snapshot.rb
@@ -73,15 +73,15 @@
    module M6
 #         ^^ definition [..] M5#M6#
      def self.g()
-#    ^^^^^^^^^^^^ definition [..] M5#<Class:M6>#g().
+#    ^^^^^^^^^^^^ definition [..] M5#`<Class:M6>`#g().
      end
    end
  
    def self.h()
-#  ^^^^^^^^^^^^ definition [..] <Class:M5>#h().
+#  ^^^^^^^^^^^^ definition [..] `<Class:M5>`#h().
      M6.g()
 #    ^^ reference [..] M5#M6#
-#       ^ reference [..] M5#<Class:M6>#g().
+#       ^ reference [..] M5#`<Class:M6>`#g().
      return
    end
  end
@@ -91,7 +91,7 @@
    module M8
 #         ^^ definition [..] C7#M8#
      def self.i()
-#    ^^^^^^^^^^^^ definition [..] C7#<Class:M8>#i().
+#    ^^^^^^^^^^^^ definition [..] C7#`<Class:M8>`#i().
      end
    end
  
@@ -99,7 +99,7 @@
 #  ^^^^^^^ definition [..] C7#j().
      M8.i()
 #    ^^ reference [..] C7#M8#
-#       ^ reference [..] C7#<Class:M8>#i().
+#       ^ reference [..] C7#`<Class:M8>`#i().
      return
    end
  end

--- a/test/scip/testdata/def_delegator.snapshot.rb
+++ b/test/scip/testdata/def_delegator.snapshot.rb
@@ -6,20 +6,20 @@
 #      ^^^^^^^^ definition [..] MyArray1#
    attr_accessor :inner_array
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray1#inner_array().
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray1#inner_array=().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray1#`inner_array=`().
    extend Forwardable
 #         ^^^^^^^^^^^ reference [..] Forwardable#
    def_delegator :@inner_array, :[], :get_at_index
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray1#get_at_index().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#Static#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#nilable().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#nilable().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Proc#
  end
@@ -31,20 +31,20 @@
 #            ^^^ reference [..] T#Sig#
    attr_accessor :inner_array
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray2#inner_array().
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray2#inner_array=().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray2#`inner_array=`().
    extend Forwardable
 #         ^^^^^^^^^^^ reference [..] Forwardable#
    def_delegator :@inner_array, :[], :get_at_index
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray2#get_at_index().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#Static#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#nilable().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#nilable().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Proc#
  end
@@ -53,42 +53,42 @@
 #      ^^^^^^^^ definition [..] MyArray3#
    attr_accessor :inner_array
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray3#inner_array().
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray3#inner_array=().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray3#`inner_array=`().
    extend Forwardable
 #         ^^^^^^^^^^^ reference [..] Forwardable#
    def_delegators :@inner_array, :size, :<<, :map
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#nilable().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#nilable().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Proc#
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray3#map().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#Static#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#nilable().
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray3#<<().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#nilable().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray3#`<<`().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#Static#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray3#size().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#Static#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#nilable().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#nilable().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
  end
@@ -99,7 +99,7 @@
 #         ^ reference [..] T#
 #            ^^^ reference [..] T#Sig#
    attr_accessor :inner_array
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray4#inner_array=().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray4#`inner_array=`().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray4#inner_array().
    extend Forwardable
 #         ^^^^^^^^^^^ reference [..] Forwardable#
@@ -107,35 +107,35 @@
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray4#size().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Proc#
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#nilable().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#nilable().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#Static#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#nilable().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#nilable().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#Static#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#nilable().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#nilable().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] <Class:T>#untyped().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:T>`#untyped().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#Static#
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray4#map().
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray4#<<().
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyArray4#`<<`().
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
  end

--- a/test/scip/testdata/fields_and_attrs.snapshot.rb
+++ b/test/scip/testdata/fields_and_attrs.snapshot.rb
@@ -8,17 +8,17 @@
    def m1
 #  ^^^^^^ definition [..] K#m1().
      @f = 0
-#    ^^ definition [..] K#@f.
+#    ^^ definition [..] K#`@f`.
      @g = @f
-#    ^^ definition [..] K#@g.
-#         ^^ reference [..] K#@f.
+#    ^^ definition [..] K#`@g`.
+#         ^^ reference [..] K#`@f`.
      return
    end
    def m2
 #  ^^^^^^ definition [..] K#m2().
      @f = @g
-#    ^^ definition [..] K#@f.
-#         ^^ reference [..] K#@g.
+#    ^^ definition [..] K#`@f`.
+#         ^^ reference [..] K#`@g`.
      return
    end
  end
@@ -29,8 +29,8 @@
    def m3
 #  ^^^^^^ definition [..] K#m3().
      @g = @f
-#    ^^ definition [..] K#@g.
-#         ^^ reference [..] K#@f.
+#    ^^ definition [..] K#`@g`.
+#         ^^ reference [..] K#`@f`.
      return
    end
  end
@@ -39,14 +39,14 @@
  class L
 #      ^ definition [..] L#
    @x = 10
-#  ^^ definition [..] <Class:L>#@x.
+#  ^^ definition [..] `<Class:L>`#`@x`.
    @y = 9
-#  ^^ definition [..] <Class:L>#@y.
+#  ^^ definition [..] `<Class:L>`#`@y`.
    def self.m1
-#  ^^^^^^^^^^^ definition [..] <Class:L>#m1().
+#  ^^^^^^^^^^^ definition [..] `<Class:L>`#m1().
      @y = @x
-#    ^^ definition [..] <Class:L>#@y.
-#         ^^ reference [..] <Class:L>#@x.
+#    ^^ definition [..] `<Class:L>`#`@y`.
+#         ^^ reference [..] `<Class:L>`#`@x`.
      return
    end
  
@@ -62,22 +62,22 @@
  class N
 #      ^ definition [..] N#
    @@a = 0
-#  ^^^ definition [..] <Class:N>#@@a.
+#  ^^^ definition [..] `<Class:N>`#`@@a`.
    @@b = 1
-#  ^^^ definition [..] <Class:N>#@@b.
+#  ^^^ definition [..] `<Class:N>`#`@@b`.
    def self.m1
-#  ^^^^^^^^^^^ definition [..] <Class:N>#m1().
+#  ^^^^^^^^^^^ definition [..] `<Class:N>`#m1().
      @@b = @@a
-#    ^^^ definition [..] <Class:N>#@@b.
-#          ^^^ reference [..] <Class:N>#@@a.
+#    ^^^ definition [..] `<Class:N>`#`@@b`.
+#          ^^^ reference [..] `<Class:N>`#`@@a`.
      return
    end
  
    def m2
 #  ^^^^^^ definition [..] N#m2().
      @@b = @@a
-#    ^^^ definition [..] N#@@b.
-#          ^^^ reference [..] N#@@a.
+#    ^^^ definition [..] N#`@@b`.
+#          ^^^ reference [..] N#`@@a`.
      return
    end
  
@@ -92,20 +92,20 @@
  class P
 #      ^ definition [..] P#
    attr_accessor :a
-#  ^^^^^^^^^^^^^^^^ definition [..] P#a=().
+#  ^^^^^^^^^^^^^^^^ definition [..] P#`a=`().
 #  ^^^^^^^^^^^^^^^^ definition [..] P#a().
    attr_reader :r
 #  ^^^^^^^^^^^^^^ definition [..] P#r().
    attr_writer :w
-#  ^^^^^^^^^^^^^^ definition [..] P#w=().
+#  ^^^^^^^^^^^^^^ definition [..] P#`w=`().
  
    def init
 #  ^^^^^^^^ definition [..] P#init().
      self.a = self.r
-#         ^^^ reference [..] P#a=().
+#         ^^^ reference [..] P#`a=`().
 #                  ^ reference [..] P#r().
      self.w = self.a
-#         ^^^ reference [..] P#w=().
+#         ^^^ reference [..] P#`w=`().
 #                  ^ reference [..] P#a().
    end
  
@@ -129,12 +129,12 @@
 #      ^ reference [..] P#
    p.a = p.r
 #  ^ reference local 1~#2121829932
-#    ^^^ reference [..] P#a=().
+#    ^^^ reference [..] P#`a=`().
 #        ^ reference local 1~#2121829932
 #          ^ reference [..] P#r().
    p.w = p.a
 #  ^ reference local 1~#2121829932
-#    ^^^ reference [..] P#w=().
+#    ^^^ reference [..] P#`w=`().
 #        ^ reference local 1~#2121829932
 #          ^ reference [..] P#a().
  end

--- a/test/scip/testdata/hoverdocs.snapshot.rb
+++ b/test/scip/testdata/hoverdocs.snapshot.rb
@@ -24,7 +24,7 @@
    end
  
    sig { returns(T::Boolean) }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #        ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #                ^ reference [..] T#
 #                   ^^^^^^^ reference [..] T#Boolean.
@@ -40,9 +40,9 @@
    end
  
    sig { params(C, T::Boolean).returns(T::Boolean) }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #        ^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
-#               ^ reference [..] T.untyped#
+#               ^ reference [..] `T.untyped`#
 #                  ^ reference [..] T#
 #                     ^^^^^^^ reference [..] T#Boolean.
 #                              ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
@@ -95,7 +95,7 @@
    # Yet another..
    # ...doc comment
    sig { returns(T::Boolean) }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #        ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #                ^ reference [..] T#
 #                   ^^^^^^^ reference [..] T#Boolean.
@@ -116,9 +116,9 @@
    # And...
    # ...one more doc comment
    sig { params(C, T::Boolean).returns(T::Boolean) }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #        ^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
-#               ^ reference [..] T.untyped#
+#               ^ reference [..] `T.untyped`#
 #                  ^ reference [..] T#
 #                     ^^^^^^^ reference [..] T#Boolean.
 #                              ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
@@ -198,7 +198,7 @@
  
      # This method is inside M1::M2
      sig { returns(T::Boolean) }
-#    ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#    ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #          ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #                  ^ reference [..] T#
 #                     ^^^^^^^ reference [..] T#Boolean.
@@ -249,10 +249,10 @@
  
  # Yet another global function
  sig { returns(T::Integer) }
-#^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #      ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #              ^ reference [..] T#
-#                 ^^^^^^^ reference [..] T.untyped#
+#                 ^^^^^^^ reference [..] `T.untyped`#
 #                 ^^^^^^^^^^ reference [..] Sorbet#Private#Static#
  def f2
 #^^^^^^ definition [..] Object#f2().
@@ -280,10 +280,10 @@
 #          ^^^ reference [..] T#Sig#
  
  sig { returns(T::Integer) }
-#^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #      ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #              ^ reference [..] T#
-#                 ^^^^^^^ reference [..] T.untyped#
+#                 ^^^^^^^ reference [..] `T.untyped`#
 #                 ^^^^^^^^^^ reference [..] Sorbet#Private#Static#
  def f4 # another undocumented global function
 #^^^^^^ definition [..] Object#f4().
@@ -315,18 +315,18 @@
 #  documentation
 #  | sets @x and @@y
      @x = 10
-#    ^^ definition [..] K1#@x.
+#    ^^ definition [..] K1#`@x`.
 #    documentation
 #    | ```ruby
 #    | @x (T.untyped)
 #    | ```
      @@y = 10
-#    ^^^ definition [..] K1#@@y.
+#    ^^^ definition [..] K1#`@@y`.
 #    documentation
 #    | ```ruby
 #    | @@y (T.untyped)
 #    | ```
-#    ^^^^^^^^ reference [..] K1#@@y.
+#    ^^^^^^^^ reference [..] K1#`@@y`.
 #    override_documentation
 #    | ```ruby
 #    | @@y (Integer(10))
@@ -335,7 +335,7 @@
  
    # lorem ipsum, you get it
    def self.p2
-#  ^^^^^^^^^^^ definition [..] <Class:K1>#p2().
+#  ^^^^^^^^^^^ definition [..] `<Class:K1>`#p2().
 #  documentation
 #  | ```ruby
 #  | sig {returns(T.untyped)}
@@ -344,12 +344,12 @@
 #  documentation
 #  | lorem ipsum, you get it
      @z = 10
-#    ^^ definition [..] <Class:K1>#@z.
+#    ^^ definition [..] `<Class:K1>`#`@z`.
 #    documentation
 #    | ```ruby
 #    | @z (T.untyped)
 #    | ```
-#    ^^^^^^^ reference [..] <Class:K1>#@z.
+#    ^^^^^^^ reference [..] `<Class:K1>`#`@z`.
 #    override_documentation
 #    | ```ruby
 #    | @z (Integer(10))
@@ -375,7 +375,7 @@
 #           | Parent class
    # doc comment on class var ooh
    @z = 9
-#  ^^ definition [..] <Class:K2>#@z.
+#  ^^ definition [..] `<Class:K2>`#`@z`.
 #  documentation
 #  | ```ruby
 #  | @z (T.untyped)
@@ -394,22 +394,22 @@
 #  documentation
 #  | overrides K1's p1
      @x = 20
-#    ^^ definition [..] K2#@x.
+#    ^^ definition [..] K2#`@x`.
 #    documentation
 #    | ```ruby
 #    | @x (T.untyped)
 #    | ```
      @@y = 20
-#    ^^^ definition [..] K2#@@y.
+#    ^^^ definition [..] K2#`@@y`.
 #    documentation
 #    | ```ruby
 #    | @@y (T.untyped)
 #    | ```
      @z += @x
-#    ^^ reference [..] K2#@z.
-#    ^^ reference (write) [..] K2#@z.
-#    ^^^^^^^^ reference [..] K2#@z.
-#          ^^ reference [..] K2#@x.
+#    ^^ reference [..] K2#`@z`.
+#    ^^ reference (write) [..] K2#`@z`.
+#    ^^^^^^^^ reference [..] K2#`@z`.
+#          ^^ reference [..] K2#`@x`.
 #          override_documentation
 #          | ```ruby
 #          | @x (Integer(20))

--- a/test/scip/testdata/implicit_super_arg.snapshot.rb
+++ b/test/scip/testdata/implicit_super_arg.snapshot.rb
@@ -25,6 +25,6 @@
 #        ^ definition local 1~#3809224601
 #           ^ definition local 2~#3809224601
      super
-#    ^^^^^ reference [..] <Class:<Magic>>#<call-with-block>().
+#    ^^^^^ reference [..] `<Class:<Magic>>`#`<call-with-block>`().
    end
  end

--- a/test/scip/testdata/inheritance.snapshot.rb
+++ b/test/scip/testdata/inheritance.snapshot.rb
@@ -7,7 +7,7 @@
 #            ^^^ reference [..] T#Sig#
  
    sig { params(a: T::Boolean).void }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #        ^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
 #                  ^ reference [..] T#
 #                     ^^^^^^^ reference [..] T#Boolean.
@@ -17,21 +17,21 @@
 #  ^^^^^^^^^^^^^^ definition [..] Z1#write_f().
 #              ^ definition local 1~#1000661517
      @f = a
-#    ^^ definition [..] Z1#@f.
-#    ^^^^^^ reference [..] Z1#@f.
+#    ^^ definition [..] Z1#`@f`.
+#    ^^^^^^ reference [..] Z1#`@f`.
 #         ^ reference local 1~#1000661517
    end
  
    sig { returns(T::Boolean) }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #        ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #                ^ reference [..] T#
 #                   ^^^^^^^ reference [..] T#Boolean.
 #                   ^^^^^^^^^^ reference [..] Sorbet#Private#Static#
    def read_f?
-#  ^^^^^^^^^^^ definition [..] Z1#read_f?().
+#  ^^^^^^^^^^^ definition [..] Z1#`read_f?`().
      @f
-#    ^^ reference [..] Z1#@f.
+#    ^^ reference [..] Z1#`@f`.
    end
  end
  
@@ -42,19 +42,19 @@
 #            ^^^ reference [..] T#Sig#
  
    sig { returns(T::Boolean) }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #        ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #                ^ reference [..] T#
 #                   ^^^^^^^ reference [..] T#Boolean.
 #                   ^^^^^^^^^^ reference [..] Sorbet#Private#Static#
    def read_f?
-#  ^^^^^^^^^^^ definition [..] Z2#read_f?().
+#  ^^^^^^^^^^^ definition [..] Z2#`read_f?`().
      @f
-#    ^^ reference [..] Z2#@f.
+#    ^^ reference [..] Z2#`@f`.
    end
  
    sig { params(a: T::Boolean).void }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #        ^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
 #                  ^ reference [..] T#
 #                     ^^^^^^^ reference [..] T#Boolean.
@@ -64,8 +64,8 @@
 #  ^^^^^^^^^^^^^^ definition [..] Z2#write_f().
 #              ^ definition local 1~#1000661517
      @f = a
-#    ^^ definition [..] Z2#@f.
-#    ^^^^^^ reference [..] Z2#@f.
+#    ^^ definition [..] Z2#`@f`.
+#    ^^^^^^ reference [..] Z2#`@f`.
 #         ^ reference local 1~#1000661517
    end
  end
@@ -78,15 +78,15 @@
 #            ^^^ reference [..] T#Sig#
  
    sig { returns(T::Boolean) }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #        ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #                ^ reference [..] T#
 #                   ^^^^^^^ reference [..] T#Boolean.
 #                   ^^^^^^^^^^ reference [..] Sorbet#Private#Static#
    def read_f_plus_1?
-#  ^^^^^^^^^^^^^^^^^^ definition [..] Z3#read_f_plus_1?().
+#  ^^^^^^^^^^^^^^^^^^ definition [..] Z3#`read_f_plus_1?`().
      @f + 1
-#    ^^ reference [..] Z3#@f.
+#    ^^ reference [..] Z3#`@f`.
    end
  end
  
@@ -98,7 +98,7 @@
 #            ^^^ reference [..] T#Sig#
  
    sig { params(a: T::Boolean).void }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #        ^^^^^^ reference [..] T#Private#Methods#DeclBuilder#params().
 #                  ^ reference [..] T#
 #                     ^^^^^^^ reference [..] T#Boolean.
@@ -110,8 +110,8 @@
      write_f(a)
 #            ^ reference local 1~#3337417690
      @f = read_f_plus_1?
-#    ^^ definition [..] Z4#@f.
-#    ^^^^^^^^^^^^^^^^^^^ reference [..] Z4#@f.
+#    ^^ definition [..] Z4#`@f`.
+#    ^^^^^^^^^^^^^^^^^^^ reference [..] Z4#`@f`.
    end
  end
  

--- a/test/scip/testdata/loops_and_conditionals.snapshot.rb
+++ b/test/scip/testdata/loops_and_conditionals.snapshot.rb
@@ -28,7 +28,7 @@
 #          ^ reference local 1~#2393773952
 #                      ^ reference local 1~#2393773952
 #                               ^ reference local 1~#2393773952
-#                                       ^^ reference [..] Integer#==().
+#                                       ^^ reference [..] Integer#`==`().
        x
 #      ^ reference local 1~#2393773952
      else

--- a/test/scip/testdata/multifile/basic/def_class1.snapshot.rb
+++ b/test/scip/testdata/multifile/basic/def_class1.snapshot.rb
@@ -7,7 +7,7 @@
 #            ^^^ reference [..] T#Sig#
  
    sig { returns(T::Boolean) }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #        ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #                ^ reference [..] T#
 #                   ^^^^^^^ reference [..] T#Boolean.

--- a/test/scip/testdata/type_change.snapshot.rb
+++ b/test/scip/testdata/type_change.snapshot.rb
@@ -130,7 +130,7 @@
 #      | class C
 #      | ```
    @k = nil
-#  ^^ definition [..] <Class:C>#@k.
+#  ^^ definition [..] `<Class:C>`#`@k`.
 #  documentation
 #  | ```ruby
 #  | @k (T.untyped)
@@ -149,67 +149,67 @@
 #                  | b (T.untyped)
 #                  | ```
      @f = nil
-#    ^^ definition [..] C#@f.
+#    ^^ definition [..] C#`@f`.
 #    documentation
 #    | ```ruby
 #    | @f (T.untyped)
 #    | ```
      @@g = nil
-#    ^^^ definition [..] C#@@g.
+#    ^^^ definition [..] C#`@@g`.
 #    documentation
 #    | ```ruby
 #    | @@g (T.untyped)
 #    | ```
      @k = nil
-#    ^^ definition [..] C#@k.
+#    ^^ definition [..] C#`@k`.
 #    documentation
 #    | ```ruby
 #    | @k (T.untyped)
 #    | ```
      if b
        @f = 1
-#      ^^ reference (write) [..] C#@f.
+#      ^^ reference (write) [..] C#`@f`.
 #      override_documentation
 #      | ```ruby
 #      | @f (Integer(1))
 #      | ```
        @@g = 1
-#      ^^^ reference (write) [..] C#@@g.
+#      ^^^ reference (write) [..] C#`@@g`.
 #      override_documentation
 #      | ```ruby
 #      | @@g (Integer(1))
 #      | ```
        @k = 1
-#      ^^ reference (write) [..] C#@k.
+#      ^^ reference (write) [..] C#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (Integer(1))
 #      | ```
-#      ^^^^^^ reference [..] C#@k.
+#      ^^^^^^ reference [..] C#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (Integer(1))
 #      | ```
      else
        @f = 'f'
-#      ^^ reference (write) [..] C#@f.
+#      ^^ reference (write) [..] C#`@f`.
 #      override_documentation
 #      | ```ruby
 #      | @f (String("f"))
 #      | ```
        @@g = 'g'
-#      ^^^ reference (write) [..] C#@@g.
+#      ^^^ reference (write) [..] C#`@@g`.
 #      override_documentation
 #      | ```ruby
 #      | @@g (String("g"))
 #      | ```
        @k = 'k'
-#      ^^ reference (write) [..] C#@k.
+#      ^^ reference (write) [..] C#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (String("k"))
 #      | ```
-#      ^^^^^^^^ reference [..] C#@k.
+#      ^^^^^^^^ reference [..] C#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (String("k"))
@@ -244,48 +244,48 @@
      if !b
 #        ^ reference local 1~#2066187318
        @f = 1
-#      ^^ definition [..] D#@f.
+#      ^^ definition [..] D#`@f`.
 #      documentation
 #      | ```ruby
 #      | @f (T.untyped)
 #      | ```
        @@g = 1
-#      ^^^ definition [..] D#@@g.
+#      ^^^ definition [..] D#`@@g`.
 #      documentation
 #      | ```ruby
 #      | @@g (T.untyped)
 #      | ```
        @k = 1
-#      ^^ definition [..] D#@k.
+#      ^^ definition [..] D#`@k`.
 #      documentation
 #      | ```ruby
 #      | @k (T.untyped)
 #      | ```
-#      ^^^^^^ reference [..] D#@k.
+#      ^^^^^^ reference [..] D#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (Integer(1))
 #      | ```
      else
        @f = 'f'
-#      ^^ definition [..] D#@f.
+#      ^^ definition [..] D#`@f`.
 #      documentation
 #      | ```ruby
 #      | @f (T.untyped)
 #      | ```
        @@g = 'g'
-#      ^^^ definition [..] D#@@g.
+#      ^^^ definition [..] D#`@@g`.
 #      documentation
 #      | ```ruby
 #      | @@g (T.untyped)
 #      | ```
        @k = 'k'
-#      ^^ definition [..] D#@k.
+#      ^^ definition [..] D#`@k`.
 #      documentation
 #      | ```ruby
 #      | @k (T.untyped)
 #      | ```
-#      ^^^^^^^^ reference [..] D#@k.
+#      ^^^^^^^^ reference [..] D#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (String("k"))

--- a/test/scip/testdata/type_docs.snapshot.rb
+++ b/test/scip/testdata/type_docs.snapshot.rb
@@ -12,7 +12,7 @@
 #            ^^^ reference [..] T#Sig#
  
    sig { params(x: Integer, y: String).returns(String) }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Sorbet#Private#Static#
 #                  ^^^^^^^ reference [..] Integer#
 #                              ^^^^^^ reference [..] String#

--- a/test/scip/testdata/types.snapshot.rb
+++ b/test/scip/testdata/types.snapshot.rb
@@ -11,8 +11,8 @@
 #       ^ definition [..] M#
    module_function
    sig { returns(T::Boolean) }
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
-#  ^^^ reference [..] Sorbet#Private#<Class:Static>#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
+#  ^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #                ^ reference [..] T#
 #                   ^^^^^^^ reference [..] T#Boolean.
 #                   ^^^^^^^ reference [..] T#Boolean.
@@ -20,7 +20,7 @@
 #                   ^^^^^^^^^^ reference [..] Sorbet#Private#Static#
    def b
 #  ^^^^^ definition [..] M#b().
-#  ^^^^^ definition [..] <Class:M>#b().
+#  ^^^^^ definition [..] `<Class:M>`#b().
      true
    end
  end


### PR DESCRIPTION
### Motivation

Fixes issue https://github.com/sourcegraph/scip-ruby/issues/89

### Test plan

Updated existing tests