### PR TITLE
feat: Index `# typed: false` files by default

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -57,7 +57,9 @@ public:
 
     void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &m = ast::cast_tree_nonnull<ast::MethodDef>(tree);
-        if (ctx.file.data(ctx).strictLevel < core::StrictLevel::True || m.symbol.data(ctx)->flags.isOverloaded ||
+        // With scip-ruby, we might as well try making progress with untyped code.
+        auto minStrictLevel = ctx.state.isSCIPRuby ? core::StrictLevel::False : core::StrictLevel::True;
+        if (ctx.file.data(ctx).strictLevel < minStrictLevel || m.symbol.data(ctx)->flags.isOverloaded ||
             (m.symbol.data(ctx)->flags.isAbstract && ctx.file.data(ctx).compiledLevel != core::CompiledLevel::True)) {
             return;
         }

--- a/test/scip/testdata/typed_false.rb
+++ b/test/scip/testdata/typed_false.rb
@@ -1,0 +1,11 @@
+# typed: false
+
+class C
+  def f
+    @f = 0
+  end
+
+  def g(x)
+    x + @f + f
+  end
+end

--- a/test/scip/testdata/typed_false.snapshot.rb
+++ b/test/scip/testdata/typed_false.snapshot.rb
@@ -1,0 +1,20 @@
+ # typed: false
+ 
+ class C
+#      ^ definition [..] C#
+   def f
+#      ^ definition [..] C#f().
+     @f = 0
+#    ^^ definition [..] C#`@f`.
+#    ^^^^^^ reference [..] C#`@f`.
+   end
+ 
+   def g(x)
+#      ^ definition [..] C#g().
+#        ^ definition local 1~#3792446982
+     x + @f + f
+#    ^ reference local 1~#3792446982
+#        ^^ reference [..] C#`@f`.
+#             ^ reference [..] C#f().
+   end
+ end


### PR DESCRIPTION
### Motivation

Fixes #30. We still need to do extra error suppression (https://github.com/sourcegraph/scip-ruby/issues/131), will do that in a follow-up PR instead of bundling it here.

### Test plan

Everything else is unchanged, so only going with a small test case for now.
