### PR TITLE
feat: Add Docker image for auto-indexing support.

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -23,6 +23,9 @@ jobs:
               | cut --delimiter='/' --fields=3)"
           fi
           echo "TAG=$TAG" >> "$GITHUB_ENV"
+          echo "PATCH=${TAG/scip-ruby-v/}" >> "$GITHUB_ENV"
+          echo "MINOR=${PATCH%.*}" >> "$GITHUB_ENV"
+          echo "MAJOR=${MINOR%.*}" >> "$GITHUB_ENV"
         env:
           TAG: ${{ inputs.tag }}
       - uses: actions/checkout@v3
@@ -40,4 +43,8 @@ jobs:
         with:
           file: Dockerfile.autoindex
           push: true
-          tags: sourcegraph/scip-ruby:autoindex
+          tags: |
+            sourcegraph/scip-ruby:autoindex
+            sourcegraph/scip-typescript:autoindex-${{ env.PATCH }}
+            sourcegraph/scip-typescript:autoindex-${{ env.MINOR }}
+            sourcegraph/scip-typescript:autoindex-${{ env.MAJOR }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -22,10 +22,12 @@ jobs:
               | tail --lines=1 \
               | cut --delimiter='/' --fields=3)"
           fi
-          echo "TAG=$TAG" >> "$GITHUB_ENV"
-          echo "PATCH=${TAG/scip-ruby-v/}" >> "$GITHUB_ENV"
-          echo "MINOR=${PATCH%.*}" >> "$GITHUB_ENV"
-          echo "MAJOR=${MINOR%.*}" >> "$GITHUB_ENV"
+          {
+            echo "TAG=$TAG"
+            echo "PATCH=${TAG/scip-ruby-v/}"
+            echo "MINOR=${PATCH%.*}"
+            echo "MAJOR=${MINOR%.*}"
+          } >> "$GITHUB_ENV"
         env:
           TAG: ${{ inputs.tag }}
       - uses: actions/checkout@v3

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,43 @@
+name: 'Publish Docker'
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish Docker image for (scip-ruby-vM.N.P)'
+  workflow_run:
+    workflows: ['Release']
+    types:
+      - completed
+
+jobs:
+  release-image:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [ -z "$TAG" ]; then
+            # From https://stackoverflow.com/questions/10649814/get-last-git-tag-from-a-remote-repo-without-cloning
+            TAG="$(git -c 'versionsort.suffix=-' \
+              ls-remote --exit-code --refs --sort='version:refname' --tags https://github.com/sourcegraph/scip-ruby.git 'scip-ruby-v*' \
+              | tail --lines=1 \
+              | cut --delimiter='/' --fields=3)"
+          fi
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+        env:
+          TAG: ${{ inputs.tag }}
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.TAG }}
+      - uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push
+        id: docker_build_autoindex
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile.autoindex
+          push: true
+          tags: sourcegraph/scip-ruby:autoindex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release # This name is used by the publish-docker workflow
 on:
   push:
     tags:

--- a/Dockerfile.autoindex
+++ b/Dockerfile.autoindex
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ruby:alpine3.16@sha256:a36324de633d5405923b087132c7728af0ec5f7c0f4efee72130b32520edcb44
+FROM --platform=linux/amd64 ruby:2.7.6-alpine3.16@sha256:b014cf3e792d7130daec772241a211c40be009fc7f00e2b728ffe26805649575
 
 RUN apk add --no-cache bash wget make libstdc++ gcc g++ automake autoconf gcompat
 

--- a/Dockerfile.autoindex
+++ b/Dockerfile.autoindex
@@ -1,7 +1,16 @@
 FROM --platform=linux/amd64 ruby:2.7.6-alpine3.16@sha256:b014cf3e792d7130daec772241a211c40be009fc7f00e2b728ffe26805649575
 
+# This Docker image is meant for auto-indexing support in Sourcegraph
+# and is not recommended for third-party use.
+
+# gcompat is a glibc-musl compat library (scip-ruby links in glibc)
+# Other deps are to help build C extensions in gems.
 RUN apk add --no-cache bash wget make libstdc++ gcc g++ automake autoconf gcompat
 
+# Use a release binary instead of building from source
+# because release builds are very time-consuming.
+#
+# The release version is verified by tools/scripts/publish-scip-ruby.sh
 RUN wget https://github.com/sourcegraph/scip-ruby/releases/download/scip-ruby-v0.3.0/scip-ruby-x86_64-linux -O /usr/bin/scip-ruby && chmod +x /usr/bin/scip-ruby
 
 COPY scip_indexer/autoindex.sh /usr/bin/scip-ruby-autoindex

--- a/Dockerfile.autoindex
+++ b/Dockerfile.autoindex
@@ -1,0 +1,11 @@
+FROM --platform=linux/amd64 ruby:alpine3.16@sha256:a36324de633d5405923b087132c7728af0ec5f7c0f4efee72130b32520edcb44
+
+RUN apk add --no-cache bash wget make libstdc++ gcc g++ automake autoconf gcompat
+
+RUN wget https://github.com/sourcegraph/scip-ruby/releases/download/scip-ruby-v0.3.0/scip-ruby-x86_64-linux -O /usr/bin/scip-ruby && chmod +x /usr/bin/scip-ruby
+
+COPY scip_indexer/autoindex.sh /usr/bin/scip-ruby-autoindex
+
+RUN chmod +x /usr/bin/scip-ruby-autoindex
+
+CMD ["/bin/sh"]

--- a/scip_indexer/autoindex.sh
+++ b/scip_indexer/autoindex.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --gem-name)
+      GEM_NAME="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --gem-version)
+      GEM_VERSION="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --is-package)
+      IS_PACKAGE_REPO="YES"
+      shift # past argument
+  esac
+done
+
+initialize_sorbet() {
+  gem install "$GEM_NAME" -v "$GEM_VERSION"
+
+  # Assume that current directory is the gem root
+  # gem lock will emit the current gem too, but we don't want
+  # that, as the root already has the source code
+  # FIXME: Allow passing in gem source from the outside
+  gem lock "$GEM_NAME-$GEM_VERSION" \
+   | grep -v "gem '$GEM_NAME'" \
+   | sed -E 's|^gem|source "https://rubygems.org"\ngem|' \
+   > Gemfile
+
+  echo "group :development do
+  gem 'tapioca', require: false
+end" >> Gemfile
+
+  bundle install
+  bundle exec tapioca init
+}
+
+# FIXME: Modify the global gem sources list to use the configured host
+# in Sourcegraph rather than https://rubygems.org
+
+# Created by Sourcegraph to indicate package repos.
+if [ -f "rubygems-metadata.yml" ]; then
+  IS_PACKAGE_REPO="YES"
+fi
+
+if [ -n "$IS_PACKAGE_REPO" ] && [ -n "${GEM_NAME:-}" ] && [ -n "${GEM_VERSION:-}" ]; then
+  initialize_sorbet
+  set +e
+  scip-ruby . --gem-metadata "$GEM_NAME@$GEM_VERSION"
+  exit 0
+fi
+
+if [ -f "sorbet/config" ]; then
+  set +e
+  if [ -n "$GEM_NAME" ] && [ -n "$GEM_VERSION" ]; then
+    scip-ruby --gem-metadata "$GEM_NAME@$GEM_VERSION"
+  else
+    scip-ruby
+  fi
+  exit 0
+fi
+
+
+set +e
+# Can remove this once the 'default to using .' problem in
+# https://github.com/sourcegraph/scip-ruby/issues/133 is fixed.
+if [ -n "$GEM_NAME" ] && [ -n "$GEM_VERSION" ]; then
+  scip-ruby . --gem-metadata "$GEM_NAME@$GEM_VERSION"
+else
+  scip-ruby .
+fi

--- a/tools/scripts/publish-scip-ruby.sh
+++ b/tools/scripts/publish-scip-ruby.sh
@@ -21,6 +21,11 @@ if ! grep -q "const char scip_ruby_version\[\] = \"$NEW_VERSION\"" scip_indexer/
   exit 1
 fi
 
+if ! grep -q "download/scip-ruby-$NEW_VERSION" Dockerfile.autoindex; then
+  echo "error: scip-ruby version in Dockerfile is not the latest release version."
+  exit 1
+fi
+
 if ! git diff --quiet; then
   echo "error: Found unstaged changes; aborting."
   exit 1


### PR DESCRIPTION
### Motivation

Add a Dockerfile + publishing workflow for autoindexing. Partial progress towards https://github.com/sourcegraph/sourcegraph/issues/44122

TODOs:
- [x] The current code will generate an index.scip in the current directory. Is that the right final step?
- [x] I should update the image to use Ruby 2.7.6 maybe? It is using 3.1.2 right now.
- [x] Add brief docs on how to build/test the image locally. Mention that it doesn't work on macOS right now.
- [x] ~Use `gem sources` so that we use the package host, not hard-coding rubygems.org~ -- Punting this to after https://github.com/sourcegraph/sourcegraph/issues/44204 is resolved.

### Test plan

Manually tested the image. Running `scip-ruby-autoindex --gem-name blah --gem-version blah` with an optional `--is-package` does the trick.