### PR TITLE
cleanup: Use test-relative paths by cd-ing before testing.

### DIFF
--- a/test/helpers/expectations.cc
+++ b/test/helpers/expectations.cc
@@ -150,7 +150,11 @@ Expectations getExpectationsForTest(string_view parentDir, string_view testName)
     bool found = false;
     Expectations exp;
     exp.isFolderTest = false;
-    exp.basename = testName.substr(parentDir.size() + 1);
+    if (absl::StartsWith(testName, parentDir)) {
+        exp.basename = testName.substr(parentDir.size() + 1);
+    } else {
+        exp.basename = testName;
+    }
     exp.folder = parentDir;
     exp.folder += "/";
     exp.testName = testName;

--- a/test/scip/scip_test.bzl
+++ b/test/scip/scip_test.bzl
@@ -62,12 +62,12 @@ def scip_test(path):
         return None
     test_name = basename(path)[:-3]
     snapshot_path = path[:-3] + ".snapshot.rb"
-    args = ["--input=$(location {})".format(path), "--output=$(location {})".format(snapshot_path)]
+    args = ["--input=$(location {})".format(path)]
     data = [path, snapshot_path, "//test:scip_test_runner"]
     return _make_test(test_name, args, data)
 
 def scip_multifile_test(dir, filepaths):
-    args = ["--input=$(location {})".format(dir), "--output=$(location {})".format(dir)]
+    args = ["--input=$(location {})".format(dir)]
     data = ["//test:scip_test_runner", "//test/scip:{}".format(dir)]
     for filepath in filepaths:
         path_without_ext, ext = split_extension(filepath)

--- a/test/scip/testdata/multifile/gem-map/gem-map.json
+++ b/test/scip/testdata/multifile/gem-map/gem-map.json
@@ -1,2 +1,2 @@
-{"path": "test/scip/testdata/multifile/gem-map/downstream.rb", "gem": "my_downstream_gem@1"}
-{"gem": "my_upstream_gem@1", "path": "test/scip/testdata/multifile/gem-map/upstream.rb"}
+{"path": "./downstream.rb", "gem": "my_downstream_gem@1"}
+{"gem": "my_upstream_gem@1", "path": "./upstream.rb"}

--- a/test/scip/testdata/multifile/gem-map/scip-ruby-args.rb
+++ b/test/scip/testdata/multifile/gem-map/scip-ruby-args.rb
@@ -1,2 +1,5 @@
 # gem-map: gem-map.json
 # gem-metadata: my_current_gem@2
+#
+# The gem-map.json has extra ./ because of Files with unnormalized
+# paths being constructed in the test harness.


### PR DESCRIPTION
### Motivation

The next thing to do is add tests for special paths like sorbet/rbi/gems,
so it will be useful to make sure that we cd to the 'project root' similar
to how scip-ruby will actually run in practice.

### Test plan

Covered by existing tests.