### PR TITLE
fix: Propagate Locs instead of LocOffsets.

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -244,8 +244,8 @@ string CFG::toTextualString(const core::GlobalState &gs, optional<core::FileRef>
     if (file) {
         auto method = this->symbol.data(gs);
         if (method->nameLoc.exists() && !method->nameLoc.empty()) {
-            fmt::format_to(std::back_inserter(buf), "method @ {} {} {{\n\n",
-                           core::Loc(file.value(), method->nameLoc).showRawLineColumn(gs), symbolName);
+            fmt::format_to(std::back_inserter(buf), "method @ {} {} {{\n\n", method->nameLoc.showRawLineColumn(gs),
+                           symbolName);
         } else {
             fmt::format_to(std::back_inserter(buf), "method @ {} (full) {} {{\n\n", method->loc().showRawLineColumn(gs),
                            symbolName);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -127,7 +127,7 @@ struct MethodBuilder {
 };
 
 MethodBuilder enterMethod(GlobalState &gs, ClassOrModuleRef klass, NameRef name) {
-    return MethodBuilder{gs, gs.enterMethodSymbol(Loc::none(), klass, name, LocOffsets::none())};
+    return MethodBuilder{gs, gs.enterMethodSymbol(Loc::none(), klass, name, Loc::none())};
 }
 
 struct ParentLinearizationInformation {
@@ -303,8 +303,7 @@ void GlobalState::initEmpty() {
     ClassOrModuleRef klass;
     klass = synthesizeClass(core::Names::Constants::NoSymbol(), 0);
     ENFORCE(klass == Symbols::noClassOrModule());
-    MethodRef method =
-        enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::noMethod(), LocOffsets::none());
+    MethodRef method = enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::noMethod(), Loc::none());
     ENFORCE(method == Symbols::noMethod());
     FieldRef field = enterFieldSymbol(Loc::none(), Symbols::noClassOrModule(), Names::noFieldOrStaticField());
     ENFORCE(field == Symbols::noField());
@@ -582,7 +581,7 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::Class(), Names::new_()).repeatedArg(Names::args()).build();
     ENFORCE(method == Symbols::Class_new());
 
-    method = enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::TodoMethod(), LocOffsets::none());
+    method = enterMethodSymbol(Loc::none(), Symbols::noClassOrModule(), Names::TodoMethod(), Loc::none());
     enterMethodArgumentSymbol(Loc::none(), method, Names::args());
     ENFORCE(method == Symbols::todoMethod());
 
@@ -888,7 +887,7 @@ void GlobalState::installIntrinsics() {
                 break;
         }
         auto countBefore = methodsUsed();
-        auto method = enterMethodSymbol(Loc::none(), symbol, entry.method, LocOffsets::none());
+        auto method = enterMethodSymbol(Loc::none(), symbol, entry.method, Loc::none());
         method.data(*this)->intrinsicOffset = offset + Method::FIRST_VALID_INTRINSIC_OFFSET;
         if (countBefore != methodsUsed()) {
             auto &blkArg = enterMethodArgumentSymbol(Loc::none(), method, Names::blkArg());
@@ -1193,7 +1192,7 @@ TypeArgumentRef GlobalState::enterTypeArgument(Loc loc, MethodRef owner, NameRef
     return result;
 }
 
-MethodRef GlobalState::enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRef name, LocOffsets nameLoc) {
+MethodRef GlobalState::enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRef name, Loc nameLoc) {
     ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
     histogramInc("symbol_enter_by_name", ownerScope->members().size());
 
@@ -2344,8 +2343,7 @@ const vector<shared_ptr<File>> &GlobalState::getFiles() const {
 
 MethodRef GlobalState::staticInitForClass(ClassOrModuleRef klass, Loc loc) {
     auto prevCount = methodsUsed();
-    auto sym = enterMethodSymbol(loc, klass.data(*this)->singletonClass(*this), core::Names::staticInit(),
-                                 klass.data(*this)->loc().offsets());
+    auto sym = enterMethodSymbol(loc, klass.data(*this)->singletonClass(*this), core::Names::staticInit(), loc);
     if (prevCount != methodsUsed()) {
         auto blkLoc = core::Loc::none(loc.file());
         auto &blkSym = enterMethodArgumentSymbol(blkLoc, sym, core::Names::blkArg());
@@ -2364,7 +2362,7 @@ MethodRef GlobalState::lookupStaticInitForClass(ClassOrModuleRef klass, bool all
 MethodRef GlobalState::staticInitForFile(Loc loc) {
     auto nm = freshNameUnique(core::UniqueNameKind::Namer, core::Names::staticInit(), loc.file().id());
     auto prevCount = this->methodsUsed();
-    auto sym = enterMethodSymbol(loc, core::Symbols::rootSingleton(), nm, LocOffsets::none());
+    auto sym = enterMethodSymbol(loc, core::Symbols::rootSingleton(), nm, Loc::none());
     if (prevCount != this->methodsUsed()) {
         auto blkLoc = core::Loc::none(loc.file());
         auto &blkSym = this->enterMethodArgumentSymbol(blkLoc, sym, core::Names::blkArg());

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -102,7 +102,7 @@ public:
     ClassOrModuleRef enterClassSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);
     TypeMemberRef enterTypeMember(Loc loc, ClassOrModuleRef owner, NameRef name, Variance variance);
     TypeArgumentRef enterTypeArgument(Loc loc, MethodRef owner, NameRef name, Variance variance);
-    MethodRef enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRef name, LocOffsets nameLoc);
+    MethodRef enterMethodSymbol(Loc loc, ClassOrModuleRef owner, NameRef name, Loc nameLoc);
     MethodRef enterNewMethodOverload(Loc loc, MethodRef original, core::NameRef originalName, uint32_t num,
                                      const std::vector<bool> &argsToKeep);
     FieldRef enterFieldSymbol(Loc loc, ClassOrModuleRef owner, NameRef name);

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1840,7 +1840,7 @@ void ClassOrModule::recordRequiredAncestorInternal(GlobalState &gs, ClassOrModul
     // We store the required ancestors into a fake property called `<required-ancestors>`
     auto ancestors = this->findMethod(gs, prop);
     if (!ancestors.exists()) {
-        ancestors = gs.enterMethodSymbol(ancestor.loc, this->ref(gs), prop, LocOffsets::none());
+        ancestors = gs.enterMethodSymbol(ancestor.loc, this->ref(gs), prop, Loc::none());
         ancestors.data(gs)->locs_.clear(); // Remove the original location
 
         // Create the return type tuple to store RequiredAncestor.symbol

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -152,7 +152,7 @@ public:
 
     ClassOrModuleRef owner;
     NameRef name;
-    core::LocOffsets nameLoc;
+    core::Loc nameLoc;
     ClassOrModuleRef rebind;
     Flags flags;
     // We store an offset into the intrinsic table used by calls.cc; the only
@@ -189,7 +189,7 @@ private:
     InlinedVector<Loc, 2> locs_;
     std::unique_ptr<InlinedVector<TypeArgumentRef, 4>> typeArgs;
 };
-CheckSize(Method, 144, 8);
+static_assert(sizeof(Method) == 168);
 
 // Contains a field or a static field
 class Field final {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -818,7 +818,7 @@ class SymbolDefiner {
         auto &parsedArgs = method.parsedArgs;
         auto symTableSize = ctx.state.methodsUsed();
         auto declLoc = ctx.locAt(method.declLoc);
-        auto sym = ctx.state.enterMethodSymbol(declLoc, owner, method.name, method.nameLoc);
+        auto sym = ctx.state.enterMethodSymbol(declLoc, owner, method.name, ctx.locAt(method.nameLoc));
         const bool isNewSymbol = symTableSize != ctx.state.methodsUsed();
         if (!isNewSymbol) {
             // See if this is == to the method we're defining now, or if we have a redefinition error.
@@ -830,7 +830,7 @@ class SymbolDefiner {
                     paramMismatchErrors(ctx.withOwner(sym), declLoc, parsedArgs);
                     ctx.state.mangleRenameSymbol(sym, method.name);
                     // Re-enter a new symbol.
-                    sym = ctx.state.enterMethodSymbol(declLoc, owner, method.name, method.nameLoc);
+                    sym = ctx.state.enterMethodSymbol(declLoc, owner, method.name, ctx.locAt(method.nameLoc));
                 } else {
                     // ...unless it's an intrinsic, because we allow multiple incompatible definitions of those in code
                     // TODO(jvilk): Wouldn't this always fail since `!sym.exists()`?
@@ -1024,8 +1024,8 @@ class SymbolDefiner {
             symbolData->flags.isSealed = true;
 
             auto classOfKlass = symbolData->singletonClass(ctx);
-            auto sealedSubclasses = ctx.state.enterMethodSymbol(
-                ctx.locAt(mod.loc), classOfKlass, core::Names::sealedSubclasses(), core::LocOffsets::none());
+            auto sealedSubclasses = ctx.state.enterMethodSymbol(ctx.locAt(mod.loc), classOfKlass,
+                                                                core::Names::sealedSubclasses(), core::Loc::none());
             auto &blkArg =
                 ctx.state.enterMethodArgumentSymbol(core::Loc::none(), sealedSubclasses, core::Names::blkArg());
             blkArg.flags.isBlock = true;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -881,7 +881,7 @@ private:
             core::make_type<core::UnresolvedClassType>(unresolvedPath->first, move(unresolvedPath->second));
 
         auto uaSym = ctx.state.enterMethodSymbol(core::Loc::none(), item.klass, core::Names::unresolvedAncestors(),
-                                                 core::LocOffsets::none());
+                                                 core::Loc::none());
 
         // Add a fake block argument so that this method symbol passes sanity checks
         auto &arg = ctx.state.enterMethodArgumentSymbol(core::Loc::none(), uaSym, core::Names::blkArg());
@@ -1074,7 +1074,7 @@ private:
                     // We never stored a mixin in this symbol
                     // Create a the fake property that will hold the mixed in modules
                     mixMethod = gs.enterMethodSymbol(core::Loc{todo.file, send->loc}, ownerKlass,
-                                                     core::Names::mixedInClassMethods(), core::LocOffsets::none());
+                                                     core::Names::mixedInClassMethods(), core::Loc::none());
                     mixMethod.data(gs)->resultType = core::make_type<core::TupleType>(vector<core::TypePtr>{});
 
                     // Create a dummy block argument to satisfy sanitycheck during GlobalState::expandNames
@@ -2441,7 +2441,7 @@ class ResolveTypeMembersAndFieldsWalk {
         }
 
         // FIXME[alias-support]: Use job.fromNameLoc here for the last argument.
-        auto alias = ctx.state.enterMethodSymbol(ctx.locAt(job.loc), job.owner, job.fromName, job.loc);
+        auto alias = ctx.state.enterMethodSymbol(ctx.locAt(job.loc), job.owner, job.fromName, ctx.locAt(job.loc));
         alias.data(ctx)->resultType = core::make_type<core::AliasType>(core::SymbolRef(toMethod));
 
         // Add a fake keyword argument to remember the toName (for fast path hashing).

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -123,7 +123,7 @@ TEST_CASE("CountTrees") {
 
     // see if it crashes via failed ENFORCE
     cb.enterTypeMember(loc, classSym, cb.enterNameConstant(name), sorbet::core::Variance::CoVariant);
-    auto methodSym = cb.enterMethodSymbol(loc, classSym, name, core::LocOffsets::none());
+    auto methodSym = cb.enterMethodSymbol(loc, classSym, name, core::Loc::none());
 
     // see if it crashes via failed ENFORCE
     cb.enterTypeArgument(loc, methodSym, cb.enterNameConstant(name), sorbet::core::Variance::CoVariant);


### PR DESCRIPTION
### Motivation

Fixes a crash when indexing Homebrew/brew, where we were running into
situations where we'd end up having a LocOffset for a nameLoc,
and it'd be unclear which file it corresponded to. Trying to
recover that information after the fact, such as from the method's
Loc field, seemed unreliable, so I've chosen to carry a Loc instead.


### Test plan

Manually tested by indexing Hombrew/brew.