### PR TITLE
fix: Try to infer gem name and version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           name: ci-build-log
           path: log
+      - name: "🏋️‍♂️ Run unit tests"
+        run: rm log && ./bazel test //test/scip:unit_tests --config=dbg
       - name: "🏋️‍♂️ Run snapshot tests"
         run: rm log && ./bazel test //test/scip --config=dbg
       # Repo tests are kinda' broken right now because the bundle cache step needs synchronization

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
           name: ci-build-log
           path: log
       - name: "🏋️‍♂️ Run unit tests"
-        run: rm log && ./bazel test //test/scip:unit_tests --config=dbg
+        run: ./bazel test //test/scip:unit_tests --config=dbg
       - name: "🏋️‍♂️ Run snapshot tests"
-        run: rm log && ./bazel test //test/scip --config=dbg
+        run: ./bazel test //test/scip --config=dbg
       # Repo tests are kinda' broken right now because the bundle cache step needs synchronization
       #
       # - name: "🏋️‍♂️ Build repo tests"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Run `scip-ruby` along with some information about your gem.
 - If you don't have a `sorbet/config` file, add an extra path argument
   to index all files in the project.
     ```bash
-    # Uses the latest revision as the version - prefer this if you will index every commit
     bundle exec scip-ruby .
     ```
 

--- a/README.md
+++ b/README.md
@@ -54,28 +54,21 @@ to download and install fetch `scip-ruby`.
 
 Run `scip-ruby` along with some information about your gem.
 
-<!-- TODO: Add support for defaulting. -->
-
 - If you have a `sorbet/config` file, that will be picked up
   automatically to determine which files to index.
     ```bash
-    # Uses the latest revision as the version - prefer this if you will index every commit
-    bundle exec scip-ruby --gem-metadata "my-gem-name@$(git rev-parse HEAD)"
-
-    # Uses the latest tag as the version - prefer this if you're only indexing specific tags
-    bundle exec scip-ruby --gem-metadata "my-gem-name@$(git describe --tags --abbrev=0)"
+    bundle exec scip-ruby
     ```
 - If you don't have a `sorbet/config` file, add an extra path argument
   to index all files in the project.
     ```bash
     # Uses the latest revision as the version - prefer this if you will index every commit
-    bundle exec scip-ruby . --gem-metadata "my-gem-name@$(git rev-parse HEAD)"
-
-    # Uses the latest tag as the version - prefer this if you're only indexing specific tags
-    bundle exec scip-ruby . --gem-metadata "my-gem-name@$(git describe --tags --abbrev=0)"
+    bundle exec scip-ruby .
     ```
 
 These commands will output a SCIP index to `index.scip` (overridable via `--index-file`).
+The gem name and version will be inferred from config files (overridable via `--gem-metadata`).
+
 The SCIP index can be uploaded to a Sourcegraph instance
 using the [Sourcegraph CLI](https://github.com/sourcegraph/src-cli)'s
 [upload command](https://docs.sourcegraph.com/cli/references/code-intel/upload).
@@ -97,7 +90,7 @@ curl -L "https://github.com/sourcegraph/scip-ruby/releases/latest/download/scip-
 # If using in CI with 'set -e', make sure to wrap the
 # scip-ruby invocation in 'set +e' followed by 'set -e'
 # so that indexing failures are non-blocking.
-./scip-ruby --index-file index.scip --gem-metadata "my-gem-name@M.N.P"
+./scip-ruby
 ```
 
 The generated index can be uploaded to a Sourcegraph instance

--- a/common/FileOps.h
+++ b/common/FileOps.h
@@ -33,6 +33,8 @@ public:
     // NOTE: This does not create parent directories if they exist.
     static bool ensureDir(std::string_view path);
 
+    static std::string getCurrentDir();
+
     // NOTE: this is a minimal wrapper around rmdir, and as such will raise an exception if the directory is not empty
     // when it's removed.
     static void removeDir(std::string_view path);

--- a/common/FileSystem.cc
+++ b/common/FileSystem.cc
@@ -12,6 +12,10 @@ void OSFileSystem::writeFile(string_view filename, string_view text) {
     return FileOps::write(filename, text);
 }
 
+std::string OSFileSystem::getCurrentDir() const {
+    return FileOps::getCurrentDir();
+}
+
 vector<string> OSFileSystem::listFilesInDir(string_view path, const UnorderedSet<std::string> &extensions,
                                             bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
                                             const std::vector<std::string> &relativeIgnorePatterns) const {

--- a/common/FileSystem.h
+++ b/common/FileSystem.h
@@ -21,6 +21,9 @@ public:
     /** Writes the specified data to the given file. */
     virtual void writeFile(std::string_view filename, std::string_view text) = 0;
 
+    /** Gets the path for the current directory. */
+    virtual std::string getCurrentDir() const = 0;
+
     /**
      * Returns a list of all files in the given directory. Returns paths that include the path to directory.
      *
@@ -45,6 +48,7 @@ public:
 
     std::string readFile(std::string_view path) const override;
     void writeFile(std::string_view filename, std::string_view text) override;
+    std::string getCurrentDir() const override;
     std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
                                             bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
                                             const std::vector<std::string> &relativeIgnorePatterns) const override;

--- a/common/common.cc
+++ b/common/common.cc
@@ -12,6 +12,7 @@
 #include <dirent.h>
 #include <exception>
 #include <memory>
+#include <sys/param.h>
 #include <vector>
 
 #include <sys/stat.h>
@@ -85,6 +86,12 @@ bool sorbet::FileOps::ensureDir(string_view path) {
     }
 
     return true;
+}
+
+std::string sorbet::FileOps::getCurrentDir() {
+    char buf[MAXPATHLEN + 1];
+    getcwd(buf, sizeof(buf));
+    return std::string(buf);
 }
 
 void sorbet::FileOps::removeDir(string_view path) {

--- a/docs/scip-ruby/CONTRIBUTING.md
+++ b/docs/scip-ruby/CONTRIBUTING.md
@@ -147,7 +147,13 @@ scip-ruby myfile.rb --index-file index.scip
 
 ### Running tests
 
-Run snapshot tests, which are self-contained:
+There are currently 3 kinds of tests:
+- Snapshot tests: These cover indexer output.
+- Unit tests: These cover some internals which are not possible
+  to test via snapshots.
+- Repo/Integration tests: These try to index an OSS repo using scip-ruby.
+
+To run snapshot tests, which are self-contained:
 
 ```
 ./bazel test //test/scip --config=dbg
@@ -157,6 +163,12 @@ Updating snapshots:
 
 ```
 ./bazel test //test/scip:update --config=dbg
+```
+
+You can run unit tests using:
+
+```
+./bazel test //test/scip:unit_tests --config=dbg
 ```
 
 WARNING: Repo tests are kinda' broken right now; they're disabled
@@ -181,6 +193,11 @@ you add a new test, you should create matching `.snapshot.rb` files
 (which may be empty) for all new `.rb` files,
 since those are used as inputs to Bazel.
 If you know of a way to get rid of that annoyance, submit a PR.
+
+### Writing a new unit test
+
+See the existing unit tests in `scip_test_runner.cc`
+and follow the same structure.
 
 ### Writing a new repo test
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1125,6 +1125,9 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> what, const 
 
         {
             ProgressIndicator cfgInferProgress(opts.showProgress, "CFG+Inference", what.size());
+            for (auto &extension : gs.semanticExtensions) {
+                extension->prepareForTypechecking(gs);
+            }
             workers.multiplexJob("typecheck", [&gs, &opts, epoch, &epochManager, &preemptionManager, fileq, outputq,
                                                cancelable, intentionallyLeakASTs]() {
                 vector<core::FileRef> processedFiles;

--- a/main/pipeline/semantic_extension/SemanticExtension.h
+++ b/main/pipeline/semantic_extension/SemanticExtension.h
@@ -27,6 +27,7 @@ class CFG;
 namespace pipeline::semantic_extension {
 class SemanticExtension {
 public:
+    virtual void prepareForTypechecking(const core::GlobalState &) = 0;
     virtual void finishTypecheckFile(const core::GlobalState &, const core::FileRef &) const = 0;
     virtual void finishTypecheck(const core::GlobalState &) const = 0;
     virtual void typecheck(const core::GlobalState &, core::FileRef file, cfg::CFG &, ast::MethodDef &) const = 0;

--- a/plugin_injector/plugin_injector.cc
+++ b/plugin_injector/plugin_injector.cc
@@ -186,6 +186,8 @@ public:
 
     virtual void run(core::MutableContext &ctx, ast::ClassDef *klass) const override{};
 
+    virtual void prepareForTypechecking(const core::GlobalState &gs) override{};
+
     virtual void typecheck(const core::GlobalState &gs, core::FileRef file, cfg::CFG &cfg,
                            ast::MethodDef &md) const override {
         if (!shouldCompile(gs, file)) {

--- a/scip_indexer/Debug.h
+++ b/scip_indexer/Debug.h
@@ -55,6 +55,8 @@ template <typename V, typename Fn> std::string showVec(const V &v, Fn f) {
     return out.str();
 }
 
+extern const sorbet::core::ErrorClass SCIPRubyDebug;
+
 void _log_debug(const sorbet::core::GlobalState &gs, sorbet::core::Loc loc, std::string s);
 } // namespace sorbet::scip_indexer
 

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -1285,7 +1285,9 @@ public:
     void injectOptions(cxxopts::Options &optsBuilder) const override {
         optsBuilder.add_options("indexer")("index-file", "Output SCIP index to a directory, which must already exist",
                                            cxxopts::value<string>())(
-            "gem-metadata", "Metadata in 'name@version' format to be used for cross-repository code navigation.",
+            "gem-metadata",
+            "Metadata in 'name@version' format to be used for cross-repository code navigation. For repositories which "
+            "index every commit, the SHA should be used for the version instead of a git tag (or equivalent).",
             cxxopts::value<string>());
     };
     unique_ptr<SemanticExtension> readOptions(cxxopts::ParseResult &providedOptions) const override {

--- a/scip_indexer/SCIPSymbolRef.cc
+++ b/scip_indexer/SCIPSymbolRef.cc
@@ -1,8 +1,11 @@
 // NOTE: Protobuf headers should go first since they use poisoned functions.
 #include "proto/SCIP.pb.h"
 
+#include <filesystem>
 #include <optional>
+#include <regex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"
@@ -10,6 +13,7 @@
 #include "absl/strings/str_replace.h"
 #include "spdlog/fmt/fmt.h"
 
+#include "common/FileSystem.h"
 #include "common/sort.h"
 #include "core/Loc.h"
 #include "main/lsp/LSPLoop.h"
@@ -28,6 +32,161 @@ string showRawRelationshipsMap(const core::GlobalState &gs, const RelationshipsM
             "{}: (inherited={}, mixins={})", ugsr.showRaw(gs), result.inherited.showFullName(gs),
             showVec(*result.mixedIn, [&gs](const auto &mixin) -> string { return mixin.showFullName(gs); }));
     });
+}
+
+using GMEKind = GemMetadataError::Kind;
+GemMetadataError configNotFoundError =
+    GemMetadataError{GMEKind::Error, "Failed to find .gemspec file for identifying gem version"};
+GemMetadataError multipleGemspecWarning = GemMetadataError{
+    GMEKind::Warning, "Found multiple .gemspec files when trying to infer Gem name and version; picking the first one "
+                      "lexicographically. Consider passing --gem-metadata name@version explicitly instead"};
+GemMetadataError failedToParseGemspecWarning = GemMetadataError{
+    GMEKind::Warning, "Failed to parse .gemspec file for inferring gem name and version. Consider passing "
+                      "--gem-metadata name@version explicitly instead"};
+GemMetadataError failedToParseNameFromGemspecWarning = GemMetadataError{
+    GMEKind::Warning, "Failed to parse gem name from .gemspec file; using the .gemspec's base name as a proxy"};
+GemMetadataError failedToParseVersionFromGemspecWarning =
+    GemMetadataError{GMEKind::Warning, "Failed to parse gem version from .gemspec file"};
+GemMetadataError failedToParseGemfileLockWarning{GMEKind::Warning,
+                                                 "Failed to extract name and version from Gemfile.lock"};
+
+pair<GemMetadata, vector<GemMetadataError>> GemMetadata::readFromGemfileLock(const string &contents) {
+    istringstream lines(contents);
+    bool sawPATH = false;
+    bool sawSpecs = false;
+    optional<string> name;
+    optional<string> version;
+    vector<GemMetadataError> errors;
+    // PATH
+    //   remote: .
+    //   specs:
+    //     my_gem_name (M.N.P)
+    for (string line; getline(lines, line);) {
+        if (absl::StartsWith(line, "PATH")) {
+            sawPATH = true;
+            continue;
+        }
+        if (sawPATH && absl::StrContains(line, "specs:")) {
+            sawSpecs = true;
+            continue;
+        }
+        if (sawSpecs) {
+            std::regex specLineRegex(R"END(\s+([A-Za-z0-9_\-]+)\s*\((.+)\)\s*)END");
+            std::smatch matches;
+            if (std::regex_match(line, matches, specLineRegex)) {
+                name = matches[1].str();
+                version = matches[2].str();
+            }
+            break;
+        }
+    }
+    if (!name.has_value()) {
+        errors.push_back(failedToParseGemfileLockWarning);
+    }
+    return {GemMetadata{name.value_or(""), version.value_or("")}, errors};
+}
+
+pair<GemMetadata, vector<GemMetadataError>> GemMetadata::readFromGemspec(const string &contents) {
+    optional<string> name;
+    optional<string> version;
+    vector<GemMetadataError> errors;
+
+    std::regex stringKeyRegex(R"END(\s*["'](.+)["'](.freeze)?)END");
+    const auto readValue = [&](const string_view line) -> string {
+        vector<string> entries = absl::StrSplit(line, '=');
+        if (entries.size() != 2) {
+            return "";
+        }
+        std::smatch matches;
+        if (std::regex_match(entries[1], matches, stringKeyRegex)) {
+            return matches[1].str();
+        }
+        return "";
+    };
+    istringstream lines(contents);
+    for (string line; std::getline(lines, line);) {
+        if (name.has_value() && version.has_value()) {
+            break;
+        }
+        if (!name.has_value() && absl::StrContains(line, ".name =")) {
+            name = readValue(line);
+            if (name->empty()) {
+                errors.push_back(failedToParseNameFromGemspecWarning);
+                continue;
+            }
+        }
+        // NOTE: In some cases, the version may be stored symbolically,
+        // in which case this parsing will fail.
+        if (!version.has_value() && absl::StrContains(line, ".version =")) {
+            version = readValue(line);
+            if (version->empty()) {
+                errors.push_back(failedToParseVersionFromGemspecWarning);
+                continue;
+            }
+        }
+    }
+    if (!name.has_value() || !version.has_value()) {
+        errors.push_back(failedToParseGemspecWarning);
+    }
+    return {GemMetadata{name.value_or(""), version.value_or("")}, errors};
+}
+
+pair<GemMetadata, vector<GemMetadataError>> GemMetadata::readFromConfig(const FileSystem &fs) {
+    UnorderedSet<string> extensions{".lock", ".gemspec"};
+    auto paths = fs.listFilesInDir(".", extensions, /*recursive*/ false, {}, {});
+    vector<GemMetadataError> errors;
+    auto currentDirName = [&fs]() -> std::string {
+        auto currentDirPath = fs.getCurrentDir();
+        ENFORCE(!currentDirPath.empty());
+        while (currentDirPath.back() == '/') {
+            currentDirPath.pop_back();
+            ENFORCE(!currentDirPath.empty());
+        }
+        return std::filesystem::path(move(currentDirPath)).filename();
+    };
+    if (paths.empty()) {
+        errors.push_back(configNotFoundError);
+        return {GemMetadata(currentDirName(), "latest"), errors};
+    }
+    optional<std::string> name{};
+    optional<std::string> version{};
+    auto copyState = [&](auto &m, auto &errs) {
+        name = m.name().empty() ? name : m.name();
+        version = m.version().empty() ? version : m.version();
+        absl::c_copy(errs, std::back_inserter(errors));
+    };
+    for (auto &path : paths) {
+        if (!absl::EndsWith(path, "Gemfile.lock")) {
+            continue;
+        }
+        auto [gemMetadata, parseErrors] = GemMetadata::readFromGemfileLock(fs.readFile(path));
+        if (!gemMetadata.name().empty() && !gemMetadata.version().empty()) {
+            return {gemMetadata, {}};
+        }
+        copyState(gemMetadata, parseErrors);
+        break;
+    }
+    string gemspecPath{};
+    for (auto &filename : paths) {
+        if (!absl::EndsWith(filename, ".gemspec")) {
+            continue;
+        }
+        gemspecPath = filename;
+        auto [gemMetadata, parseErrors] = GemMetadata::readFromGemspec(fs.readFile(filename));
+        if (!gemMetadata.name().empty() && !gemMetadata.version().empty()) {
+            return {gemMetadata, {}};
+        }
+        copyState(gemMetadata, parseErrors);
+        break;
+    }
+    if (name.has_value() && version.has_value()) {
+        errors.clear();
+    }
+    if (!name.has_value() && !gemspecPath.empty()) {
+        vector<string_view> components = absl::StrSplit(gemspecPath, '/');
+        name = string(absl::StripSuffix(components.back(), ".gemspec"));
+    }
+    return {GemMetadata(name.value_or(currentDirName()), version.value_or("latest")), errors};
 }
 
 // Try to compute a scip::Symbol for this value.

--- a/test/helpers/MockFileSystem.h
+++ b/test/helpers/MockFileSystem.h
@@ -17,6 +17,7 @@ public:
     std::string readFile(std::string_view path) const override;
     void writeFile(std::string_view filename, std::string_view text) override;
     void deleteFile(std::string_view filename);
+    std::string getCurrentDir() const override;
     std::vector<std::string> listFilesInDir(std::string_view path, const UnorderedSet<std::string> &extensions,
                                             bool recursive, const std::vector<std::string> &absoluteIgnorePatterns,
                                             const std::vector<std::string> &relativeIgnorePatterns) const override;

--- a/test/scip/scip_test.bzl
+++ b/test/scip/scip_test.bzl
@@ -27,6 +27,7 @@ def scip_test_suite(paths, multifile_paths):
         else:
             file_groups[d] = [p]
 
+    tests.append(scip_unit_tests())
     for dir, files in file_groups.items():
         names = scip_multifile_test(dir, files)
         tests.append(names[0])
@@ -40,6 +41,18 @@ def scip_test_suite(paths, multifile_paths):
         name = "update",
         tests = updates,
     )
+
+def scip_unit_tests():
+    test_name = "unit_tests"
+    args = ["unit_tests"]
+    native.sh_test(
+        name = "unit_tests",
+        srcs = ["scip_test_runner.sh"],
+        args = ["only_unit_tests"],
+        data = ["//test:scip_test_runner"],
+        size = "small",
+    )
+    return "unit_tests"
 
 def scip_test(path):
     if not path.endswith(".rb") or path.endswith(".snapshot.rb"):


### PR DESCRIPTION
### Motivation

This will be useful for auto-indexing because we'd like the indexer to infer the Gem name and version instead of having it be input from the command-line (the logic needs to live _somewhere_, so it might as well live in the indexer).

TODO:
- [x] Update README to remove the argument `--gem-metadata` by default.
- [x] Add unit tests for parsing.

### Test plan

Tested manually against shopify-api-ruby. I will add some automated tests.