### PR TITLE
fix: Use default --index-file argument for convenience.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,27 +60,30 @@ Run `scip-ruby` along with some information about your gem.
   automatically to determine which files to index.
     ```bash
     # Uses the latest revision as the version - prefer this if you will index every commit
-    bundle exec scip-ruby --index-file index.scip --gem-metadata "my-gem-name@$(git rev-parse HEAD)"
+    bundle exec scip-ruby --gem-metadata "my-gem-name@$(git rev-parse HEAD)"
 
     # Uses the latest tag as the version - prefer this if you're only indexing specific tags
-    bundle exec scip-ruby --index-file index.scip --gem-metadata "my-gem-name@$(git describe --tags --abbrev=0)"
+    bundle exec scip-ruby --gem-metadata "my-gem-name@$(git describe --tags --abbrev=0)"
     ```
 - If you don't have a `sorbet/config` file, add an extra path argument
   to index all files in the project.
     ```bash
     # Uses the latest revision as the version - prefer this if you will index every commit
-    bundle exec scip-ruby . --index-file index.scip --gem-metadata "my-gem-name@$(git rev-parse HEAD)"
+    bundle exec scip-ruby . --gem-metadata "my-gem-name@$(git rev-parse HEAD)"
 
     # Uses the latest tag as the version - prefer this if you're only indexing specific tags
-    bundle exec scip-ruby . --index-file index.scip --gem-metadata "my-gem-name@$(git describe --tags --abbrev=0)"
+    bundle exec scip-ruby . --gem-metadata "my-gem-name@$(git describe --tags --abbrev=0)"
     ```
 
-The generated `index.scip` file can be uploaded
-to a Sourcegraph instance using the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli).
+These commands will output a SCIP index to `index.scip` (overridable via `--index-file`).
+The SCIP index can be uploaded to a Sourcegraph instance
+using the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli)'s
+[upload command](https://docs.sourcegraph.com/cli/references/code-intel/upload).
 
 If you're curious about the internals of the index,
 such as which files were indexed,
-check out the [SCIP CLI](https://github.com/sourcegraph/scip/blob/main/docs/CLI.md).
+check out the [SCIP CLI](https://github.com/sourcegraph/scip/blob/main/docs/CLI.md)
+and the [SCIP development docs](https://github.com/sourcegraph/scip/blob/main/Development.md#debugging).
 
 ## Download binary and index
 

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -1279,16 +1279,19 @@ public:
                        sorbet_version, scip_ruby_sync_upstream_sorbet_sha);
             throw sorbet::EarlyReturnWithCode(0);
         }
+        string indexFilePath{};
         if (providedOptions.count("index-file") > 0) {
-            return make_unique<SCIPSemanticExtension>(
-                providedOptions["index-file"].as<string>(),
-                scip_indexer::GemMetadata::tryParseOrDefault(
-                    providedOptions.count("gem-metadata") > 0 ? providedOptions["gem-metadata"].as<string>() : ""));
+            indexFilePath = providedOptions["index-file"].as<string>();
+        } else {
+            indexFilePath = "index.scip";
         }
-        return this->defaultInstance();
+        return make_unique<SCIPSemanticExtension>(
+            indexFilePath,
+            scip_indexer::GemMetadata::tryParseOrDefault(
+                providedOptions.count("gem-metadata") > 0 ? providedOptions["gem-metadata"].as<string>() : ""));
     };
     virtual unique_ptr<SemanticExtension> defaultInstance() const override {
-        return make_unique<SCIPSemanticExtension>("", scip_indexer::GemMetadata::tryParseOrDefault(""));
+        return make_unique<SCIPSemanticExtension>("index.scip", scip_indexer::GemMetadata::tryParseOrDefault(""));
     };
     static vector<SemanticExtensionProvider *> getProviders();
     virtual ~SCIPSemanticExtensionProvider() = default;


### PR DESCRIPTION
### Motivation

Simplifies the invocation, the `--index-file` is kinda' not terribly useful for most people.

### Test plan

Tested manually against `shopify-api-ruby`.