### PR TITLE
ci: Use ruby/setup-ruby instead of actions/setup-ruby

### DIFF
--- a/.github/workflows/build_gems.yml
+++ b/.github/workflows/build_gems.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # Keep in sync with ci.yml
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
       - name: Manually evict cache entry if applicable
         if: ${{ runner.os == 'Linux' }}
         run: ACCESS_TOKEN='${{ secrets.GITHUB_TOKEN }}' python3 .github/workflows/evict.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # Keep in sync with ci.yml
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
       - name: Manually evict cache entry if applicable
         if: ${{ runner.os == 'Linux' }}
         run: ACCESS_TOKEN='${{ secrets.GITHUB_TOKEN }}' python3 .github/workflows/evict.py


### PR DESCRIPTION
### Motivation

The latter is deprecated/archived now

### Test plan

Will run the Check Gem Build action manually.