### PR TITLE
fix: Fix crash with defaulted lambda parameters.

### DIFF
--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -69,8 +69,8 @@ static bool isTemporary(const core::GlobalState &gs, const core::LocalVariable &
     }
     auto n = var._name;
     return n == Names::blockPreCallTemp() || n == Names::blockTemp() || n == Names::blockPassTemp() ||
-           n == Names::blkArg() || n == Names::blockCall() || n == Names::blockBreakAssign() || n == Names::forTemp() ||
-           n == Names::keepForCfgTemp() ||
+           n == Names::blkArg() || n == Names::blockCall() || n == Names::blockBreakAssign() ||
+           n == Names::argPresent() || n == Names::forTemp() || n == Names::keepForCfgTemp() ||
            // Insert checks because sometimes temporaries are initialized with a 0 unique value. 😬
            n == Names::finalReturn() || n == NameRef::noName() || n == Names::blockCall() || n == Names::selfLocal() ||
            n == Names::unconditional();

--- a/test/scip/testdata/blocks_lambdas_procs.rb
+++ b/test/scip/testdata/blocks_lambdas_procs.rb
@@ -49,3 +49,15 @@ def prc
   p3.call(x: 3)
   p4.call(x: 4)
 end
+
+def call_block(&blk)
+  blk.call
+end
+
+def use_block_with_defaults
+  call_block do |oops: nil|
+  end
+
+  call_block do |oops = "nil"|
+  end
+end

--- a/test/scip/testdata/blocks_lambdas_procs.snapshot.rb
+++ b/test/scip/testdata/blocks_lambdas_procs.snapshot.rb
@@ -141,3 +141,23 @@
 #  ^^ reference local 11~#1283111692
 #     ^^^^ reference [..] Proc#call().
  end
+ 
+ def call_block(&blk)
+#    ^^^^^^^^^^ definition [..] Object#call_block().
+#                ^^^ definition local 1~#1487178087
+   blk.call
+#  ^^^ reference local 1~#1487178087
+ end
+ 
+ def use_block_with_defaults
+#    ^^^^^^^^^^^^^^^^^^^^^^^ definition [..] Object#use_block_with_defaults().
+   call_block do |oops: nil|
+#  ^^^^^^^^^^ reference [..] Object#call_block().
+#                 ^^^^^ definition local 1~#4118119342
+   end
+ 
+   call_block do |oops = "nil"|
+#  ^^^^^^^^^^ reference [..] Object#call_block().
+#                 ^^^^ definition local 2~#4118119342
+   end
+ end


### PR DESCRIPTION
### Motivation

Triggered when trying to index Homebrew/brew.

### Test plan

Added test crashes without this patch.
