### PR TITLE
feat: Try to read dependency versions from Gemfile.lock.

### DIFF
--- a/scip_indexer/SCIPSymbolRef.cc
+++ b/scip_indexer/SCIPSymbolRef.cc
@@ -11,6 +11,7 @@
 #include "spdlog/fmt/fmt.h"
 
 #include "common/FileSystem.h"
+#include "common/common.h"
 #include "common/sort.h"
 #include "core/Loc.h"
 #include "main/lsp/LSPLoop.h"
@@ -48,6 +49,10 @@ utils::Result UntypedGenericSymbolRef::symbolForExpr(const core::GlobalState &gs
         metadata = gemMap.globalPlaceholderGem;
     } else {
         auto owningFile = loc.has_value() ? loc->file() : this->selfOrOwner.loc(gs).file();
+        if (this->name.exists() && absl::StrContains(this->name.shortName(gs), "Loader")) {
+            fmt::print(stderr, "Loader path: {}, loc: {}", owningFile.data(gs).path(),
+                       loc.has_value() ? loc->showRawLineColumn(gs) : "<>");
+        }
         if (!owningFile.exists()) {
             // Synthetic symbols and built-in like constructs do not have a source location.
             return utils::Result::skipValue();

--- a/test/BUILD
+++ b/test/BUILD
@@ -77,6 +77,8 @@ cc_binary(
         "//test/scip:__pkg__",
         "//tools:__pkg__",
     ],
+    # sprintf has been deprecated in newer macOS SDKs
+    copts = ["-Wno-deprecated-declarations"],
     deps = [
         # TODO(varun): Revisit dependencies after rewriting test runner.
         "//ast/desugar",

--- a/test/scip_test_runner.cc
+++ b/test/scip_test_runner.cc
@@ -106,7 +106,8 @@ PATH
     for (auto &testCase : testCases) {
         MockFileSystem fs("/lolz");
         fs.writeFile(testCase.fileName, testCase.content);
-        auto [metadata, actualErrors] = GemMetadata::readFromConfig(fs);
+        GemDependencies deps;
+        auto actualErrors = deps.populateFromConfig(fs);
         UnorderedSet<GemMetadataError> actualErrorSet(actualErrors.begin(), actualErrors.end());
         UnorderedSet<GemMetadataError> expectedErrorSet(testCase.expectedErrors.begin(), testCase.expectedErrors.end());
         auto showError = [](const auto &err) -> string { return err.message + "\n"; };
@@ -202,8 +203,10 @@ TEST_CASE("GemInference") {
         notSorbetRBI = gs.enterFile("myproject/x.rbi", "");
     }
 
+    scip_indexer::GemDependencies deps;
+    deps.addCurrentGem(scip_indexer::GemMetadata::forTest("mygem", "33"));
     scip_indexer::GemMapping gemMap{};
-    gemMap.markCurrentGem(scip_indexer::GemMetadata::forTest("mygem", "33"));
+    gemMap.addGemDependencies(std::move(deps));
 
     auto checkGem = [&](core::FileRef file, string name, string version) {
         auto gem = gemMap.lookupGemForFile(gs, file);


### PR DESCRIPTION
### Motivation

Some repos using Sorbet do not have gem versions in RBI names. E.g. https://github.com/yob/pdf-reader/tree/625e8dca295d8b6a48f634cba812f14fd3b805a4/sorbet/rbi/gems

Try to infer these from Gemfile.lock

### Test plan

- [ ] TODO: Add multifile test
