### PR TITLE
fix: Add support for unresolved fields from mixins

### DIFF
--- a/scip_indexer/BUILD
+++ b/scip_indexer/BUILD
@@ -30,6 +30,8 @@ cc_library(
     srcs = [
         "Debug.cc",
         "Debug.h",
+        "SCIPFieldResolve.cc",
+        "SCIPFieldResolve.h",
         "SCIPIndexer.cc",
         "SCIPProtoExt.cc",
         "SCIPProtoExt.h",

--- a/scip_indexer/Debug.h
+++ b/scip_indexer/Debug.h
@@ -42,7 +42,7 @@ template <typename T, typename Fn> std::string showSet(const sorbet::UnorderedSe
     return out.str();
 }
 
-template <typename T, typename Fn> std::string showVec(const std::vector<T> &v, Fn f) {
+template <typename V, typename Fn> std::string showVec(const V &v, Fn f) {
     std::ostringstream out;
     out << "[";
     for (auto i = 0; i < v.size(); ++i) {

--- a/scip_indexer/SCIPFieldResolve.cc
+++ b/scip_indexer/SCIPFieldResolve.cc
@@ -1,0 +1,140 @@
+#include <vector>
+
+#include "absl/strings/ascii.h"
+
+#include "common/common.h"
+#include "core/GlobalState.h"
+#include "core/SymbolRef.h"
+#include "core/Symbols.h"
+
+#include "scip_indexer/Debug.h"
+#include "scip_indexer/SCIPFieldResolve.h"
+
+using namespace std;
+
+namespace sorbet::scip_indexer {
+
+string FieldQueryResult::Data::showRaw(const core::GlobalState &gs) const {
+    switch (this->kind()) {
+        case Kind::FromDeclared:
+            return this->originalSymbol().showRaw(gs);
+        case Kind::FromUndeclared:
+            return fmt::format("In({})", absl::StripAsciiWhitespace(this->originalClass().showFullName(gs)));
+    }
+}
+
+string FieldQueryResult::showRaw(const core::GlobalState &gs) const {
+    if (this->mixedIn->empty()) {
+        return fmt::format("FieldQueryResult(inherited: {})", this->inherited.showRaw(gs));
+    }
+    return fmt::format("FieldQueryResult(inherited: {}, mixins: {})", this->inherited.showRaw(gs),
+                       showVec(*this->mixedIn.get(), [&gs](const auto &mixin) -> string { return mixin.showRaw(gs); }));
+}
+
+void FieldResolver::resetMixins() {
+    this->mixinQueue.clear();
+}
+
+// Compute all transitively included modules which mention the field being queried.
+//
+// If an include chain for a field looks like class C.@f <- module M2.@f <- module M1.@f,
+// both M1 and M2 will be included in the results (this avoids any kind of postprocessing
+// of a transitive closure of relationships at the cost of a larger index).
+void FieldResolver::findUnresolvedFieldInMixinsTransitive(const core::GlobalState &gs, FieldQuery query,
+                                                          vector<FieldQueryResult::Data> &out) {
+    this->mixinQueue.clear();
+    for (auto mixin : query.start.data(gs)->mixins()) {
+        this->mixinQueue.push_back(mixin);
+    }
+    auto field = query.field;
+    using Data = FieldQueryResult::Data;
+    while (auto m = this->mixinQueue.try_pop_front()) {
+        auto mixin = m.value();
+        auto sym = mixin.data(gs)->findMember(gs, field);
+        if (sym.exists()) {
+            out.push_back(Data(sym));
+            continue;
+        }
+        auto it = gs.unresolvedFields.find(mixin);
+        if (it != gs.unresolvedFields.end() && it->second.contains(field)) {
+            out.push_back(Data(mixin));
+        }
+    }
+}
+
+FieldQueryResult::Data FieldResolver::findUnresolvedFieldInInheritanceChain(const core::GlobalState &gs, core::Loc loc,
+                                                                            FieldQuery query) {
+    auto start = query.start;
+    auto field = query.field;
+
+    auto fieldText = query.field.shortName(gs);
+    auto isInstanceVar = fieldText.size() >= 2 && fieldText[0] == '@' && fieldText[1] != '@';
+    auto isClassInstanceVar = isInstanceVar && start.data(gs)->isSingletonClass(gs);
+    // Class instance variables are not inherited, unlike ordinary instance
+    // variables or class variables.
+    if (isClassInstanceVar) {
+        return FieldQueryResult::Data(start);
+    }
+    auto isClassVar = fieldText.size() >= 2 && fieldText[0] == '@' && fieldText[1] == '@';
+    if (isClassVar && !start.data(gs)->isSingletonClass(gs)) {
+        // Triggered when undeclared class variables are accessed from instance methods.
+        start = start.data(gs)->lookupSingletonClass(gs);
+    }
+
+    if (gs.unresolvedFields.find(start) == gs.unresolvedFields.end() ||
+        !gs.unresolvedFields.find(start)->second.contains(field)) {
+        // Triggered by code patterns like:
+        //   # top-level
+        //   def MyClass.method
+        //     # blah
+        //   end
+        // which is not supported by Sorbet.
+        LOG_DEBUG(gs, loc,
+                  fmt::format("couldn't find field {} in class {};\n"
+                              "are you using a code pattern like def MyClass.method which is unsupported by Sorbet?",
+                              field.exists() ? field.toString(gs) : "<non-existent>",
+                              start.exists() ? start.showFullName(gs) : "<non-existent>"));
+        // As a best-effort guess, assume that the definition is
+        // in this class but we somehow missed it.
+        return FieldQueryResult::Data(start);
+    }
+
+    auto best = start;
+    auto cur = start;
+    while (cur.exists()) {
+        auto klass = cur.data(gs);
+        auto sym = klass->findMember(gs, field);
+        if (sym.exists()) { // TODO(varun): Is this early exit justified?
+                            // Maybe it is possible to hit this in multiple ancestors?
+            return FieldQueryResult::Data(sym);
+        }
+        auto it = gs.unresolvedFields.find(cur);
+        if (it != gs.unresolvedFields.end() && it->second.contains(field)) {
+            best = cur;
+        }
+
+        if (cur == klass->superClass()) { // FIXME(varun): Handle mix-ins
+            break;
+        }
+        cur = klass->superClass();
+    }
+    return FieldQueryResult::Data(best);
+}
+
+pair<FieldQueryResult, bool> FieldResolver::findUnresolvedFieldTransitive(const core::GlobalState &gs, core::Loc loc,
+                                                                          FieldQuery query) {
+    auto cacheIt = this->cache.find(query);
+    if (cacheIt != this->cache.end()) {
+        return {cacheIt->second, true};
+    }
+    auto inherited = this->findUnresolvedFieldInInheritanceChain(gs, loc, query);
+    using Data = FieldQueryResult::Data;
+    vector<Data> mixins;
+    findUnresolvedFieldInMixinsTransitive(gs, query, mixins);
+    auto [it, inserted] =
+        this->cache.insert({query, FieldQueryResult{inherited, make_shared<vector<Data>>(move(mixins))}});
+    ENFORCE(inserted);
+    return {it->second, false};
+}
+
+} // namespace sorbet::scip_indexer

--- a/scip_indexer/SCIPFieldResolve.cc
+++ b/scip_indexer/SCIPFieldResolve.cc
@@ -118,12 +118,12 @@ core::ClassOrModuleRef FieldResolver::findUnresolvedFieldInInheritanceChain(cons
     return best;
 }
 
-pair<FieldQueryResult, bool> FieldResolver::findUnresolvedFieldTransitive(const core::GlobalState &gs, FieldQuery query,
-                                                                          core::Loc debugLoc) {
+FieldQueryResult FieldResolver::findUnresolvedFieldTransitive(const core::GlobalState &gs, FieldQuery query,
+                                                              core::Loc debugLoc) {
     ENFORCE(query.field.exists());
     auto cacheIt = this->cache.find(query);
     if (cacheIt != this->cache.end()) {
-        return {cacheIt->second, true};
+        return cacheIt->second;
     }
     auto inherited = this->findUnresolvedFieldInInheritanceChain(gs, query, debugLoc);
     vector<core::ClassOrModuleRef> mixins;
@@ -131,7 +131,7 @@ pair<FieldQueryResult, bool> FieldResolver::findUnresolvedFieldTransitive(const 
     auto [it, inserted] =
         this->cache.insert({query, FieldQueryResult{inherited, make_shared<decltype(mixins)>(move(mixins))}});
     ENFORCE(inserted);
-    return {it->second, false};
+    return it->second;
 }
 
 } // namespace sorbet::scip_indexer

--- a/scip_indexer/SCIPFieldResolve.cc
+++ b/scip_indexer/SCIPFieldResolve.cc
@@ -63,8 +63,8 @@ core::ClassOrModuleRef FieldResolver::normalizeParentForClassVar(const core::Glo
     return klass;
 }
 
-core::ClassOrModuleRef FieldResolver::findUnresolvedFieldInInheritanceChain(const core::GlobalState &gs, core::Loc loc,
-                                                                            FieldQuery query) {
+core::ClassOrModuleRef FieldResolver::findUnresolvedFieldInInheritanceChain(const core::GlobalState &gs,
+                                                                            FieldQuery query, core::Loc debugLoc) {
     auto start = query.start;
     auto field = query.field;
 
@@ -86,7 +86,7 @@ core::ClassOrModuleRef FieldResolver::findUnresolvedFieldInInheritanceChain(cons
         //     # blah
         //   end
         // which is not supported by Sorbet.
-        LOG_DEBUG(gs, loc,
+        LOG_DEBUG(gs, debugLoc,
                   fmt::format("couldn't find field {} in class {};\n"
                               "are you using a code pattern like def MyClass.method which is unsupported by Sorbet?",
                               field.exists() ? field.toString(gs) : "<non-existent>",
@@ -118,14 +118,14 @@ core::ClassOrModuleRef FieldResolver::findUnresolvedFieldInInheritanceChain(cons
     return best;
 }
 
-pair<FieldQueryResult, bool> FieldResolver::findUnresolvedFieldTransitive(const core::GlobalState &gs, core::Loc loc,
-                                                                          FieldQuery query) {
+pair<FieldQueryResult, bool> FieldResolver::findUnresolvedFieldTransitive(const core::GlobalState &gs, FieldQuery query,
+                                                                          core::Loc debugLoc) {
     ENFORCE(query.field.exists());
     auto cacheIt = this->cache.find(query);
     if (cacheIt != this->cache.end()) {
         return {cacheIt->second, true};
     }
-    auto inherited = this->findUnresolvedFieldInInheritanceChain(gs, loc, query);
+    auto inherited = this->findUnresolvedFieldInInheritanceChain(gs, query, debugLoc);
     vector<core::ClassOrModuleRef> mixins;
     findUnresolvedFieldInMixinsTransitive(gs, query, mixins);
     auto [it, inserted] =

--- a/scip_indexer/SCIPFieldResolve.cc
+++ b/scip_indexer/SCIPFieldResolve.cc
@@ -119,7 +119,7 @@ FieldQueryResult::Data FieldResolver::findUnresolvedFieldInInheritanceChain(cons
             best = cur;
         }
 
-        if (cur == klass->superClass()) { // FIXME(varun): Handle mix-ins
+        if (cur == klass->superClass()) {
             break;
         }
         cur = klass->superClass();

--- a/scip_indexer/SCIPFieldResolve.h
+++ b/scip_indexer/SCIPFieldResolve.h
@@ -25,47 +25,8 @@ template <typename H> H AbslHashValue(H h, const FieldQuery &q) {
 }
 
 struct FieldQueryResult final {
-    enum class Kind : bool {
-        FromDeclared,
-        FromUndeclared,
-    };
-
-    class Data {
-        union Storage {
-            core::ClassOrModuleRef owner;
-            core::SymbolRef symbol;
-            Storage() {
-                memset(this, 0, sizeof(Storage));
-            }
-        } storage;
-        Kind _kind;
-
-    public:
-        Data(Data &&) = default;
-        Data(const Data &) = default;
-        Kind kind() const {
-            return this->_kind;
-        }
-        core::ClassOrModuleRef originalClass() const {
-            ENFORCE(this->kind() == Kind::FromUndeclared);
-            return this->storage.owner;
-        }
-        core::SymbolRef originalSymbol() const {
-            ENFORCE(this->kind() == Kind::FromUndeclared);
-            return this->storage.symbol;
-        }
-        Data(core::ClassOrModuleRef klass) : _kind(Kind::FromUndeclared) {
-            this->storage.owner = klass;
-        }
-        Data(core::SymbolRef sym) : _kind(Kind::FromDeclared) {
-            this->storage.symbol = sym;
-        }
-
-        std::string showRaw(const core::GlobalState &) const;
-    };
-
-    Data inherited;
-    std::shared_ptr<std::vector<Data>> mixedIn;
+    core::ClassOrModuleRef inherited;
+    std::shared_ptr<std::vector<core::ClassOrModuleRef>> mixedIn;
 
     std::string showRaw(const core::GlobalState &gs) const;
 };
@@ -114,9 +75,9 @@ private:
     void resetMixins();
 
     void findUnresolvedFieldInMixinsTransitive(const sorbet::core::GlobalState &gs, FieldQuery query,
-                                               std::vector<FieldQueryResult::Data> &out);
+                                               std::vector<core::ClassOrModuleRef> &out);
 
-    FieldQueryResult::Data findUnresolvedFieldInInheritanceChain(const core::GlobalState &gs, core::Loc loc,
+    core::ClassOrModuleRef findUnresolvedFieldInInheritanceChain(const core::GlobalState &gs, core::Loc loc,
                                                                  FieldQuery query);
 };
 

--- a/scip_indexer/SCIPFieldResolve.h
+++ b/scip_indexer/SCIPFieldResolve.h
@@ -1,0 +1,122 @@
+
+#ifndef SORBET_SCIP_FIELD_RESOLVE
+#define SORBET_SCIP_FIELD_RESOLVE
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "core/NameRef.h"
+#include "core/SymbolRef.h"
+
+namespace sorbet::scip_indexer {
+
+struct FieldQuery final {
+    sorbet::core::ClassOrModuleRef start;
+    sorbet::core::NameRef field;
+
+    bool operator==(const FieldQuery &other) const noexcept {
+        return this->start == other.start && this->field == other.field;
+    }
+};
+
+template <typename H> H AbslHashValue(H h, const FieldQuery &q) {
+    return H::combine(std::move(h), q.start, q.field);
+}
+
+struct FieldQueryResult final {
+    enum class Kind : bool {
+        FromDeclared,
+        FromUndeclared,
+    };
+
+    class Data {
+        union Storage {
+            core::ClassOrModuleRef owner;
+            core::SymbolRef symbol;
+            Storage() {
+                memset(this, 0, sizeof(Storage));
+            }
+        } storage;
+        Kind _kind;
+
+    public:
+        Data(Data &&) = default;
+        Data(const Data &) = default;
+        Kind kind() const {
+            return this->_kind;
+        }
+        core::ClassOrModuleRef originalClass() const {
+            ENFORCE(this->kind() == Kind::FromUndeclared);
+            return this->storage.owner;
+        }
+        core::SymbolRef originalSymbol() const {
+            ENFORCE(this->kind() == Kind::FromUndeclared);
+            return this->storage.symbol;
+        }
+        Data(core::ClassOrModuleRef klass) : _kind(Kind::FromUndeclared) {
+            this->storage.owner = klass;
+        }
+        Data(core::SymbolRef sym) : _kind(Kind::FromDeclared) {
+            this->storage.symbol = sym;
+        }
+
+        std::string showRaw(const core::GlobalState &) const;
+    };
+
+    Data inherited;
+    std::shared_ptr<std::vector<Data>> mixedIn;
+
+    std::string showRaw(const core::GlobalState &gs) const;
+};
+
+// Non-shrinking queue for cheap-to-copy types.
+template <typename T> class BasicQueue final {
+    std::vector<T> storage;
+    size_t current;
+
+public:
+    BasicQueue() = default;
+    BasicQueue(BasicQueue &&) = default;
+    BasicQueue &operator=(BasicQueue &&) = default;
+    BasicQueue(const BasicQueue &) = delete;
+    BasicQueue &operator=(const BasicQueue &) = delete;
+
+    void clear() {
+        this->storage.clear();
+        this->current = 0;
+    }
+    void push_back(T val) {
+        this->storage.push_back(val);
+    }
+    std::optional<T> try_pop_front() {
+        if (this->current >= this->storage.size()) {
+            return {};
+        }
+        auto ret = this->storage[this->current];
+        this->current++;
+        return ret;
+    }
+};
+
+class FieldResolver final {
+    sorbet::UnorderedMap<FieldQuery, FieldQueryResult> cache;
+    BasicQueue<sorbet::core::ClassOrModuleRef> mixinQueue;
+
+public:
+    std::pair<FieldQueryResult, /*cacheHit*/ bool> findUnresolvedFieldTransitive(const core::GlobalState &gs,
+                                                                                 core::Loc loc, FieldQuery query);
+
+private:
+    void resetMixins();
+
+    void findUnresolvedFieldInMixinsTransitive(const sorbet::core::GlobalState &gs, FieldQuery query,
+                                               std::vector<FieldQueryResult::Data> &out);
+
+    FieldQueryResult::Data findUnresolvedFieldInInheritanceChain(const core::GlobalState &gs, core::Loc loc,
+                                                                 FieldQuery query);
+};
+
+} // namespace sorbet::scip_indexer
+
+#endif // SORBET_SCIP_FIELD_RESOLVE

--- a/scip_indexer/SCIPFieldResolve.h
+++ b/scip_indexer/SCIPFieldResolve.h
@@ -6,22 +6,24 @@
 #include <optional>
 #include <vector>
 
+#include "core/FileRef.h"
 #include "core/NameRef.h"
 #include "core/SymbolRef.h"
 
 namespace sorbet::scip_indexer {
 
 struct FieldQuery final {
+    core::FileRef file;
     sorbet::core::ClassOrModuleRef start;
     sorbet::core::NameRef field;
 
     bool operator==(const FieldQuery &other) const noexcept {
-        return this->start == other.start && this->field == other.field;
+        return this->file == other.file && this->start == other.start && this->field == other.field;
     }
 };
 
 template <typename H> H AbslHashValue(H h, const FieldQuery &q) {
-    return H::combine(std::move(h), q.start, q.field);
+    return H::combine(std::move(h), q.file, q.start, q.field);
 }
 
 struct FieldQueryResult final {
@@ -66,7 +68,7 @@ class FieldResolver final {
 
 public:
     std::pair<FieldQueryResult, /*cacheHit*/ bool> findUnresolvedFieldTransitive(const core::GlobalState &gs,
-                                                                                 core::Loc loc, FieldQuery query);
+                                                                                 FieldQuery query, core::Loc debugLoc);
 
     static core::ClassOrModuleRef normalizeParentForClassVar(const core::GlobalState &gs, core::ClassOrModuleRef klass,
                                                              std::string_view name);
@@ -77,8 +79,8 @@ private:
     void findUnresolvedFieldInMixinsTransitive(const sorbet::core::GlobalState &gs, FieldQuery query,
                                                std::vector<core::ClassOrModuleRef> &out);
 
-    core::ClassOrModuleRef findUnresolvedFieldInInheritanceChain(const core::GlobalState &gs, core::Loc loc,
-                                                                 FieldQuery query);
+    core::ClassOrModuleRef findUnresolvedFieldInInheritanceChain(const core::GlobalState &gs, FieldQuery query,
+                                                                 core::Loc debugLoc);
 };
 
 } // namespace sorbet::scip_indexer

--- a/scip_indexer/SCIPFieldResolve.h
+++ b/scip_indexer/SCIPFieldResolve.h
@@ -107,6 +107,9 @@ public:
     std::pair<FieldQueryResult, /*cacheHit*/ bool> findUnresolvedFieldTransitive(const core::GlobalState &gs,
                                                                                  core::Loc loc, FieldQuery query);
 
+    static core::ClassOrModuleRef normalizeParentForClassVar(const core::GlobalState &gs, core::ClassOrModuleRef klass,
+                                                             std::string_view name);
+
 private:
     void resetMixins();
 

--- a/scip_indexer/SCIPFieldResolve.h
+++ b/scip_indexer/SCIPFieldResolve.h
@@ -67,8 +67,7 @@ class FieldResolver final {
     BasicQueue<sorbet::core::ClassOrModuleRef> mixinQueue;
 
 public:
-    std::pair<FieldQueryResult, /*cacheHit*/ bool> findUnresolvedFieldTransitive(const core::GlobalState &gs,
-                                                                                 FieldQuery query, core::Loc debugLoc);
+    FieldQueryResult findUnresolvedFieldTransitive(const core::GlobalState &gs, FieldQuery query, core::Loc debugLoc);
 
     static core::ClassOrModuleRef normalizeParentForClassVar(const core::GlobalState &gs, core::ClassOrModuleRef klass,
                                                              std::string_view name);

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -589,7 +589,7 @@ public:
                         continue;
                     }
                     auto [result, cacheHit] = fieldResolver.findUnresolvedFieldTransitive(
-                        ctx, ctx.locAt(bind.loc), {klass.asClassOrModuleRef(), instr->name});
+                        ctx, {ctx.file, klass.asClassOrModuleRef(), instr->name}, ctx.locAt(bind.loc));
                     auto checkExists = [&](bool exists, const std::string &text) {
                         ENFORCE(exists,
                                 "Returned non-existent {} from findUnresolvedFieldTransitive with start={}, "
@@ -632,7 +632,7 @@ public:
                         // miss out on relationships for declared symbols.
                         if (!relMap.contains(symRef.withoutType())) {
                             auto [result, _] = fieldResolver.findUnresolvedFieldTransitive(
-                                ctx, ctx.locAt(bind.loc), {klass.asClassOrModuleRef(), name});
+                                ctx, {ctx.file, klass.asClassOrModuleRef(), name}, ctx.locAt(bind.loc));
                             result.inherited = instr->what.owner(gs).asClassOrModuleRef();
                             relMap.insert({symRef.withoutType(), result});
                         }

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -560,7 +560,7 @@ public:
         this->map = {};
         auto &gs = ctx.state;
         auto method = ctx.owner;
-        auto klass = method.owner(gs);
+        const auto klass = method.owner(gs);
         // Make sure that the offsets we store here match the offsets we use
         // in saveDefinition/saveReference.
         auto trim = [&](core::LocOffsets loc) -> core::LocOffsets {
@@ -602,9 +602,10 @@ public:
                     switch (result.inherited.kind()) {
                         case FieldQueryResult::Kind::FromUndeclared: {
                             checkExists(result.inherited.originalClass().exists(), "class");
-                            klass = FieldResolver::normalizeParentForClassVar(gs, klass.asClassOrModuleRef(),
-                                                                              instr->name.shortName(gs));
-                            auto namedSymRef = GenericSymbolRef::undeclaredField(klass, instr->name, bind.bind.type);
+                            auto normalizedKlass = FieldResolver::normalizeParentForClassVar(
+                                gs, klass.asClassOrModuleRef(), instr->name.shortName(gs));
+                            auto namedSymRef =
+                                GenericSymbolRef::undeclaredField(normalizedKlass, instr->name, bind.bind.type);
                             if (!cacheHit) {
                                 // It may be the case that the mixin values are already stored because of the
                                 // traversal in some other function. In that case, don't bother overriding.

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -604,6 +604,8 @@ public:
                     switch (result.inherited.kind()) {
                         case FieldQueryResult::Kind::FromUndeclared: {
                             checkExists(result.inherited.originalClass().exists(), "class");
+                            klass = FieldResolver::normalizeParentForClassVar(gs, klass.asClassOrModuleRef(),
+                                                                              instr->name.shortName(gs));
                             auto namedSymRef = GenericSymbolRef::undeclaredField(klass, instr->name, bind.bind.type);
                             if (!cacheHit) {
                                 // It may be the case that the mixin values are already stored because of the

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -478,9 +478,6 @@ public:
 
     void finalizeRefOnlySymbolInfos(const core::GlobalState &gs, core::FileRef file) {
         auto &potentialSyms = this->potentialRefOnlySymbols[file];
-        fmt::print(stderr, "potentialSyms = {}\n",
-                   showSet(potentialSyms, [&](UntypedGenericSymbolRef sym) -> string { return sym.showRaw(gs); }));
-        fmt::print(stderr, "relMap = {}\n", showRawRelationshipsMap(gs, this->relationshipsMap[file]));
 
         for (auto symRef : potentialSyms) {
             auto valueOrError = this->saveSymbolString(gs, symRef, nullptr);
@@ -876,8 +873,6 @@ public:
     void traverse(const cfg::CFG &cfg) {
         this->aliasMap.populate(this->ctx, cfg, this->scipState.fieldResolver,
                                 this->scipState.relationshipsMap[ctx.file]);
-        fmt::print(stderr, "log: [traverse] relationshipsMap = {}\n",
-                   showRawRelationshipsMap(this->ctx.state, this->scipState.relationshipsMap[ctx.file]));
         auto &gs = this->ctx.state;
         auto file = this->ctx.file;
         auto method = this->ctx.owner;

--- a/scip_indexer/SCIPProtoExt.cc
+++ b/scip_indexer/SCIPProtoExt.cc
@@ -1,5 +1,11 @@
 #include "scip_indexer/SCIPProtoExt.h"
+// Include first because it uses poisoned identifiers.
 
+#include "spdlog/fmt/fmt.h"
+
+#include "scip_indexer/Debug.h"
+
+#include <ostream>
 #include <string>
 
 namespace scip {
@@ -68,4 +74,22 @@ int compareSymbolInformation(const scip::SymbolInformation &s1, const scip::Symb
     return 0;
 }
 #undef CHECK_CMP
+
+std::string showRawRelationship(const scip::Relationship &rel) {
+    std::vector<std::string> info;
+    if (rel.is_reference()) {
+        info.push_back("ref");
+    }
+    if (rel.is_implementation()) {
+        info.push_back("impl");
+    }
+    if (rel.is_type_definition()) {
+        info.push_back("type_def");
+    }
+    if (rel.is_definition()) {
+        info.push_back("def");
+    }
+    return fmt::format("Rel(to: {}, {})", rel.symbol(),
+                       sorbet::scip_indexer::showVec(info, [](const auto &s) { return s; }));
+}
 } // namespace scip

--- a/scip_indexer/SCIPProtoExt.h
+++ b/scip_indexer/SCIPProtoExt.h
@@ -9,6 +9,8 @@ int compareOccurrence(const scip::Occurrence &o1, const scip::Occurrence &o2);
 int compareRelationship(const scip::Relationship &r1, const scip::Relationship &r2);
 
 int compareSymbolInformation(const scip::SymbolInformation &s1, const scip::SymbolInformation &s2);
+
+std::string showRawRelationship(const scip::Relationship &rel);
 } // namespace scip
 
 #endif // SORBET_SCIP_PROTO_EXT

--- a/scip_indexer/SCIPSymbolRef.cc
+++ b/scip_indexer/SCIPSymbolRef.cc
@@ -10,10 +10,12 @@
 #include "absl/strings/str_replace.h"
 #include "spdlog/fmt/fmt.h"
 
+#include "common/sort.h"
 #include "core/Loc.h"
 #include "main/lsp/lsp.h"
 
 #include "scip_indexer/Debug.h"
+#include "scip_indexer/SCIPProtoExt.h"
 #include "scip_indexer/SCIPSymbolRef.h"
 
 using namespace std;
@@ -143,6 +145,8 @@ void UntypedGenericSymbolRef::saveRelationships(
         rel.set_is_reference(true);
         saveSymbol(mixin, rel);
     }
+
+    fast_sort(rels, [](const auto &r1, const auto &r2) -> bool { return scip::compareRelationship(r1, r2) < 0; });
 }
 
 string GenericSymbolRef::showRaw(const core::GlobalState &gs) const {

--- a/test/scip/testdata/field_inheritance.rb
+++ b/test/scip/testdata/field_inheritance.rb
@@ -106,6 +106,18 @@ def f
   return
 end
 
+## Check that pre-declared class variables work too
+
+class DD1
+  @@x = T.let(0, Integer)
+end
+
+class DD2 < DD1
+  def self.get_x
+    @@x
+  end
+end
+
 # Class instance variables are not inherited.
 
 class E1

--- a/test/scip/testdata/field_inheritance.rb
+++ b/test/scip/testdata/field_inheritance.rb
@@ -134,3 +134,17 @@ class E2 < E1
     @y = 10
   end
 end
+
+# Declared fields are inherited the same way as undeclared fields
+
+class F1
+  def initialize
+    @x = T.let(0, Integer)
+  end
+end
+
+class F2
+  def get_x
+    @x
+  end
+end

--- a/test/scip/testdata/field_inheritance.snapshot.rb
+++ b/test/scip/testdata/field_inheritance.snapshot.rb
@@ -29,6 +29,7 @@
 #           ^^ reference [..] C2#`@f`.
 #           relation definition=[..] C1#`@f`.
 #                ^^ reference [..] C2#`@h`.
+#                relation definition=[..] C1#`@h`.
    end
  
    def set_inherited_ivar

--- a/test/scip/testdata/field_inheritance.snapshot.rb
+++ b/test/scip/testdata/field_inheritance.snapshot.rb
@@ -268,3 +268,26 @@
 #    ^^^^^^^ reference [..] `<Class:E2>`#`@y`.
    end
  end
+ 
+ # Declared fields are inherited the same way as undeclared fields
+ 
+ class F1
+#      ^^ definition [..] F1#
+   def initialize
+#      ^^^^^^^^^^ definition [..] F1#initialize().
+     @x = T.let(0, Integer)
+#    ^^ definition [..] F1#`@x`.
+#    ^^^^^^^^^^^^^^^^^^^^^^ reference [..] F1#`@x`.
+#                  ^^^^^^^ definition local 1~#3465713227
+#                  ^^^^^^^ reference [..] Integer#
+   end
+ end
+ 
+ class F2
+#      ^^ definition [..] F2#
+   def get_x
+#      ^^^^^ definition [..] F2#get_x().
+     @x
+#    ^^ reference [..] F2#`@x`.
+   end
+ end

--- a/test/scip/testdata/field_inheritance.snapshot.rb
+++ b/test/scip/testdata/field_inheritance.snapshot.rb
@@ -26,14 +26,17 @@
    def get_inherited_ivar
 #      ^^^^^^^^^^^^^^^^^^ definition [..] C2#get_inherited_ivar().
      return @f + @h
-#           ^^ reference [..] C1#`@f`.
-#                ^^ reference [..] C1#`@h`.
+#           ^^ reference [..] C2#`@f`.
+#           relation definition=[..] C1#`@f`.
+#                ^^ reference [..] C2#`@h`.
+#                relation definition=[..] C1#`@h`.
    end
  
    def set_inherited_ivar
 #      ^^^^^^^^^^^^^^^^^^ definition [..] C2#set_inherited_ivar().
      @f = 10
-#    ^^ definition [..] C1#`@f`.
+#    ^^ definition [..] C2#`@f`.
+#    relation definition=[..] C1#`@f`.
      return
    end
  
@@ -57,9 +60,11 @@
    def refs
 #      ^^^^ definition [..] C3#refs().
      @f = @g + @i
-#    ^^ definition [..] C1#`@f`.
-#         ^^ reference [..] C2#`@g`.
-#              ^^ reference [..] C1#`@i`.
+#    ^^ definition [..] C3#`@f`.
+#    relation definition=[..] C1#`@f`.
+#         ^^ reference [..] C3#`@g`.
+#         relation definition=[..] C2#`@g`.
+#              ^^ reference [..] C3#`@i`.
      return
    end
  end
@@ -148,10 +153,13 @@
 #           ^^^ definition [..] `<Class:D2>`#get().
      @@d2_x = @@d1_v + @@d1_x
 #    ^^^^^^ definition [..] `<Class:D2>`#`@@d2_x`.
-#             ^^^^^^ reference [..] `<Class:D1>`#`@@d1_v`.
-#                      ^^^^^^ reference [..] `<Class:D1>`#`@@d1_x`.
+#             ^^^^^^ reference [..] `<Class:D2>`#`@@d1_v`.
+#             relation definition=[..] `<Class:D1>`#`@@d1_v`.
+#                      ^^^^^^ reference [..] `<Class:D2>`#`@@d1_x`.
+#                      relation definition=[..] `<Class:D1>`#`@@d1_x`.
      @@d1_y + @@d1_z
-#    ^^^^^^ reference [..] `<Class:D1>`#`@@d1_y`.
+#    ^^^^^^ reference [..] `<Class:D2>`#`@@d1_y`.
+#    relation definition=[..] `<Class:D1>`#`@@d1_y`.
 #             ^^^^^^ reference [..] `<Class:D2>`#`@@d1_z`.
      return
    end
@@ -163,13 +171,18 @@
    def self.get_2
 #           ^^^^^ definition [..] `<Class:D3>`#get_2().
      @@d1_v + @@d1_x
-#    ^^^^^^ reference [..] `<Class:D1>`#`@@d1_v`.
-#             ^^^^^^ reference [..] `<Class:D1>`#`@@d1_x`.
+#    ^^^^^^ reference [..] `<Class:D3>`#`@@d1_v`.
+#    relation definition=[..] `<Class:D1>`#`@@d1_v`.
+#             ^^^^^^ reference [..] `<Class:D3>`#`@@d1_x`.
+#             relation definition=[..] `<Class:D1>`#`@@d1_x`.
      @@d1_y + @@d1_z
-#    ^^^^^^ reference [..] `<Class:D1>`#`@@d1_y`.
-#             ^^^^^^ reference [..] `<Class:D2>`#`@@d1_z`.
+#    ^^^^^^ reference [..] `<Class:D3>`#`@@d1_y`.
+#    relation definition=[..] `<Class:D1>`#`@@d1_y`.
+#             ^^^^^^ reference [..] `<Class:D3>`#`@@d1_z`.
+#             relation definition=[..] `<Class:D2>`#`@@d1_z`.
      @@d2_x
-#    ^^^^^^ reference [..] `<Class:D2>`#`@@d2_x`.
+#    ^^^^^^ reference [..] `<Class:D3>`#`@@d2_x`.
+#    relation definition=[..] `<Class:D2>`#`@@d2_x`.
      return
    end
  end

--- a/test/scip/testdata/field_inheritance.snapshot.rb
+++ b/test/scip/testdata/field_inheritance.snapshot.rb
@@ -224,6 +224,28 @@
    return
  end
  
+ ## Check that pre-declared class variables work too
+ 
+ class DD1
+#      ^^^ definition [..] DD1#
+   @@x = T.let(0, Integer)
+#  ^^^ definition [..] `<Class:DD1>`#`@@x`.
+#  ^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:DD1>`#`@@x`.
+#                 ^^^^^^^ definition local 1~#119448696
+#                 ^^^^^^^ reference [..] Integer#
+ end
+ 
+ class DD2 < DD1
+#      ^^^ definition [..] DD2#
+#            ^^^ definition [..] DD1#
+   def self.get_x
+#           ^^^^^ definition [..] `<Class:DD2>`#get_x().
+     @@x
+#    ^^^ reference [..] `<Class:DD2>`#`@@x`.
+#    relation definition=[..] `<Class:DD1>`#`@@x`.
+   end
+ end
+ 
  # Class instance variables are not inherited.
  
  class E1

--- a/test/scip/testdata/field_inheritance.snapshot.rb
+++ b/test/scip/testdata/field_inheritance.snapshot.rb
@@ -29,7 +29,6 @@
 #           ^^ reference [..] C2#`@f`.
 #           relation definition=[..] C1#`@f`.
 #                ^^ reference [..] C2#`@h`.
-#                relation definition=[..] C1#`@h`.
    end
  
    def set_inherited_ivar
@@ -65,6 +64,7 @@
 #         ^^ reference [..] C3#`@g`.
 #         relation definition=[..] C2#`@g`.
 #              ^^ reference [..] C3#`@i`.
+#              relation definition=[..] C1#`@i`.
      return
    end
  end

--- a/test/scip/testdata/fields_and_attrs.snapshot.rb
+++ b/test/scip/testdata/fields_and_attrs.snapshot.rb
@@ -78,10 +78,8 @@
    def m2
 #      ^^ definition [..] N#m2().
      @@b = @@a
-#    ^^^ definition [..] N#`@@b`.
-#    relation definition=[..] `<Class:N>`#`@@b`.
-#          ^^^ reference [..] N#`@@a`.
-#          relation definition=[..] `<Class:N>`#`@@a`.
+#    ^^^ definition [..] `<Class:N>`#`@@b`.
+#          ^^^ reference [..] `<Class:N>`#`@@a`.
      return
    end
  

--- a/test/scip/testdata/fields_and_attrs.snapshot.rb
+++ b/test/scip/testdata/fields_and_attrs.snapshot.rb
@@ -78,8 +78,10 @@
    def m2
 #      ^^ definition [..] N#m2().
      @@b = @@a
-#    ^^^ definition [..] `<Class:N>`#`@@b`.
-#          ^^^ reference [..] `<Class:N>`#`@@a`.
+#    ^^^ definition [..] N#`@@b`.
+#    relation definition=[..] `<Class:N>`#`@@b`.
+#          ^^^ reference [..] N#`@@a`.
+#          relation definition=[..] `<Class:N>`#`@@a`.
      return
    end
  

--- a/test/scip/testdata/freeze_constants.snapshot.rb
+++ b/test/scip/testdata/freeze_constants.snapshot.rb
@@ -5,25 +5,25 @@
 #^ definition [..] X.
 #documentation
 #| ```ruby
-#| ::X (T.untyped)
+#| X (T.untyped)
 #| ```
  Y = 'Y'.freeze
 #^ definition [..] Y.
 #documentation
 #| ```ruby
-#| ::Y (T.untyped)
+#| Y (T.untyped)
 #| ```
  A = %w[X Y].freeze
 #^ definition [..] A.
 #documentation
 #| ```ruby
-#| ::A (T.untyped)
+#| A (T.untyped)
 #| ```
  B = %W[#{X} Y].freeze
 #^ definition [..] B.
 #documentation
 #| ```ruby
-#| ::B (T.untyped)
+#| B (T.untyped)
 #| ```
 #         ^ reference [..] X.
  
@@ -37,19 +37,19 @@
 #  ^ definition [..] M#Z.
 #  documentation
 #  | ```ruby
-#  | ::M::Z (T.untyped)
+#  | Z (T.untyped)
 #  | ```
    A = %w[X Y Z].freeze
 #  ^ definition [..] M#A.
 #  documentation
 #  | ```ruby
-#  | ::M::A (T.untyped)
+#  | A (T.untyped)
 #  | ```
    B = %W[#{X} Y Z].freeze
 #  ^ definition [..] M#B.
 #  documentation
 #  | ```ruby
-#  | ::M::B (T.untyped)
+#  | B (T.untyped)
 #  | ```
 #           ^ reference [..] X.
  end

--- a/test/scip/testdata/globals.rb
+++ b/test/scip/testdata/globals.rb
@@ -16,3 +16,9 @@ class C
 end
 
 puts $c
+
+$d = T.let(0, Integer)
+
+def g
+  $d
+end

--- a/test/scip/testdata/globals.snapshot.rb
+++ b/test/scip/testdata/globals.snapshot.rb
@@ -30,3 +30,14 @@
  puts $c
 #^^^^ reference [..] Kernel#puts().
 #     ^^ reference [..] `<Class:<root>>`#$c.
+ 
+ $d = T.let(0, Integer)
+#^^ definition [..] `<Class:<root>>`#$d.
+#              ^^^^^^^ definition local 3~#119448696
+#              ^^^^^^^ reference [..] Integer#
+ 
+ def g
+#    ^ definition [..] Object#g().
+   $d
+#  ^^ reference [..] `<Class:<root>>`#$d.
+ end

--- a/test/scip/testdata/hoverdocs.snapshot.rb
+++ b/test/scip/testdata/hoverdocs.snapshot.rb
@@ -296,22 +296,12 @@
 #    | @x (T.untyped)
 #    | ```
      @@y = 10
-#    ^^^ definition [..] K1#`@@y`.
-#    documentation
-#    | ```ruby
-#    | @@y (T.untyped)
-#    | ```
-#    relation definition=[..] `<Class:K1>`#`@@y`.
-#    ^^^^^^^^ reference [..] K1#`@@y`.
+#    ^^^ definition [..] `<Class:K1>`#`@@y`.
+#    ^^^^^^^^ reference [..] `<Class:K1>`#`@@y`.
 #    override_documentation
 #    | ```ruby
 #    | @@y (Integer(10))
 #    | ```
-#    documentation
-#    | ```ruby
-#    | @@y (T.untyped)
-#    | ```
-#    relation definition=[..] `<Class:K1>`#`@@y`.
    end
  
    # lorem ipsum, you get it
@@ -326,10 +316,6 @@
 #           | lorem ipsum, you get it
      @z = 10
 #    ^^ definition [..] `<Class:K1>`#`@z`.
-#    documentation
-#    | ```ruby
-#    | @z (T.untyped)
-#    | ```
 #    ^^^^^^^ reference [..] `<Class:K1>`#`@z`.
 #    override_documentation
 #    | ```ruby
@@ -357,12 +343,6 @@
    # doc comment on class var ooh
    @z = 9
 #  ^^ definition [..] `<Class:K2>`#`@z`.
-#  documentation
-#  | ```ruby
-#  | @z (T.untyped)
-#  | ```
-#  documentation
-#  | doc comment on class var ooh
  
    # overrides K1's p1
    def p1
@@ -376,30 +356,22 @@
 #      | overrides K1's p1
      @x = 20
 #    ^^ definition [..] K2#`@x`.
-#    documentation
-#    | ```ruby
-#    | @x (T.untyped)
-#    | ```
 #    relation definition=[..] K1#`@x`.
      @@y = 20
-#    ^^^ definition [..] K2#`@@y`.
+#    ^^^ definition [..] `<Class:K2>`#`@@y`.
 #    documentation
 #    | ```ruby
 #    | @@y (T.untyped)
 #    | ```
 #    relation definition=[..] `<Class:K1>`#`@@y`.
      @z += @x
-#    ^^ reference (write) [..] K2#`@z`.
-#    ^^ reference [..] K2#`@z`.
-#    ^^^^^^^^ reference [..] K2#`@z`.
+#    ^^ reference (write) [..] `<Class:K2>`#`@z`.
+#    ^^ reference [..] `<Class:K2>`#`@z`.
+#    ^^^^^^^^ reference [..] `<Class:K2>`#`@z`.
 #          ^^ reference [..] K2#`@x`.
 #          override_documentation
 #          | ```ruby
 #          | @x (Integer(20))
-#          | ```
-#          documentation
-#          | ```ruby
-#          | @x (T.untyped)
 #          | ```
 #          relation definition=[..] K1#`@x`.
    end

--- a/test/scip/testdata/hoverdocs.snapshot.rb
+++ b/test/scip/testdata/hoverdocs.snapshot.rb
@@ -343,6 +343,12 @@
    # doc comment on class var ooh
    @z = 9
 #  ^^ definition [..] `<Class:K2>`#`@z`.
+#  documentation
+#  | ```ruby
+#  | @z (T.untyped)
+#  | ```
+#  documentation
+#  | doc comment on class var ooh
  
    # overrides K1's p1
    def p1
@@ -365,9 +371,9 @@
 #    | ```
 #    relation definition=[..] `<Class:K1>`#`@@y`.
      @z += @x
-#    ^^ reference (write) [..] `<Class:K2>`#`@z`.
-#    ^^ reference [..] `<Class:K2>`#`@z`.
-#    ^^^^^^^^ reference [..] `<Class:K2>`#`@z`.
+#    ^^ reference (write) [..] K2#`@z`.
+#    ^^ reference [..] K2#`@z`.
+#    ^^^^^^^^ reference [..] K2#`@z`.
 #          ^^ reference [..] K2#`@x`.
 #          override_documentation
 #          | ```ruby

--- a/test/scip/testdata/hoverdocs.snapshot.rb
+++ b/test/scip/testdata/hoverdocs.snapshot.rb
@@ -296,16 +296,22 @@
 #    | @x (T.untyped)
 #    | ```
      @@y = 10
-#    ^^^ definition [..] `<Class:K1>`#`@@y`.
+#    ^^^ definition [..] K1#`@@y`.
 #    documentation
 #    | ```ruby
 #    | @@y (T.untyped)
 #    | ```
-#    ^^^^^^^^ reference [..] `<Class:K1>`#`@@y`.
+#    relation definition=[..] `<Class:K1>`#`@@y`.
+#    ^^^^^^^^ reference [..] K1#`@@y`.
 #    override_documentation
 #    | ```ruby
 #    | @@y (Integer(10))
 #    | ```
+#    documentation
+#    | ```ruby
+#    | @@y (T.untyped)
+#    | ```
+#    relation definition=[..] `<Class:K1>`#`@@y`.
    end
  
    # lorem ipsum, you get it
@@ -369,25 +375,32 @@
 #      documentation
 #      | overrides K1's p1
      @x = 20
-#    ^^ definition [..] K1#`@x`.
+#    ^^ definition [..] K2#`@x`.
 #    documentation
 #    | ```ruby
 #    | @x (T.untyped)
 #    | ```
+#    relation definition=[..] K1#`@x`.
      @@y = 20
-#    ^^^ definition [..] `<Class:K1>`#`@@y`.
+#    ^^^ definition [..] K2#`@@y`.
 #    documentation
 #    | ```ruby
 #    | @@y (T.untyped)
 #    | ```
+#    relation definition=[..] `<Class:K1>`#`@@y`.
      @z += @x
 #    ^^ reference (write) [..] K2#`@z`.
 #    ^^ reference [..] K2#`@z`.
 #    ^^^^^^^^ reference [..] K2#`@z`.
-#          ^^ reference [..] K1#`@x`.
+#          ^^ reference [..] K2#`@x`.
 #          override_documentation
 #          | ```ruby
 #          | @x (Integer(20))
 #          | ```
+#          documentation
+#          | ```ruby
+#          | @x (T.untyped)
+#          | ```
+#          relation definition=[..] K1#`@x`.
    end
  end

--- a/test/scip/testdata/inheritance.snapshot.rb
+++ b/test/scip/testdata/inheritance.snapshot.rb
@@ -61,7 +61,8 @@
    def read_f_plus_1?
 #      ^^^^^^^^^^^^^^ definition [..] Z3#`read_f_plus_1?`().
      @f + 1
-#    ^^ reference [..] Z1#`@f`.
+#    ^^ reference [..] Z3#`@f`.
+#    relation definition=[..] Z1#`@f`.
    end
  end
  
@@ -80,8 +81,10 @@
 #    ^^^^^^^ reference [..] Z1#write_f().
 #            ^ reference local 1~#3337417690
      @f = read_f_plus_1?
-#    ^^ definition [..] Z1#`@f`.
-#    ^^^^^^^^^^^^^^^^^^^ reference [..] Z1#`@f`.
+#    ^^ definition [..] Z4#`@f`.
+#    relation definition=[..] Z1#`@f`.
+#    ^^^^^^^^^^^^^^^^^^^ reference [..] Z4#`@f`.
+#    relation definition=[..] Z1#`@f`.
 #         ^^^^^^^^^^^^^^ reference [..] Z3#`read_f_plus_1?`().
    end
  end

--- a/test/scip/testdata/mixin.rb
+++ b/test/scip/testdata/mixin.rb
@@ -97,7 +97,7 @@ end
 
 # Definition in directly included module & superclass & Self
 
-module T0
+module T4
   module M
     def set_f_0; @f = 0; end
   end
@@ -115,7 +115,7 @@ end
 
 # Definition in transitively included module & superclass & Self
 
-module T3
+module T5
   module M0
     def set_f_0; @f = 0; end
   end
@@ -137,7 +137,7 @@ end
 
 # Definition in directly included module & superclass only
 
-module T4
+module T6
   module M
     def set_f_0; @f = 0; end
   end
@@ -153,7 +153,7 @@ end
 
 # Definition in transitively included module & superclass only
 
-module T5
+module T7
   module M0
     def set_f_0; @f = 0; end
   end
@@ -173,7 +173,7 @@ end
 
 # Definition in module included via superclass & superclass & Self
 
-module T6
+module T8
   module M
     def set_f_0; @f = 0; end
   end
@@ -191,7 +191,7 @@ end
 
 # Definition in module included via superclass & superclass only
 
-module T7
+module T9
   module M
     def set_f_0; @f = 0; end
   end
@@ -208,7 +208,7 @@ end
 
 # Definition in module included via superclass & Self
 
-module T8
+module T10
   module M
     def set_f_0; @f = 0; end
   end
@@ -225,7 +225,7 @@ end
 
 # Definition in module included via superclass only
 
-module T9
+module T11
   module M
     def set_f_0; @f = 0; end
   end
@@ -241,7 +241,7 @@ end
 
 # Definition in multiple transitively included modules & common child & Self
 
-module T10
+module T12
   module M0
     def set_f_0; @f = 0; end
   end
@@ -265,7 +265,7 @@ end
 
 # Definition in multiple transitively included modules & common child only
 
-module T11
+module T13
   module M0
     def set_f_0; @f = 0; end
   end
@@ -288,7 +288,7 @@ end
 
 # Definition in multiple transitively included modules & Self
 
-module T12
+module T14
   module M0
     def set_f_0; @f = 0; end
   end
@@ -311,7 +311,7 @@ end
 
 # Definition in multiple transitively included modules only
 
-module T13
+module T15
   module M0
     def set_f_0; @f = 0; end
   end
@@ -333,7 +333,7 @@ end
 
 # Definition in multiple directly included modules & Self
 
-module T14
+module T16
   module M0
     def set_f_0; @f = 0; end
   end
@@ -352,7 +352,7 @@ end
 
 # Definition in multiple directly included modules only
 
-module T15
+module T17
   module M0
     def set_f_0; @f = 0; end
   end
@@ -421,7 +421,7 @@ end
 
 # Reference in directly included module with def in superclass
 
-module W2
+module W3
   module M
     def get_f; @f; end
   end
@@ -438,7 +438,7 @@ end
 
 # Reference in transitively included module with def in in-between module
 
-module W3
+module W4
   module M0
     def get_f; @f; end
   end
@@ -456,7 +456,7 @@ end
 
 # Reference in one directly included module with def in other directly included module
 
-module W4
+module W5
   module M0
     def get_f; @f; end
   end
@@ -471,4 +471,3 @@ module W4
     def get_fp1; @f + 1; end
   end
 end
-

--- a/test/scip/testdata/mixin.rb
+++ b/test/scip/testdata/mixin.rb
@@ -1,16 +1,12 @@
 # typed: true
 
 module M
-  def f
-    puts 'M.f'
-  end
+  def f; puts 'M.f'; end
 end
 
 class C1
   include M
-  def f
-    puts 'C1.f'
-  end
+  def f; puts 'C1.f'; end
 end
 
 # f refers to C1.f
@@ -23,9 +19,7 @@ class C3 < C1
 end
 
 class D1
-  def f
-    puts 'D1.f'
-  end
+  def f; puts 'D1.f'; end
 end
 
 class D2
@@ -38,3 +32,443 @@ C3.new.f # C1.f
 
 D1.new.f # D1.f
 D2.new.f # M.f
+
+# Definition in directly included module and Self
+
+module T0
+  module M
+    def set_f_0; @f = 0; end
+  end
+
+  class C
+    include M
+    def set_f_1; @f = 1; end
+    def get_f; @f; end
+  end
+end
+
+# Definition in transitively included module and Self
+
+module T1
+  module M0
+    def set_f_0; @f = 0; end
+  end
+
+  module M1
+    include M0
+  end
+
+  class C
+    include M1
+    def set_f_1; @f = 1; end
+    def get_f; @f; end
+  end
+end
+
+# Definition in directly included module only
+
+module T2
+  module M
+    def set_f_0; @f = 0; end
+  end
+
+  class C
+    include M
+    def get_f; @f; end
+  end
+end
+
+# Definition in transitively included module only
+
+module T3
+  module M0
+    def set_f_0; @f = 0; end
+  end
+
+  module M1
+    include M0
+  end
+
+  class C
+    include M1
+    def get_f; @f; end
+  end
+end
+
+# Definition in directly included module & superclass & Self
+
+module T0
+  module M
+    def set_f_0; @f = 0; end
+  end
+
+  class C0
+    def set_f_2; @f = 2; end
+  end
+
+  class C1 < C0
+    include M
+    def set_f_1; @f = 1; end
+    def get_f; @f; end
+  end
+end
+
+# Definition in transitively included module & superclass & Self
+
+module T3
+  module M0
+    def set_f_0; @f = 0; end
+  end
+
+  module M1
+    include M0
+  end
+
+  class C0
+    def set_f_2; @f = 2; end
+  end
+
+  class C1 < C0
+    include M
+    def set_f_1; @f = 1; end
+    def get_f; @f; end
+  end
+end
+
+# Definition in directly included module & superclass only
+
+module T4
+  module M
+    def set_f_0; @f = 0; end
+  end
+
+  class C0
+    def set_f_1; @f = 1; end
+  end
+
+  class C1 < C0
+    def get_f; @f; end
+  end
+end
+
+# Definition in transitively included module & superclass only
+
+module T5
+  module M0
+    def set_f_0; @f = 0; end
+  end
+
+  module M1
+    include M0
+  end
+
+  class C0
+    def set_f_1; @f = 1; end
+  end
+
+  class C1 < C0
+    def get_f; @f; end
+  end
+end
+
+# Definition in module included via superclass & superclass & Self
+
+module T6
+  module M
+    def set_f_0; @f = 0; end
+  end
+
+  class C0
+    include M
+    def set_f_1; @f = 1; end
+  end
+
+  class C1 < C0
+    def set_f_2; @f = 2; end
+    def get_f; @f; end
+  end
+end
+
+# Definition in module included via superclass & superclass only
+
+module T7
+  module M
+    def set_f_0; @f = 0; end
+  end
+
+  class C0
+    include M
+    def set_f_1; @f = 1; end
+  end
+
+  class C1 < C0
+    def get_f; @f; end
+  end
+end
+
+# Definition in module included via superclass & Self
+
+module T8
+  module M
+    def set_f_0; @f = 0; end
+  end
+
+  class C0
+    include M
+  end
+
+  class C1 < C0
+    def set_f_2; @f = 2; end
+    def get_f; @f; end
+  end
+end
+
+# Definition in module included via superclass only
+
+module T9
+  module M
+    def set_f_0; @f = 0; end
+  end
+
+  class C0
+    include M
+  end
+
+  class C1 < C0
+    def get_f; @f; end
+  end
+end
+
+# Definition in multiple transitively included modules & common child & Self
+
+module T10
+  module M0
+    def set_f_0; @f = 0; end
+  end
+
+  module M1
+    def set_f_1; @f = 1; end
+  end
+
+  module M2
+    include M0
+    include M1
+    def set_f_2; @f = 2; end
+  end
+
+  class C
+    include M2
+    def set_f_3; @f = 3; end
+    def get_f; @f; end
+  end
+end
+
+# Definition in multiple transitively included modules & common child only
+
+module T11
+  module M0
+    def set_f_0; @f = 0; end
+  end
+
+  module M1
+    def set_f_1; @f = 1; end
+  end
+
+  module M2
+    include M0
+    include M1
+    def set_f_2; @f = 2; end
+  end
+
+  class C
+    include M2
+    def get_f; @f; end
+  end
+end
+
+# Definition in multiple transitively included modules & Self
+
+module T12
+  module M0
+    def set_f_0; @f = 0; end
+  end
+
+  module M1
+    def set_f_1; @f = 1; end
+  end
+
+  module M2
+    include M0
+    include M1
+  end
+
+  class C
+    include M2
+    def set_f_3; @f = 3; end
+    def get_f; @f; end
+  end
+end
+
+# Definition in multiple transitively included modules only
+
+module T13
+  module M0
+    def set_f_0; @f = 0; end
+  end
+
+  module M1
+    def set_f_1; @f = 1; end
+  end
+
+  module M2
+    include M0
+    include M1
+  end
+
+  class C
+    include M2
+    def get_f; @f; end
+  end
+end
+
+# Definition in multiple directly included modules & Self
+
+module T14
+  module M0
+    def set_f_0; @f = 0; end
+  end
+
+  module M1
+    def set_f_1; @f = 1; end
+  end
+
+  class C
+    include M0
+    include M1
+    def set_f_2; @f = 2; end
+    def get_f; @f; end
+  end
+end
+
+# Definition in multiple directly included modules only
+
+module T15
+  module M0
+    def set_f_0; @f = 0; end
+  end
+
+  module M1
+    def set_f_1; @f = 1; end
+  end
+
+  class C
+    include M0
+    include M1
+    def get_f; @f; end
+  end
+end
+
+# OKAY! Now for the more "weird" situations
+# Before this, all the tests had a definition come "before" use.
+# Let's see what happens if there is a use before any definition.
+
+# Reference in directly included module with def in Self
+
+module W0
+  module M
+    def get_f; @f; end
+  end
+
+  class C
+    include M
+    def set_f; @f = 0; end
+  end
+end
+
+# Reference in transitively included module with def in Self
+
+module W1
+  module M0
+    def get_f; @f; end
+  end
+  
+  module M1
+    include M0
+  end
+
+  class C
+    include M1
+    def set_f; @f = 0; end
+  end
+end
+
+# Reference in superclass with def in directly included module
+
+module W2
+  module M
+    def set_f; @f = 0; end
+  end
+
+  class C0
+    def get_f; @f; end
+  end
+
+  class C1 < C0
+    include M
+    def get_fp1; @f + 1; end
+  end
+end
+
+# Reference in directly included module with def in superclass
+
+module W2
+  module M
+    def get_f; @f; end
+  end
+
+  class C0
+    def set_f; @f = 0; end
+  end
+
+  class C1 < C0
+    include M
+    def get_fp1; @f + 1; end
+  end
+end
+
+# Reference in transitively included module with def in in-between module
+
+module W3
+  module M0
+    def get_f; @f; end
+  end
+
+  module M1
+    include M0
+    def set_f; @f = 0; end
+  end
+
+  class C
+    include M1
+    def get_fp1; @f + 1; end
+  end
+end
+
+# Reference in one directly included module with def in other directly included module
+
+module W4
+  module M0
+    def get_f; @f; end
+  end
+
+  module M1
+    def set_f; @f + 1; end
+  end
+
+  class C
+    include M0
+    include M1
+    def get_fp1; @f + 1; end
+  end
+end
+

--- a/test/scip/testdata/mixin.rb
+++ b/test/scip/testdata/mixin.rb
@@ -1,0 +1,40 @@
+# typed: true
+
+module M
+  def f
+    puts 'M.f'
+  end
+end
+
+class C1
+  include M
+  def f
+    puts 'C1.f'
+  end
+end
+
+# f refers to C1.f
+class C2 < C1
+end
+
+# f refers to C1.f
+class C3 < C1
+  include M
+end
+
+class D1
+  def f
+    puts 'D1.f'
+  end
+end
+
+class D2
+  include M
+end
+
+C1.new.f # C1.f
+C2.new.f # C1.f
+C3.new.f # C1.f
+
+D1.new.f # D1.f
+D2.new.f # M.f

--- a/test/scip/testdata/mixin.snapshot.rb
+++ b/test/scip/testdata/mixin.snapshot.rb
@@ -75,7 +75,6 @@
 #         ^ definition [..] T0#M#
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T0#M#set_f_0().
-#        ^^^^^^^ definition [..] T0#M#set_f_0().
 #                 ^^ definition [..] T0#M#`@f`.
 #                 ^^^^^^ reference [..] T0#M#`@f`.
    end
@@ -162,7 +161,6 @@
 #         ^^ definition [..] T3#M0#
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T3#M0#set_f_0().
-#        ^^^^^^^ definition [..] T3#M0#set_f_0().
 #                 ^^ definition [..] T3#M0#`@f`.
 #                 ^^^^^^ reference [..] T3#M0#`@f`.
    end
@@ -187,89 +185,6 @@
  
  # Definition in directly included module & superclass & Self
  
- module T0
-#       ^^ definition [..] T0#
-   module M
-#         ^ definition [..] T0#M#
-     def set_f_0; @f = 0; end
-#                 ^^ definition [..] T0#M#`@f`.
-#                 ^^^^^^ reference [..] T0#M#`@f`.
-   end
- 
-   class C0
-#        ^^ definition [..] T0#C0#
-     def set_f_2; @f = 2; end
-#        ^^^^^^^ definition [..] T0#C0#set_f_2().
-#                 ^^ definition [..] T0#C0#`@f`.
-#                 ^^^^^^ reference [..] T0#C0#`@f`.
-   end
- 
-   class C1 < C0
-#        ^^ definition [..] T0#C1#
-#             ^^ definition [..] T0#C0#
-     include M
-#    ^^^^^^^ reference [..] Module#include().
-#            ^ reference [..] T0#M#
-     def set_f_1; @f = 1; end
-#        ^^^^^^^ definition [..] T0#C1#set_f_1().
-#                 ^^ definition [..] T0#C1#`@f`.
-#                 relation definition=[..] T0#C0#`@f`. reference=[..] T0#M#`@f`.
-#                 ^^^^^^ reference [..] T0#C1#`@f`.
-#                 relation definition=[..] T0#C0#`@f`. reference=[..] T0#M#`@f`.
-     def get_f; @f; end
-#        ^^^^^ definition [..] T0#C1#get_f().
-#               ^^ reference [..] T0#C1#`@f`.
-#               relation definition=[..] T0#C0#`@f`. reference=[..] T0#M#`@f`.
-   end
- end
- 
- # Definition in transitively included module & superclass & Self
- 
- module T3
-#       ^^ definition [..] T3#
-   module M0
-#         ^^ definition [..] T3#M0#
-     def set_f_0; @f = 0; end
-#                 ^^ definition [..] T3#M0#`@f`.
-#                 ^^^^^^ reference [..] T3#M0#`@f`.
-   end
- 
-   module M1
-#         ^^ definition [..] T3#M1#
-     include M0
-#    ^^^^^^^ reference [..] Module#include().
-#            ^^ reference [..] T3#M0#
-   end
- 
-   class C0
-#        ^^ definition [..] T3#C0#
-     def set_f_2; @f = 2; end
-#        ^^^^^^^ definition [..] T3#C0#set_f_2().
-#                 ^^ definition [..] T3#C0#`@f`.
-#                 ^^^^^^ reference [..] T3#C0#`@f`.
-   end
- 
-   class C1 < C0
-#        ^^ definition [..] T3#C1#
-#             ^^ definition [..] T3#C0#
-     include M
-#    ^^^^^^^ reference [..] Module#include().
-#            ^ reference [..] M#
-     def set_f_1; @f = 1; end
-#        ^^^^^^^ definition [..] T3#C1#set_f_1().
-#                 ^^ definition [..] T3#C1#`@f`.
-#                 relation definition=[..] T3#C0#`@f`.
-#                 ^^^^^^ reference [..] T3#C1#`@f`.
-#                 relation definition=[..] T3#C0#`@f`.
-     def get_f; @f; end
-#        ^^^^^ definition [..] T3#C1#get_f().
-#               ^^ reference [..] T3#C1#`@f`.
-#               relation definition=[..] T3#C0#`@f`.
-   end
- end
- 
- # Definition in directly included module & superclass only
- 
  module T4
 #       ^^ definition [..] T4#
    module M
@@ -282,8 +197,8 @@
  
    class C0
 #        ^^ definition [..] T4#C0#
-     def set_f_1; @f = 1; end
-#        ^^^^^^^ definition [..] T4#C0#set_f_1().
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T4#C0#set_f_2().
 #                 ^^ definition [..] T4#C0#`@f`.
 #                 ^^^^^^ reference [..] T4#C0#`@f`.
    end
@@ -291,14 +206,23 @@
    class C1 < C0
 #        ^^ definition [..] T4#C1#
 #             ^^ definition [..] T4#C0#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] T4#M#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T4#C1#set_f_1().
+#                 ^^ definition [..] T4#C1#`@f`.
+#                 relation definition=[..] T4#C0#`@f`. reference=[..] T4#M#`@f`.
+#                 ^^^^^^ reference [..] T4#C1#`@f`.
+#                 relation definition=[..] T4#C0#`@f`. reference=[..] T4#M#`@f`.
      def get_f; @f; end
 #        ^^^^^ definition [..] T4#C1#get_f().
 #               ^^ reference [..] T4#C1#`@f`.
-#               relation definition=[..] T4#C0#`@f`.
+#               relation definition=[..] T4#C0#`@f`. reference=[..] T4#M#`@f`.
    end
  end
  
- # Definition in transitively included module & superclass only
+ # Definition in transitively included module & superclass & Self
  
  module T5
 #       ^^ definition [..] T5#
@@ -319,8 +243,8 @@
  
    class C0
 #        ^^ definition [..] T5#C0#
-     def set_f_1; @f = 1; end
-#        ^^^^^^^ definition [..] T5#C0#set_f_1().
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T5#C0#set_f_2().
 #                 ^^ definition [..] T5#C0#`@f`.
 #                 ^^^^^^ reference [..] T5#C0#`@f`.
    end
@@ -328,6 +252,15 @@
    class C1 < C0
 #        ^^ definition [..] T5#C1#
 #             ^^ definition [..] T5#C0#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] M#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T5#C1#set_f_1().
+#                 ^^ definition [..] T5#C1#`@f`.
+#                 relation definition=[..] T5#C0#`@f`.
+#                 ^^^^^^ reference [..] T5#C1#`@f`.
+#                 relation definition=[..] T5#C0#`@f`.
      def get_f; @f; end
 #        ^^^^^ definition [..] T5#C1#get_f().
 #               ^^ reference [..] T5#C1#`@f`.
@@ -335,7 +268,7 @@
    end
  end
  
- # Definition in module included via superclass & superclass & Self
+ # Definition in directly included module & superclass only
  
  module T6
 #       ^^ definition [..] T6#
@@ -349,25 +282,15 @@
  
    class C0
 #        ^^ definition [..] T6#C0#
-     include M
-#    ^^^^^^^ reference [..] Module#include().
-#            ^ reference [..] T6#M#
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T6#C0#set_f_1().
 #                 ^^ definition [..] T6#C0#`@f`.
-#                 relation reference=[..] T6#M#`@f`.
 #                 ^^^^^^ reference [..] T6#C0#`@f`.
    end
  
    class C1 < C0
 #        ^^ definition [..] T6#C1#
 #             ^^ definition [..] T6#C0#
-     def set_f_2; @f = 2; end
-#        ^^^^^^^ definition [..] T6#C1#set_f_2().
-#                 ^^ definition [..] T6#C1#`@f`.
-#                 relation definition=[..] T6#C0#`@f`.
-#                 ^^^^^^ reference [..] T6#C1#`@f`.
-#                 relation definition=[..] T6#C0#`@f`.
      def get_f; @f; end
 #        ^^^^^ definition [..] T6#C1#get_f().
 #               ^^ reference [..] T6#C1#`@f`.
@@ -375,27 +298,30 @@
    end
  end
  
- # Definition in module included via superclass & superclass only
+ # Definition in transitively included module & superclass only
  
  module T7
 #       ^^ definition [..] T7#
-   module M
-#         ^ definition [..] T7#M#
+   module M0
+#         ^^ definition [..] T7#M0#
      def set_f_0; @f = 0; end
-#        ^^^^^^^ definition [..] T7#M#set_f_0().
-#                 ^^ definition [..] T7#M#`@f`.
-#                 ^^^^^^ reference [..] T7#M#`@f`.
+#        ^^^^^^^ definition [..] T7#M0#set_f_0().
+#                 ^^ definition [..] T7#M0#`@f`.
+#                 ^^^^^^ reference [..] T7#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T7#M1#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T7#M0#
    end
  
    class C0
 #        ^^ definition [..] T7#C0#
-     include M
-#    ^^^^^^^ reference [..] Module#include().
-#            ^ reference [..] T7#M#
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T7#C0#set_f_1().
 #                 ^^ definition [..] T7#C0#`@f`.
-#                 relation reference=[..] T7#M#`@f`.
 #                 ^^^^^^ reference [..] T7#C0#`@f`.
    end
  
@@ -409,7 +335,7 @@
    end
  end
  
- # Definition in module included via superclass & Self
+ # Definition in module included via superclass & superclass & Self
  
  module T8
 #       ^^ definition [..] T8#
@@ -426,6 +352,11 @@
      include M
 #    ^^^^^^^ reference [..] Module#include().
 #            ^ reference [..] T8#M#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T8#C0#set_f_1().
+#                 ^^ definition [..] T8#C0#`@f`.
+#                 relation reference=[..] T8#M#`@f`.
+#                 ^^^^^^ reference [..] T8#C0#`@f`.
    end
  
    class C1 < C0
@@ -434,14 +365,17 @@
      def set_f_2; @f = 2; end
 #        ^^^^^^^ definition [..] T8#C1#set_f_2().
 #                 ^^ definition [..] T8#C1#`@f`.
+#                 relation definition=[..] T8#C0#`@f`.
 #                 ^^^^^^ reference [..] T8#C1#`@f`.
+#                 relation definition=[..] T8#C0#`@f`.
      def get_f; @f; end
 #        ^^^^^ definition [..] T8#C1#get_f().
 #               ^^ reference [..] T8#C1#`@f`.
+#               relation definition=[..] T8#C0#`@f`.
    end
  end
  
- # Definition in module included via superclass only
+ # Definition in module included via superclass & superclass only
  
  module T9
 #       ^^ definition [..] T9#
@@ -458,6 +392,11 @@
      include M
 #    ^^^^^^^ reference [..] Module#include().
 #            ^ reference [..] T9#M#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T9#C0#set_f_1().
+#                 ^^ definition [..] T9#C0#`@f`.
+#                 relation reference=[..] T9#M#`@f`.
+#                 ^^^^^^ reference [..] T9#C0#`@f`.
    end
  
    class C1 < C0
@@ -466,107 +405,71 @@
      def get_f; @f; end
 #        ^^^^^ definition [..] T9#C1#get_f().
 #               ^^ reference [..] T9#C1#`@f`.
+#               relation definition=[..] T9#C0#`@f`.
+   end
+ end
+ 
+ # Definition in module included via superclass & Self
+ 
+ module T10
+#       ^^^ definition [..] T10#
+   module M
+#         ^ definition [..] T10#M#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T10#M#set_f_0().
+#                 ^^ definition [..] T10#M#`@f`.
+#                 ^^^^^^ reference [..] T10#M#`@f`.
+   end
+ 
+   class C0
+#        ^^ definition [..] T10#C0#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] T10#M#
+   end
+ 
+   class C1 < C0
+#        ^^ definition [..] T10#C1#
+#             ^^ definition [..] T10#C0#
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T10#C1#set_f_2().
+#                 ^^ definition [..] T10#C1#`@f`.
+#                 ^^^^^^ reference [..] T10#C1#`@f`.
+     def get_f; @f; end
+#        ^^^^^ definition [..] T10#C1#get_f().
+#               ^^ reference [..] T10#C1#`@f`.
+   end
+ end
+ 
+ # Definition in module included via superclass only
+ 
+ module T11
+#       ^^^ definition [..] T11#
+   module M
+#         ^ definition [..] T11#M#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T11#M#set_f_0().
+#                 ^^ definition [..] T11#M#`@f`.
+#                 ^^^^^^ reference [..] T11#M#`@f`.
+   end
+ 
+   class C0
+#        ^^ definition [..] T11#C0#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] T11#M#
+   end
+ 
+   class C1 < C0
+#        ^^ definition [..] T11#C1#
+#             ^^ definition [..] T11#C0#
+     def get_f; @f; end
+#        ^^^^^ definition [..] T11#C1#get_f().
+#               ^^ reference [..] T11#C1#`@f`.
    end
  end
  
  # Definition in multiple transitively included modules & common child & Self
- 
- module T10
-#       ^^^ definition [..] T10#
-   module M0
-#         ^^ definition [..] T10#M0#
-     def set_f_0; @f = 0; end
-#        ^^^^^^^ definition [..] T10#M0#set_f_0().
-#                 ^^ definition [..] T10#M0#`@f`.
-#                 ^^^^^^ reference [..] T10#M0#`@f`.
-   end
- 
-   module M1
-#         ^^ definition [..] T10#M1#
-     def set_f_1; @f = 1; end
-#        ^^^^^^^ definition [..] T10#M1#set_f_1().
-#                 ^^ definition [..] T10#M1#`@f`.
-#                 ^^^^^^ reference [..] T10#M1#`@f`.
-   end
- 
-   module M2
-#         ^^ definition [..] T10#M2#
-     include M0
-#    ^^^^^^^ reference [..] Module#include().
-#            ^^ reference [..] T10#M0#
-     include M1
-#    ^^^^^^^ reference [..] Module#include().
-#            ^^ reference [..] T10#M1#
-     def set_f_2; @f = 2; end
-#        ^^^^^^^ definition [..] T10#M2#set_f_2().
-#                 ^^ definition [..] T10#M2#`@f`.
-#                 relation reference=[..] T10#M0#`@f`. reference=[..] T10#M1#`@f`.
-#                 ^^^^^^ reference [..] T10#M2#`@f`.
-   end
- 
-   class C
-#        ^ definition [..] T10#C#
-     include M2
-#    ^^^^^^^ reference [..] Module#include().
-#            ^^ reference [..] T10#M2#
-     def set_f_3; @f = 3; end
-#        ^^^^^^^ definition [..] T10#C#set_f_3().
-#                 ^^ definition [..] T10#C#`@f`.
-#                 relation reference=[..] T10#M0#`@f`. reference=[..] T10#M1#`@f`. reference=[..] T10#M2#`@f`.
-#                 ^^^^^^ reference [..] T10#C#`@f`.
-     def get_f; @f; end
-#        ^^^^^ definition [..] T10#C#get_f().
-#               ^^ reference [..] T10#C#`@f`.
-   end
- end
- 
- # Definition in multiple transitively included modules & common child only
- 
- module T11
-#       ^^^ definition [..] T11#
-   module M0
-#         ^^ definition [..] T11#M0#
-     def set_f_0; @f = 0; end
-#        ^^^^^^^ definition [..] T11#M0#set_f_0().
-#                 ^^ definition [..] T11#M0#`@f`.
-#                 ^^^^^^ reference [..] T11#M0#`@f`.
-   end
- 
-   module M1
-#         ^^ definition [..] T11#M1#
-     def set_f_1; @f = 1; end
-#        ^^^^^^^ definition [..] T11#M1#set_f_1().
-#                 ^^ definition [..] T11#M1#`@f`.
-#                 ^^^^^^ reference [..] T11#M1#`@f`.
-   end
- 
-   module M2
-#         ^^ definition [..] T11#M2#
-     include M0
-#    ^^^^^^^ reference [..] Module#include().
-#            ^^ reference [..] T11#M0#
-     include M1
-#    ^^^^^^^ reference [..] Module#include().
-#            ^^ reference [..] T11#M1#
-     def set_f_2; @f = 2; end
-#        ^^^^^^^ definition [..] T11#M2#set_f_2().
-#                 ^^ definition [..] T11#M2#`@f`.
-#                 relation reference=[..] T11#M0#`@f`. reference=[..] T11#M1#`@f`.
-#                 ^^^^^^ reference [..] T11#M2#`@f`.
-   end
- 
-   class C
-#        ^ definition [..] T11#C#
-     include M2
-#    ^^^^^^^ reference [..] Module#include().
-#            ^^ reference [..] T11#M2#
-     def get_f; @f; end
-#        ^^^^^ definition [..] T11#C#get_f().
-#               ^^ reference [..] T11#C#`@f`.
-   end
- end
- 
- # Definition in multiple transitively included modules & Self
  
  module T12
 #       ^^^ definition [..] T12#
@@ -594,6 +497,11 @@
      include M1
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T12#M1#
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T12#M2#set_f_2().
+#                 ^^ definition [..] T12#M2#`@f`.
+#                 relation reference=[..] T12#M0#`@f`. reference=[..] T12#M1#`@f`.
+#                 ^^^^^^ reference [..] T12#M2#`@f`.
    end
  
    class C
@@ -604,7 +512,7 @@
      def set_f_3; @f = 3; end
 #        ^^^^^^^ definition [..] T12#C#set_f_3().
 #                 ^^ definition [..] T12#C#`@f`.
-#                 relation reference=[..] T12#M0#`@f`. reference=[..] T12#M1#`@f`.
+#                 relation reference=[..] T12#M0#`@f`. reference=[..] T12#M1#`@f`. reference=[..] T12#M2#`@f`.
 #                 ^^^^^^ reference [..] T12#C#`@f`.
      def get_f; @f; end
 #        ^^^^^ definition [..] T12#C#get_f().
@@ -612,7 +520,7 @@
    end
  end
  
- # Definition in multiple transitively included modules only
+ # Definition in multiple transitively included modules & common child only
  
  module T13
 #       ^^^ definition [..] T13#
@@ -640,6 +548,11 @@
      include M1
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T13#M1#
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T13#M2#set_f_2().
+#                 ^^ definition [..] T13#M2#`@f`.
+#                 relation reference=[..] T13#M0#`@f`. reference=[..] T13#M1#`@f`.
+#                 ^^^^^^ reference [..] T13#M2#`@f`.
    end
  
    class C
@@ -653,7 +566,7 @@
    end
  end
  
- # Definition in multiple directly included modules & Self
+ # Definition in multiple transitively included modules & Self
  
  module T14
 #       ^^^ definition [..] T14#
@@ -673,16 +586,23 @@
 #                 ^^^^^^ reference [..] T14#M1#`@f`.
    end
  
-   class C
-#        ^ definition [..] T14#C#
+   module M2
+#         ^^ definition [..] T14#M2#
      include M0
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T14#M0#
      include M1
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T14#M1#
-     def set_f_2; @f = 2; end
-#        ^^^^^^^ definition [..] T14#C#set_f_2().
+   end
+ 
+   class C
+#        ^ definition [..] T14#C#
+     include M2
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T14#M2#
+     def set_f_3; @f = 3; end
+#        ^^^^^^^ definition [..] T14#C#set_f_3().
 #                 ^^ definition [..] T14#C#`@f`.
 #                 relation reference=[..] T14#M0#`@f`. reference=[..] T14#M1#`@f`.
 #                 ^^^^^^ reference [..] T14#C#`@f`.
@@ -692,7 +612,7 @@
    end
  end
  
- # Definition in multiple directly included modules only
+ # Definition in multiple transitively included modules only
  
  module T15
 #       ^^^ definition [..] T15#
@@ -712,17 +632,97 @@
 #                 ^^^^^^ reference [..] T15#M1#`@f`.
    end
  
-   class C
-#        ^ definition [..] T15#C#
+   module M2
+#         ^^ definition [..] T15#M2#
      include M0
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T15#M0#
      include M1
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T15#M1#
+   end
+ 
+   class C
+#        ^ definition [..] T15#C#
+     include M2
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T15#M2#
      def get_f; @f; end
 #        ^^^^^ definition [..] T15#C#get_f().
 #               ^^ reference [..] T15#C#`@f`.
+   end
+ end
+ 
+ # Definition in multiple directly included modules & Self
+ 
+ module T16
+#       ^^^ definition [..] T16#
+   module M0
+#         ^^ definition [..] T16#M0#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T16#M0#set_f_0().
+#                 ^^ definition [..] T16#M0#`@f`.
+#                 ^^^^^^ reference [..] T16#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T16#M1#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T16#M1#set_f_1().
+#                 ^^ definition [..] T16#M1#`@f`.
+#                 ^^^^^^ reference [..] T16#M1#`@f`.
+   end
+ 
+   class C
+#        ^ definition [..] T16#C#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T16#M0#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T16#M1#
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T16#C#set_f_2().
+#                 ^^ definition [..] T16#C#`@f`.
+#                 relation reference=[..] T16#M0#`@f`. reference=[..] T16#M1#`@f`.
+#                 ^^^^^^ reference [..] T16#C#`@f`.
+     def get_f; @f; end
+#        ^^^^^ definition [..] T16#C#get_f().
+#               ^^ reference [..] T16#C#`@f`.
+   end
+ end
+ 
+ # Definition in multiple directly included modules only
+ 
+ module T17
+#       ^^^ definition [..] T17#
+   module M0
+#         ^^ definition [..] T17#M0#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T17#M0#set_f_0().
+#                 ^^ definition [..] T17#M0#`@f`.
+#                 ^^^^^^ reference [..] T17#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T17#M1#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T17#M1#set_f_1().
+#                 ^^ definition [..] T17#M1#`@f`.
+#                 ^^^^^^ reference [..] T17#M1#`@f`.
+   end
+ 
+   class C
+#        ^ definition [..] T17#C#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T17#M0#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T17#M1#
+     def get_f; @f; end
+#        ^^^^^ definition [..] T17#C#get_f().
+#               ^^ reference [..] T17#C#`@f`.
    end
  end
  
@@ -812,7 +812,6 @@
 #            ^ reference [..] W2#M#
      def get_fp1; @f + 1; end
 #        ^^^^^^^ definition [..] W2#C1#get_fp1().
-#        ^^^^^^^ definition [..] W2#C1#get_fp1().
 #                 ^^ reference [..] W2#C1#`@f`.
 #                 relation definition=[..] W2#C0#`@f`. reference=[..] W2#M#`@f`.
    end
@@ -820,70 +819,37 @@
  
  # Reference in directly included module with def in superclass
  
- module W2
-#       ^^ definition [..] W2#
+ module W3
+#       ^^ definition [..] W3#
    module M
-#         ^ definition [..] W2#M#
+#         ^ definition [..] W3#M#
      def get_f; @f; end
-#        ^^^^^ definition [..] W2#M#get_f().
-#               ^^ reference [..] W2#M#`@f`.
+#        ^^^^^ definition [..] W3#M#get_f().
+#               ^^ reference [..] W3#M#`@f`.
    end
  
    class C0
-#        ^^ definition [..] W2#C0#
+#        ^^ definition [..] W3#C0#
      def set_f; @f = 0; end
-#        ^^^^^ definition [..] W2#C0#set_f().
-#               ^^ definition [..] W2#C0#`@f`.
-#               ^^^^^^ reference [..] W2#C0#`@f`.
+#        ^^^^^ definition [..] W3#C0#set_f().
+#               ^^ definition [..] W3#C0#`@f`.
+#               ^^^^^^ reference [..] W3#C0#`@f`.
    end
  
    class C1 < C0
-#        ^^ definition [..] W2#C1#
-#             ^^ definition [..] W2#C0#
+#        ^^ definition [..] W3#C1#
+#             ^^ definition [..] W3#C0#
      include M
 #    ^^^^^^^ reference [..] Module#include().
-#            ^ reference [..] W2#M#
+#            ^ reference [..] W3#M#
      def get_fp1; @f + 1; end
-#                 ^^ reference [..] W2#C1#`@f`.
-#                 relation definition=[..] W2#C0#`@f`. reference=[..] W2#M#`@f`.
+#        ^^^^^^^ definition [..] W3#C1#get_fp1().
+#                 ^^ reference [..] W3#C1#`@f`.
+#                 relation definition=[..] W3#C0#`@f`. reference=[..] W3#M#`@f`.
    end
  end
  
  # Reference in transitively included module with def in in-between module
- 
- module W3
-#       ^^ definition [..] W3#
-   module M0
-#         ^^ definition [..] W3#M0#
-     def get_f; @f; end
-#        ^^^^^ definition [..] W3#M0#get_f().
-#               ^^ reference [..] W3#M0#`@f`.
-   end
- 
-   module M1
-#         ^^ definition [..] W3#M1#
-     include M0
-#    ^^^^^^^ reference [..] Module#include().
-#            ^^ reference [..] W3#M0#
-     def set_f; @f = 0; end
-#        ^^^^^ definition [..] W3#M1#set_f().
-#               ^^ definition [..] W3#M1#`@f`.
-#               relation reference=[..] W3#M0#`@f`.
-#               ^^^^^^ reference [..] W3#M1#`@f`.
-   end
- 
-   class C
-#        ^ definition [..] W3#C#
-     include M1
-#    ^^^^^^^ reference [..] Module#include().
-#            ^^ reference [..] W3#M1#
-     def get_fp1; @f + 1; end
-#        ^^^^^^^ definition [..] W3#C#get_fp1().
-#                 ^^ reference [..] W3#C#`@f`.
-   end
- end
- 
- # Reference in one directly included module with def in other directly included module
  
  module W4
 #       ^^ definition [..] W4#
@@ -896,16 +862,18 @@
  
    module M1
 #         ^^ definition [..] W4#M1#
-     def set_f; @f + 1; end
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] W4#M0#
+     def set_f; @f = 0; end
 #        ^^^^^ definition [..] W4#M1#set_f().
-#               ^^ reference [..] W4#M1#`@f`.
+#               ^^ definition [..] W4#M1#`@f`.
+#               relation reference=[..] W4#M0#`@f`.
+#               ^^^^^^ reference [..] W4#M1#`@f`.
    end
  
    class C
 #        ^ definition [..] W4#C#
-     include M0
-#    ^^^^^^^ reference [..] Module#include().
-#            ^^ reference [..] W4#M0#
      include M1
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] W4#M1#
@@ -915,3 +883,34 @@
    end
  end
  
+ # Reference in one directly included module with def in other directly included module
+ 
+ module W5
+#       ^^ definition [..] W5#
+   module M0
+#         ^^ definition [..] W5#M0#
+     def get_f; @f; end
+#        ^^^^^ definition [..] W5#M0#get_f().
+#               ^^ reference [..] W5#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] W5#M1#
+     def set_f; @f + 1; end
+#        ^^^^^ definition [..] W5#M1#set_f().
+#               ^^ reference [..] W5#M1#`@f`.
+   end
+ 
+   class C
+#        ^ definition [..] W5#C#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] W5#M0#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] W5#M1#
+     def get_fp1; @f + 1; end
+#        ^^^^^^^ definition [..] W5#C#get_fp1().
+#                 ^^ reference [..] W5#C#`@f`.
+   end
+ end

--- a/test/scip/testdata/mixin.snapshot.rb
+++ b/test/scip/testdata/mixin.snapshot.rb
@@ -1,0 +1,74 @@
+ # typed: true
+ 
+ module M
+#       ^ definition [..] M#
+   def f
+#      ^ definition [..] M#f().
+     puts 'M.f'
+   end
+ end
+ 
+ class C1
+#      ^^ definition [..] C1#
+   include M
+#  ^^^^^^^ reference [..] Module#include().
+#          ^ reference [..] M#
+   def f
+#      ^ definition [..] C1#f().
+     puts 'C1.f'
+#    ^^^^ reference [..] Kernel#puts().
+   end
+ end
+ 
+ # f refers to C1.f
+ class C2 < C1
+#      ^^ definition [..] C2#
+#           ^^ definition [..] C1#
+ end
+ 
+ # f refers to C1.f
+ class C3 < C1
+#      ^^ definition [..] C3#
+#           ^^ definition [..] C1#
+   include M
+#  ^^^^^^^ reference [..] Module#include().
+#          ^ reference [..] M#
+ end
+ 
+ class D1
+#      ^^ definition [..] D1#
+   def f
+#      ^ definition [..] D1#f().
+     puts 'D1.f'
+#    ^^^^ reference [..] Kernel#puts().
+   end
+ end
+ 
+ class D2
+#      ^^ definition [..] D2#
+   include M
+#  ^^^^^^^ reference [..] Module#include().
+#          ^ reference [..] M#
+ end
+ 
+ C1.new.f # C1.f
+#^^ reference [..] C1#
+#   ^^^ reference [..] Class#new().
+#       ^ reference [..] C1#f().
+ C2.new.f # C1.f
+#^^ reference [..] C2#
+#   ^^^ reference [..] Class#new().
+#       ^ reference [..] C1#f().
+ C3.new.f # C1.f
+#^^ reference [..] C3#
+#   ^^^ reference [..] Class#new().
+#       ^ reference [..] C1#f().
+ 
+ D1.new.f # D1.f
+#^^ reference [..] D1#
+#   ^^^ reference [..] Class#new().
+#       ^ reference [..] D1#f().
+ D2.new.f # M.f
+#^^ reference [..] D2#
+#   ^^^ reference [..] Class#new().
+#       ^ reference [..] M#f().

--- a/test/scip/testdata/mixin.snapshot.rb
+++ b/test/scip/testdata/mixin.snapshot.rb
@@ -2,10 +2,8 @@
  
  module M
 #       ^ definition [..] M#
-   def f
+   def f; puts 'M.f'; end
 #      ^ definition [..] M#f().
-     puts 'M.f'
-   end
  end
  
  class C1
@@ -13,11 +11,9 @@
    include M
 #  ^^^^^^^ reference [..] Module#include().
 #          ^ reference [..] M#
-   def f
+   def f; puts 'C1.f'; end
 #      ^ definition [..] C1#f().
-     puts 'C1.f'
-#    ^^^^ reference [..] Kernel#puts().
-   end
+#         ^^^^ reference [..] Kernel#puts().
  end
  
  # f refers to C1.f
@@ -37,11 +33,9 @@
  
  class D1
 #      ^^ definition [..] D1#
-   def f
+   def f; puts 'D1.f'; end
 #      ^ definition [..] D1#f().
-     puts 'D1.f'
-#    ^^^^ reference [..] Kernel#puts().
-   end
+#         ^^^^ reference [..] Kernel#puts().
  end
  
  class D2
@@ -72,3 +66,852 @@
 #^^ reference [..] D2#
 #   ^^^ reference [..] Class#new().
 #       ^ reference [..] M#f().
+ 
+ # Definition in directly included module and Self
+ 
+ module T0
+#       ^^ definition [..] T0#
+   module M
+#         ^ definition [..] T0#M#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T0#M#set_f_0().
+#        ^^^^^^^ definition [..] T0#M#set_f_0().
+#                 ^^ definition [..] T0#M#`@f`.
+#                 ^^^^^^ reference [..] T0#M#`@f`.
+   end
+ 
+   class C
+#        ^ definition [..] T0#C#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] T0#M#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T0#C#set_f_1().
+#                 ^^ definition [..] T0#C#`@f`.
+#                 relation reference=[..] T0#M#`@f`.
+#                 ^^^^^^ reference [..] T0#C#`@f`.
+     def get_f; @f; end
+#        ^^^^^ definition [..] T0#C#get_f().
+#               ^^ reference [..] T0#C#`@f`.
+   end
+ end
+ 
+ # Definition in transitively included module and Self
+ 
+ module T1
+#       ^^ definition [..] T1#
+   module M0
+#         ^^ definition [..] T1#M0#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T1#M0#set_f_0().
+#                 ^^ definition [..] T1#M0#`@f`.
+#                 ^^^^^^ reference [..] T1#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T1#M1#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T1#M0#
+   end
+ 
+   class C
+#        ^ definition [..] T1#C#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T1#M1#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T1#C#set_f_1().
+#                 ^^ definition [..] T1#C#`@f`.
+#                 relation reference=[..] T1#M0#`@f`.
+#                 ^^^^^^ reference [..] T1#C#`@f`.
+     def get_f; @f; end
+#        ^^^^^ definition [..] T1#C#get_f().
+#               ^^ reference [..] T1#C#`@f`.
+   end
+ end
+ 
+ # Definition in directly included module only
+ 
+ module T2
+#       ^^ definition [..] T2#
+   module M
+#         ^ definition [..] T2#M#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T2#M#set_f_0().
+#                 ^^ definition [..] T2#M#`@f`.
+#                 ^^^^^^ reference [..] T2#M#`@f`.
+   end
+ 
+   class C
+#        ^ definition [..] T2#C#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] T2#M#
+     def get_f; @f; end
+#        ^^^^^ definition [..] T2#C#get_f().
+#               ^^ reference [..] T2#C#`@f`.
+   end
+ end
+ 
+ # Definition in transitively included module only
+ 
+ module T3
+#       ^^ definition [..] T3#
+   module M0
+#         ^^ definition [..] T3#M0#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T3#M0#set_f_0().
+#        ^^^^^^^ definition [..] T3#M0#set_f_0().
+#                 ^^ definition [..] T3#M0#`@f`.
+#                 ^^^^^^ reference [..] T3#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T3#M1#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T3#M0#
+   end
+ 
+   class C
+#        ^ definition [..] T3#C#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T3#M1#
+     def get_f; @f; end
+#        ^^^^^ definition [..] T3#C#get_f().
+#               ^^ reference [..] T3#C#`@f`.
+   end
+ end
+ 
+ # Definition in directly included module & superclass & Self
+ 
+ module T0
+#       ^^ definition [..] T0#
+   module M
+#         ^ definition [..] T0#M#
+     def set_f_0; @f = 0; end
+#                 ^^ definition [..] T0#M#`@f`.
+#                 ^^^^^^ reference [..] T0#M#`@f`.
+   end
+ 
+   class C0
+#        ^^ definition [..] T0#C0#
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T0#C0#set_f_2().
+#                 ^^ definition [..] T0#C0#`@f`.
+#                 ^^^^^^ reference [..] T0#C0#`@f`.
+   end
+ 
+   class C1 < C0
+#        ^^ definition [..] T0#C1#
+#             ^^ definition [..] T0#C0#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] T0#M#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T0#C1#set_f_1().
+#                 ^^ definition [..] T0#C1#`@f`.
+#                 relation definition=[..] T0#C0#`@f`. reference=[..] T0#M#`@f`.
+#                 ^^^^^^ reference [..] T0#C1#`@f`.
+#                 relation definition=[..] T0#C0#`@f`. reference=[..] T0#M#`@f`.
+     def get_f; @f; end
+#        ^^^^^ definition [..] T0#C1#get_f().
+#               ^^ reference [..] T0#C1#`@f`.
+#               relation definition=[..] T0#C0#`@f`. reference=[..] T0#M#`@f`.
+   end
+ end
+ 
+ # Definition in transitively included module & superclass & Self
+ 
+ module T3
+#       ^^ definition [..] T3#
+   module M0
+#         ^^ definition [..] T3#M0#
+     def set_f_0; @f = 0; end
+#                 ^^ definition [..] T3#M0#`@f`.
+#                 ^^^^^^ reference [..] T3#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T3#M1#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T3#M0#
+   end
+ 
+   class C0
+#        ^^ definition [..] T3#C0#
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T3#C0#set_f_2().
+#                 ^^ definition [..] T3#C0#`@f`.
+#                 ^^^^^^ reference [..] T3#C0#`@f`.
+   end
+ 
+   class C1 < C0
+#        ^^ definition [..] T3#C1#
+#             ^^ definition [..] T3#C0#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] M#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T3#C1#set_f_1().
+#                 ^^ definition [..] T3#C1#`@f`.
+#                 relation definition=[..] T3#C0#`@f`.
+#                 ^^^^^^ reference [..] T3#C1#`@f`.
+#                 relation definition=[..] T3#C0#`@f`.
+     def get_f; @f; end
+#        ^^^^^ definition [..] T3#C1#get_f().
+#               ^^ reference [..] T3#C1#`@f`.
+#               relation definition=[..] T3#C0#`@f`.
+   end
+ end
+ 
+ # Definition in directly included module & superclass only
+ 
+ module T4
+#       ^^ definition [..] T4#
+   module M
+#         ^ definition [..] T4#M#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T4#M#set_f_0().
+#                 ^^ definition [..] T4#M#`@f`.
+#                 ^^^^^^ reference [..] T4#M#`@f`.
+   end
+ 
+   class C0
+#        ^^ definition [..] T4#C0#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T4#C0#set_f_1().
+#                 ^^ definition [..] T4#C0#`@f`.
+#                 ^^^^^^ reference [..] T4#C0#`@f`.
+   end
+ 
+   class C1 < C0
+#        ^^ definition [..] T4#C1#
+#             ^^ definition [..] T4#C0#
+     def get_f; @f; end
+#        ^^^^^ definition [..] T4#C1#get_f().
+#               ^^ reference [..] T4#C1#`@f`.
+#               relation definition=[..] T4#C0#`@f`.
+   end
+ end
+ 
+ # Definition in transitively included module & superclass only
+ 
+ module T5
+#       ^^ definition [..] T5#
+   module M0
+#         ^^ definition [..] T5#M0#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T5#M0#set_f_0().
+#                 ^^ definition [..] T5#M0#`@f`.
+#                 ^^^^^^ reference [..] T5#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T5#M1#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T5#M0#
+   end
+ 
+   class C0
+#        ^^ definition [..] T5#C0#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T5#C0#set_f_1().
+#                 ^^ definition [..] T5#C0#`@f`.
+#                 ^^^^^^ reference [..] T5#C0#`@f`.
+   end
+ 
+   class C1 < C0
+#        ^^ definition [..] T5#C1#
+#             ^^ definition [..] T5#C0#
+     def get_f; @f; end
+#        ^^^^^ definition [..] T5#C1#get_f().
+#               ^^ reference [..] T5#C1#`@f`.
+#               relation definition=[..] T5#C0#`@f`.
+   end
+ end
+ 
+ # Definition in module included via superclass & superclass & Self
+ 
+ module T6
+#       ^^ definition [..] T6#
+   module M
+#         ^ definition [..] T6#M#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T6#M#set_f_0().
+#                 ^^ definition [..] T6#M#`@f`.
+#                 ^^^^^^ reference [..] T6#M#`@f`.
+   end
+ 
+   class C0
+#        ^^ definition [..] T6#C0#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] T6#M#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T6#C0#set_f_1().
+#                 ^^ definition [..] T6#C0#`@f`.
+#                 relation reference=[..] T6#M#`@f`.
+#                 ^^^^^^ reference [..] T6#C0#`@f`.
+   end
+ 
+   class C1 < C0
+#        ^^ definition [..] T6#C1#
+#             ^^ definition [..] T6#C0#
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T6#C1#set_f_2().
+#                 ^^ definition [..] T6#C1#`@f`.
+#                 relation definition=[..] T6#C0#`@f`.
+#                 ^^^^^^ reference [..] T6#C1#`@f`.
+#                 relation definition=[..] T6#C0#`@f`.
+     def get_f; @f; end
+#        ^^^^^ definition [..] T6#C1#get_f().
+#               ^^ reference [..] T6#C1#`@f`.
+#               relation definition=[..] T6#C0#`@f`.
+   end
+ end
+ 
+ # Definition in module included via superclass & superclass only
+ 
+ module T7
+#       ^^ definition [..] T7#
+   module M
+#         ^ definition [..] T7#M#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T7#M#set_f_0().
+#                 ^^ definition [..] T7#M#`@f`.
+#                 ^^^^^^ reference [..] T7#M#`@f`.
+   end
+ 
+   class C0
+#        ^^ definition [..] T7#C0#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] T7#M#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T7#C0#set_f_1().
+#                 ^^ definition [..] T7#C0#`@f`.
+#                 relation reference=[..] T7#M#`@f`.
+#                 ^^^^^^ reference [..] T7#C0#`@f`.
+   end
+ 
+   class C1 < C0
+#        ^^ definition [..] T7#C1#
+#             ^^ definition [..] T7#C0#
+     def get_f; @f; end
+#        ^^^^^ definition [..] T7#C1#get_f().
+#               ^^ reference [..] T7#C1#`@f`.
+#               relation definition=[..] T7#C0#`@f`.
+   end
+ end
+ 
+ # Definition in module included via superclass & Self
+ 
+ module T8
+#       ^^ definition [..] T8#
+   module M
+#         ^ definition [..] T8#M#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T8#M#set_f_0().
+#                 ^^ definition [..] T8#M#`@f`.
+#                 ^^^^^^ reference [..] T8#M#`@f`.
+   end
+ 
+   class C0
+#        ^^ definition [..] T8#C0#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] T8#M#
+   end
+ 
+   class C1 < C0
+#        ^^ definition [..] T8#C1#
+#             ^^ definition [..] T8#C0#
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T8#C1#set_f_2().
+#                 ^^ definition [..] T8#C1#`@f`.
+#                 ^^^^^^ reference [..] T8#C1#`@f`.
+     def get_f; @f; end
+#        ^^^^^ definition [..] T8#C1#get_f().
+#               ^^ reference [..] T8#C1#`@f`.
+   end
+ end
+ 
+ # Definition in module included via superclass only
+ 
+ module T9
+#       ^^ definition [..] T9#
+   module M
+#         ^ definition [..] T9#M#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T9#M#set_f_0().
+#                 ^^ definition [..] T9#M#`@f`.
+#                 ^^^^^^ reference [..] T9#M#`@f`.
+   end
+ 
+   class C0
+#        ^^ definition [..] T9#C0#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] T9#M#
+   end
+ 
+   class C1 < C0
+#        ^^ definition [..] T9#C1#
+#             ^^ definition [..] T9#C0#
+     def get_f; @f; end
+#        ^^^^^ definition [..] T9#C1#get_f().
+#               ^^ reference [..] T9#C1#`@f`.
+   end
+ end
+ 
+ # Definition in multiple transitively included modules & common child & Self
+ 
+ module T10
+#       ^^^ definition [..] T10#
+   module M0
+#         ^^ definition [..] T10#M0#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T10#M0#set_f_0().
+#                 ^^ definition [..] T10#M0#`@f`.
+#                 ^^^^^^ reference [..] T10#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T10#M1#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T10#M1#set_f_1().
+#                 ^^ definition [..] T10#M1#`@f`.
+#                 ^^^^^^ reference [..] T10#M1#`@f`.
+   end
+ 
+   module M2
+#         ^^ definition [..] T10#M2#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T10#M0#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T10#M1#
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T10#M2#set_f_2().
+#                 ^^ definition [..] T10#M2#`@f`.
+#                 relation reference=[..] T10#M0#`@f`. reference=[..] T10#M1#`@f`.
+#                 ^^^^^^ reference [..] T10#M2#`@f`.
+   end
+ 
+   class C
+#        ^ definition [..] T10#C#
+     include M2
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T10#M2#
+     def set_f_3; @f = 3; end
+#        ^^^^^^^ definition [..] T10#C#set_f_3().
+#                 ^^ definition [..] T10#C#`@f`.
+#                 relation reference=[..] T10#M0#`@f`. reference=[..] T10#M1#`@f`. reference=[..] T10#M2#`@f`.
+#                 ^^^^^^ reference [..] T10#C#`@f`.
+     def get_f; @f; end
+#        ^^^^^ definition [..] T10#C#get_f().
+#               ^^ reference [..] T10#C#`@f`.
+   end
+ end
+ 
+ # Definition in multiple transitively included modules & common child only
+ 
+ module T11
+#       ^^^ definition [..] T11#
+   module M0
+#         ^^ definition [..] T11#M0#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T11#M0#set_f_0().
+#                 ^^ definition [..] T11#M0#`@f`.
+#                 ^^^^^^ reference [..] T11#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T11#M1#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T11#M1#set_f_1().
+#                 ^^ definition [..] T11#M1#`@f`.
+#                 ^^^^^^ reference [..] T11#M1#`@f`.
+   end
+ 
+   module M2
+#         ^^ definition [..] T11#M2#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T11#M0#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T11#M1#
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T11#M2#set_f_2().
+#                 ^^ definition [..] T11#M2#`@f`.
+#                 relation reference=[..] T11#M0#`@f`. reference=[..] T11#M1#`@f`.
+#                 ^^^^^^ reference [..] T11#M2#`@f`.
+   end
+ 
+   class C
+#        ^ definition [..] T11#C#
+     include M2
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T11#M2#
+     def get_f; @f; end
+#        ^^^^^ definition [..] T11#C#get_f().
+#               ^^ reference [..] T11#C#`@f`.
+   end
+ end
+ 
+ # Definition in multiple transitively included modules & Self
+ 
+ module T12
+#       ^^^ definition [..] T12#
+   module M0
+#         ^^ definition [..] T12#M0#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T12#M0#set_f_0().
+#                 ^^ definition [..] T12#M0#`@f`.
+#                 ^^^^^^ reference [..] T12#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T12#M1#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T12#M1#set_f_1().
+#                 ^^ definition [..] T12#M1#`@f`.
+#                 ^^^^^^ reference [..] T12#M1#`@f`.
+   end
+ 
+   module M2
+#         ^^ definition [..] T12#M2#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T12#M0#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T12#M1#
+   end
+ 
+   class C
+#        ^ definition [..] T12#C#
+     include M2
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T12#M2#
+     def set_f_3; @f = 3; end
+#        ^^^^^^^ definition [..] T12#C#set_f_3().
+#                 ^^ definition [..] T12#C#`@f`.
+#                 relation reference=[..] T12#M0#`@f`. reference=[..] T12#M1#`@f`.
+#                 ^^^^^^ reference [..] T12#C#`@f`.
+     def get_f; @f; end
+#        ^^^^^ definition [..] T12#C#get_f().
+#               ^^ reference [..] T12#C#`@f`.
+   end
+ end
+ 
+ # Definition in multiple transitively included modules only
+ 
+ module T13
+#       ^^^ definition [..] T13#
+   module M0
+#         ^^ definition [..] T13#M0#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T13#M0#set_f_0().
+#                 ^^ definition [..] T13#M0#`@f`.
+#                 ^^^^^^ reference [..] T13#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T13#M1#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T13#M1#set_f_1().
+#                 ^^ definition [..] T13#M1#`@f`.
+#                 ^^^^^^ reference [..] T13#M1#`@f`.
+   end
+ 
+   module M2
+#         ^^ definition [..] T13#M2#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T13#M0#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T13#M1#
+   end
+ 
+   class C
+#        ^ definition [..] T13#C#
+     include M2
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T13#M2#
+     def get_f; @f; end
+#        ^^^^^ definition [..] T13#C#get_f().
+#               ^^ reference [..] T13#C#`@f`.
+   end
+ end
+ 
+ # Definition in multiple directly included modules & Self
+ 
+ module T14
+#       ^^^ definition [..] T14#
+   module M0
+#         ^^ definition [..] T14#M0#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T14#M0#set_f_0().
+#                 ^^ definition [..] T14#M0#`@f`.
+#                 ^^^^^^ reference [..] T14#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T14#M1#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T14#M1#set_f_1().
+#                 ^^ definition [..] T14#M1#`@f`.
+#                 ^^^^^^ reference [..] T14#M1#`@f`.
+   end
+ 
+   class C
+#        ^ definition [..] T14#C#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T14#M0#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T14#M1#
+     def set_f_2; @f = 2; end
+#        ^^^^^^^ definition [..] T14#C#set_f_2().
+#                 ^^ definition [..] T14#C#`@f`.
+#                 relation reference=[..] T14#M0#`@f`. reference=[..] T14#M1#`@f`.
+#                 ^^^^^^ reference [..] T14#C#`@f`.
+     def get_f; @f; end
+#        ^^^^^ definition [..] T14#C#get_f().
+#               ^^ reference [..] T14#C#`@f`.
+   end
+ end
+ 
+ # Definition in multiple directly included modules only
+ 
+ module T15
+#       ^^^ definition [..] T15#
+   module M0
+#         ^^ definition [..] T15#M0#
+     def set_f_0; @f = 0; end
+#        ^^^^^^^ definition [..] T15#M0#set_f_0().
+#                 ^^ definition [..] T15#M0#`@f`.
+#                 ^^^^^^ reference [..] T15#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] T15#M1#
+     def set_f_1; @f = 1; end
+#        ^^^^^^^ definition [..] T15#M1#set_f_1().
+#                 ^^ definition [..] T15#M1#`@f`.
+#                 ^^^^^^ reference [..] T15#M1#`@f`.
+   end
+ 
+   class C
+#        ^ definition [..] T15#C#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T15#M0#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] T15#M1#
+     def get_f; @f; end
+#        ^^^^^ definition [..] T15#C#get_f().
+#               ^^ reference [..] T15#C#`@f`.
+   end
+ end
+ 
+ # OKAY! Now for the more "weird" situations
+ # Before this, all the tests had a definition come "before" use.
+ # Let's see what happens if there is a use before any definition.
+ 
+ # Reference in directly included module with def in Self
+ 
+ module W0
+#       ^^ definition [..] W0#
+   module M
+#         ^ definition [..] W0#M#
+     def get_f; @f; end
+#        ^^^^^ definition [..] W0#M#get_f().
+#               ^^ reference [..] W0#M#`@f`.
+   end
+ 
+   class C
+#        ^ definition [..] W0#C#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] W0#M#
+     def set_f; @f = 0; end
+#        ^^^^^ definition [..] W0#C#set_f().
+#               ^^ definition [..] W0#C#`@f`.
+#               relation reference=[..] W0#M#`@f`.
+#               ^^^^^^ reference [..] W0#C#`@f`.
+   end
+ end
+ 
+ # Reference in transitively included module with def in Self
+ 
+ module W1
+#       ^^ definition [..] W1#
+   module M0
+#         ^^ definition [..] W1#M0#
+     def get_f; @f; end
+#        ^^^^^ definition [..] W1#M0#get_f().
+#               ^^ reference [..] W1#M0#`@f`.
+   end
+   
+   module M1
+#         ^^ definition [..] W1#M1#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] W1#M0#
+   end
+ 
+   class C
+#        ^ definition [..] W1#C#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] W1#M1#
+     def set_f; @f = 0; end
+#        ^^^^^ definition [..] W1#C#set_f().
+#               ^^ definition [..] W1#C#`@f`.
+#               relation reference=[..] W1#M0#`@f`.
+#               ^^^^^^ reference [..] W1#C#`@f`.
+   end
+ end
+ 
+ # Reference in superclass with def in directly included module
+ 
+ module W2
+#       ^^ definition [..] W2#
+   module M
+#         ^ definition [..] W2#M#
+     def set_f; @f = 0; end
+#        ^^^^^ definition [..] W2#M#set_f().
+#               ^^ definition [..] W2#M#`@f`.
+#               ^^^^^^ reference [..] W2#M#`@f`.
+   end
+ 
+   class C0
+#        ^^ definition [..] W2#C0#
+     def get_f; @f; end
+#        ^^^^^ definition [..] W2#C0#get_f().
+#               ^^ reference [..] W2#C0#`@f`.
+   end
+ 
+   class C1 < C0
+#        ^^ definition [..] W2#C1#
+#             ^^ definition [..] W2#C0#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] W2#M#
+     def get_fp1; @f + 1; end
+#        ^^^^^^^ definition [..] W2#C1#get_fp1().
+#        ^^^^^^^ definition [..] W2#C1#get_fp1().
+#                 ^^ reference [..] W2#C1#`@f`.
+#                 relation definition=[..] W2#C0#`@f`. reference=[..] W2#M#`@f`.
+   end
+ end
+ 
+ # Reference in directly included module with def in superclass
+ 
+ module W2
+#       ^^ definition [..] W2#
+   module M
+#         ^ definition [..] W2#M#
+     def get_f; @f; end
+#        ^^^^^ definition [..] W2#M#get_f().
+#               ^^ reference [..] W2#M#`@f`.
+   end
+ 
+   class C0
+#        ^^ definition [..] W2#C0#
+     def set_f; @f = 0; end
+#        ^^^^^ definition [..] W2#C0#set_f().
+#               ^^ definition [..] W2#C0#`@f`.
+#               ^^^^^^ reference [..] W2#C0#`@f`.
+   end
+ 
+   class C1 < C0
+#        ^^ definition [..] W2#C1#
+#             ^^ definition [..] W2#C0#
+     include M
+#    ^^^^^^^ reference [..] Module#include().
+#            ^ reference [..] W2#M#
+     def get_fp1; @f + 1; end
+#                 ^^ reference [..] W2#C1#`@f`.
+#                 relation definition=[..] W2#C0#`@f`. reference=[..] W2#M#`@f`.
+   end
+ end
+ 
+ # Reference in transitively included module with def in in-between module
+ 
+ module W3
+#       ^^ definition [..] W3#
+   module M0
+#         ^^ definition [..] W3#M0#
+     def get_f; @f; end
+#        ^^^^^ definition [..] W3#M0#get_f().
+#               ^^ reference [..] W3#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] W3#M1#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] W3#M0#
+     def set_f; @f = 0; end
+#        ^^^^^ definition [..] W3#M1#set_f().
+#               ^^ definition [..] W3#M1#`@f`.
+#               relation reference=[..] W3#M0#`@f`.
+#               ^^^^^^ reference [..] W3#M1#`@f`.
+   end
+ 
+   class C
+#        ^ definition [..] W3#C#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] W3#M1#
+     def get_fp1; @f + 1; end
+#        ^^^^^^^ definition [..] W3#C#get_fp1().
+#                 ^^ reference [..] W3#C#`@f`.
+   end
+ end
+ 
+ # Reference in one directly included module with def in other directly included module
+ 
+ module W4
+#       ^^ definition [..] W4#
+   module M0
+#         ^^ definition [..] W4#M0#
+     def get_f; @f; end
+#        ^^^^^ definition [..] W4#M0#get_f().
+#               ^^ reference [..] W4#M0#`@f`.
+   end
+ 
+   module M1
+#         ^^ definition [..] W4#M1#
+     def set_f; @f + 1; end
+#        ^^^^^ definition [..] W4#M1#set_f().
+#               ^^ reference [..] W4#M1#`@f`.
+   end
+ 
+   class C
+#        ^ definition [..] W4#C#
+     include M0
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] W4#M0#
+     include M1
+#    ^^^^^^^ reference [..] Module#include().
+#            ^^ reference [..] W4#M1#
+     def get_fp1; @f + 1; end
+#        ^^^^^^^ definition [..] W4#C#get_fp1().
+#                 ^^ reference [..] W4#C#`@f`.
+   end
+ end
+ 

--- a/test/scip/testdata/type_change.snapshot.rb
+++ b/test/scip/testdata/type_change.snapshot.rb
@@ -132,6 +132,10 @@
 #      | ```
    @k = nil
 #  ^^ definition [..] `<Class:C>`#`@k`.
+#  documentation
+#  | ```ruby
+#  | @k (T.untyped)
+#  | ```
  
    def change_type(b)
 #      ^^^^^^^^^^^ definition [..] C#change_type().
@@ -150,7 +154,7 @@
      @@g = nil
 #    ^^^ definition [..] `<Class:C>`#`@@g`.
      @k = nil
-#    ^^ definition [..] `<Class:C>`#`@k`.
+#    ^^ definition [..] C#`@k`.
      if b
        @f = 1
 #      ^^ reference (write) [..] C#`@f`.
@@ -165,12 +169,12 @@
 #      | @@g (Integer(1))
 #      | ```
        @k = 1
-#      ^^ reference (write) [..] `<Class:C>`#`@k`.
+#      ^^ reference (write) [..] C#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (Integer(1))
 #      | ```
-#      ^^^^^^ reference [..] `<Class:C>`#`@k`.
+#      ^^^^^^ reference [..] C#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (Integer(1))
@@ -189,12 +193,12 @@
 #      | @@g (String("g"))
 #      | ```
        @k = 'k'
-#      ^^ reference (write) [..] `<Class:C>`#`@k`.
+#      ^^ reference (write) [..] C#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (String("k"))
 #      | ```
-#      ^^^^^^^^ reference [..] `<Class:C>`#`@k`.
+#      ^^^^^^^^ reference [..] C#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (String("k"))
@@ -244,12 +248,14 @@
 #      | ```
 #      relation definition=[..] `<Class:C>`#`@@g`.
        @k = 1
-#      ^^ definition [..] `<Class:D>`#`@k`.
-#      ^^^^^^ reference [..] `<Class:D>`#`@k`.
+#      ^^ definition [..] D#`@k`.
+#      relation definition=[..] C#`@k`.
+#      ^^^^^^ reference [..] D#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (Integer(1))
 #      | ```
+#      relation definition=[..] C#`@k`.
      else
        @f = 'f'
 #      ^^ definition [..] D#`@f`.
@@ -266,12 +272,14 @@
 #      | ```
 #      relation definition=[..] `<Class:C>`#`@@g`.
        @k = 'k'
-#      ^^ definition [..] `<Class:D>`#`@k`.
-#      ^^^^^^^^ reference [..] `<Class:D>`#`@k`.
+#      ^^ definition [..] D#`@k`.
+#      relation definition=[..] C#`@k`.
+#      ^^^^^^^^ reference [..] D#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (String("k"))
 #      | ```
+#      relation definition=[..] C#`@k`.
      end
    end
  end

--- a/test/scip/testdata/type_change.snapshot.rb
+++ b/test/scip/testdata/type_change.snapshot.rb
@@ -156,11 +156,12 @@
 #    | @f (T.untyped)
 #    | ```
      @@g = nil
-#    ^^^ definition [..] `<Class:C>`#`@@g`.
+#    ^^^ definition [..] C#`@@g`.
 #    documentation
 #    | ```ruby
 #    | @@g (T.untyped)
 #    | ```
+#    relation definition=[..] `<Class:C>`#`@@g`.
      @k = nil
 #    ^^ definition [..] C#`@k`.
 #    documentation
@@ -175,11 +176,16 @@
 #      | @f (Integer(1))
 #      | ```
        @@g = 1
-#      ^^^ reference (write) [..] `<Class:C>`#`@@g`.
+#      ^^^ reference (write) [..] C#`@@g`.
 #      override_documentation
 #      | ```ruby
 #      | @@g (Integer(1))
 #      | ```
+#      documentation
+#      | ```ruby
+#      | @@g (T.untyped)
+#      | ```
+#      relation definition=[..] `<Class:C>`#`@@g`.
        @k = 1
 #      ^^ reference (write) [..] C#`@k`.
 #      override_documentation
@@ -199,11 +205,16 @@
 #      | @f (String("f"))
 #      | ```
        @@g = 'g'
-#      ^^^ reference (write) [..] `<Class:C>`#`@@g`.
+#      ^^^ reference (write) [..] C#`@@g`.
 #      override_documentation
 #      | ```ruby
 #      | @@g (String("g"))
 #      | ```
+#      documentation
+#      | ```ruby
+#      | @@g (T.untyped)
+#      | ```
+#      relation definition=[..] `<Class:C>`#`@@g`.
        @k = 'k'
 #      ^^ reference (write) [..] C#`@k`.
 #      override_documentation
@@ -246,52 +257,68 @@
 #       ^ reference [..] BasicObject#`!`().
 #        ^ reference local 1~#2066187318
        @f = 1
-#      ^^ definition [..] C#`@f`.
+#      ^^ definition [..] D#`@f`.
 #      documentation
 #      | ```ruby
 #      | @f (T.untyped)
 #      | ```
+#      relation definition=[..] C#`@f`.
        @@g = 1
-#      ^^^ definition [..] `<Class:C>`#`@@g`.
+#      ^^^ definition [..] D#`@@g`.
 #      documentation
 #      | ```ruby
 #      | @@g (T.untyped)
 #      | ```
+#      relation definition=[..] `<Class:C>`#`@@g`.
        @k = 1
-#      ^^ definition [..] C#`@k`.
+#      ^^ definition [..] D#`@k`.
 #      documentation
 #      | ```ruby
 #      | @k (T.untyped)
 #      | ```
-#      ^^^^^^ reference [..] C#`@k`.
+#      relation definition=[..] C#`@k`.
+#      ^^^^^^ reference [..] D#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (Integer(1))
 #      | ```
-     else
-       @f = 'f'
-#      ^^ definition [..] C#`@f`.
-#      documentation
-#      | ```ruby
-#      | @f (T.untyped)
-#      | ```
-       @@g = 'g'
-#      ^^^ definition [..] `<Class:C>`#`@@g`.
-#      documentation
-#      | ```ruby
-#      | @@g (T.untyped)
-#      | ```
-       @k = 'k'
-#      ^^ definition [..] C#`@k`.
 #      documentation
 #      | ```ruby
 #      | @k (T.untyped)
 #      | ```
-#      ^^^^^^^^ reference [..] C#`@k`.
+#      relation definition=[..] C#`@k`.
+     else
+       @f = 'f'
+#      ^^ definition [..] D#`@f`.
+#      documentation
+#      | ```ruby
+#      | @f (T.untyped)
+#      | ```
+#      relation definition=[..] C#`@f`.
+       @@g = 'g'
+#      ^^^ definition [..] D#`@@g`.
+#      documentation
+#      | ```ruby
+#      | @@g (T.untyped)
+#      | ```
+#      relation definition=[..] `<Class:C>`#`@@g`.
+       @k = 'k'
+#      ^^ definition [..] D#`@k`.
+#      documentation
+#      | ```ruby
+#      | @k (T.untyped)
+#      | ```
+#      relation definition=[..] C#`@k`.
+#      ^^^^^^^^ reference [..] D#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (String("k"))
 #      | ```
+#      documentation
+#      | ```ruby
+#      | @k (T.untyped)
+#      | ```
+#      relation definition=[..] C#`@k`.
      end
    end
  end

--- a/test/scip/testdata/type_change.snapshot.rb
+++ b/test/scip/testdata/type_change.snapshot.rb
@@ -132,10 +132,6 @@
 #      | ```
    @k = nil
 #  ^^ definition [..] `<Class:C>`#`@k`.
-#  documentation
-#  | ```ruby
-#  | @k (T.untyped)
-#  | ```
  
    def change_type(b)
 #      ^^^^^^^^^^^ definition [..] C#change_type().
@@ -151,23 +147,10 @@
 #                  | ```
      @f = nil
 #    ^^ definition [..] C#`@f`.
-#    documentation
-#    | ```ruby
-#    | @f (T.untyped)
-#    | ```
      @@g = nil
-#    ^^^ definition [..] C#`@@g`.
-#    documentation
-#    | ```ruby
-#    | @@g (T.untyped)
-#    | ```
-#    relation definition=[..] `<Class:C>`#`@@g`.
+#    ^^^ definition [..] `<Class:C>`#`@@g`.
      @k = nil
-#    ^^ definition [..] C#`@k`.
-#    documentation
-#    | ```ruby
-#    | @k (T.untyped)
-#    | ```
+#    ^^ definition [..] `<Class:C>`#`@k`.
      if b
        @f = 1
 #      ^^ reference (write) [..] C#`@f`.
@@ -176,23 +159,18 @@
 #      | @f (Integer(1))
 #      | ```
        @@g = 1
-#      ^^^ reference (write) [..] C#`@@g`.
+#      ^^^ reference (write) [..] `<Class:C>`#`@@g`.
 #      override_documentation
 #      | ```ruby
 #      | @@g (Integer(1))
 #      | ```
-#      documentation
-#      | ```ruby
-#      | @@g (T.untyped)
-#      | ```
-#      relation definition=[..] `<Class:C>`#`@@g`.
        @k = 1
-#      ^^ reference (write) [..] C#`@k`.
+#      ^^ reference (write) [..] `<Class:C>`#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (Integer(1))
 #      | ```
-#      ^^^^^^ reference [..] C#`@k`.
+#      ^^^^^^ reference [..] `<Class:C>`#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (Integer(1))
@@ -205,23 +183,18 @@
 #      | @f (String("f"))
 #      | ```
        @@g = 'g'
-#      ^^^ reference (write) [..] C#`@@g`.
+#      ^^^ reference (write) [..] `<Class:C>`#`@@g`.
 #      override_documentation
 #      | ```ruby
 #      | @@g (String("g"))
 #      | ```
-#      documentation
-#      | ```ruby
-#      | @@g (T.untyped)
-#      | ```
-#      relation definition=[..] `<Class:C>`#`@@g`.
        @k = 'k'
-#      ^^ reference (write) [..] C#`@k`.
+#      ^^ reference (write) [..] `<Class:C>`#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (String("k"))
 #      | ```
-#      ^^^^^^^^ reference [..] C#`@k`.
+#      ^^^^^^^^ reference [..] `<Class:C>`#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (String("k"))
@@ -264,29 +237,19 @@
 #      | ```
 #      relation definition=[..] C#`@f`.
        @@g = 1
-#      ^^^ definition [..] D#`@@g`.
+#      ^^^ definition [..] `<Class:D>`#`@@g`.
 #      documentation
 #      | ```ruby
 #      | @@g (T.untyped)
 #      | ```
 #      relation definition=[..] `<Class:C>`#`@@g`.
        @k = 1
-#      ^^ definition [..] D#`@k`.
-#      documentation
-#      | ```ruby
-#      | @k (T.untyped)
-#      | ```
-#      relation definition=[..] C#`@k`.
-#      ^^^^^^ reference [..] D#`@k`.
+#      ^^ definition [..] `<Class:D>`#`@k`.
+#      ^^^^^^ reference [..] `<Class:D>`#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (Integer(1))
 #      | ```
-#      documentation
-#      | ```ruby
-#      | @k (T.untyped)
-#      | ```
-#      relation definition=[..] C#`@k`.
      else
        @f = 'f'
 #      ^^ definition [..] D#`@f`.
@@ -296,29 +259,19 @@
 #      | ```
 #      relation definition=[..] C#`@f`.
        @@g = 'g'
-#      ^^^ definition [..] D#`@@g`.
+#      ^^^ definition [..] `<Class:D>`#`@@g`.
 #      documentation
 #      | ```ruby
 #      | @@g (T.untyped)
 #      | ```
 #      relation definition=[..] `<Class:C>`#`@@g`.
        @k = 'k'
-#      ^^ definition [..] D#`@k`.
-#      documentation
-#      | ```ruby
-#      | @k (T.untyped)
-#      | ```
-#      relation definition=[..] C#`@k`.
-#      ^^^^^^^^ reference [..] D#`@k`.
+#      ^^ definition [..] `<Class:D>`#`@k`.
+#      ^^^^^^^^ reference [..] `<Class:D>`#`@k`.
 #      override_documentation
 #      | ```ruby
 #      | @k (String("k"))
 #      | ```
-#      documentation
-#      | ```ruby
-#      | @k (T.untyped)
-#      | ```
-#      relation definition=[..] C#`@k`.
      end
    end
  end

--- a/test/scip_test_runner.cc
+++ b/test/scip_test_runner.cc
@@ -223,14 +223,8 @@ void formatSnapshot(const scip::Document &document, FormatOptions options, std::
                 continue;
             }
             auto &symbolInfo = symbolTable[occ.symbol()];
-            bool isDefinedByAnother = ([&]() -> bool {
-                for (auto &rel : symbolInfo.relationships()) {
-                    if (rel.is_definition()) {
-                        return true;
-                    }
-                }
-                return false;
-            })();
+            bool isDefinedByAnother =
+                absl::c_any_of(symbolInfo.relationships(), [](const auto &rel) -> bool { return rel.is_definition(); });
             if (!isDefinition && !isDefinedByAnother) {
                 continue;
             }


### PR DESCRIPTION
### Motivation

Mixins are used very frequently. We should have better code nav for them.

### TODO

- [ ] Manually test Go to Def and Find References when an undeclared field is present in different files. (Currently, this will create two different SymbolInformation values for the same symbol in different files.)
- [ ] Manually test an inheritance hierarchy involving multiple classes. In that situation, it seems like the transitive linkage should be happening through relation traversal. E.g. if `C < B < A` then `C.@f` would be defined by `B.@f` which would be defined by `A.@f`. In that case, we should check if all references to `A.@f` show up when we do Find references on `C.@f`. There is a TODO related to this, which should be updated/removed.
- [x] Remove debugging statements
- [x] Right now, we emit a SymbolInformation is emitted when a definition is emitted, but it is possible for a field inside a class coming from a mixin to not have any definition inside the class. Consider:
    ```ruby
    module M
        def set_f_0
            @f = 0
        end
    end
    class C
        def set_f_1
            @f = 1
        end
    end
    class D < C
        include M
        def get_f
            @f
        end
    end
    ```
    The code is currently set up so that:
    1. The reference inside a class will emit a symbol for the further ancestor which mentions the class. (However, strictly speaking, we don't require a definition inside that ancestor's body right now... -- but it would be strange for a superclass to access a field that it never sets, so...). In this case, the occurrence for `@f` in `get_f` will use `C#@f`. (← Not sure if this is a good idea though, see next point.)
    2. We emit a reference relationship for symbols that are mentioned (transitively) in mixins when emitting the _definition_. In this case, there is no definition for `@f` inside `D`, so no relationship is emitted. (Additionally, it is not guaranteed that we can modify `C#@f`'s `SymbolInformation`, since `C` may be coming from a different index altogether. -- This makes me question if we should be instead using `D@#f` for the occurrence of `@f` instead.)

    It is unclear to me what exactly we should do. There are a couple of options:
    1. Emit a fake definition for `D#@f` (what location should be used?), and attach reference relationships to it which connect it to `M#@f` and `C#@f`.
    2. Emit 2 occurrences for every `@f` in `D`, one for `C#@f` and another for `M#@f`.
- [x] More tests, including for complex include chains

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
