### PR TITLE
autoindex: Bundle git in Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v0.3.3
+
+### Auto-indexing
+
+(Sourcegraph-use only)
+
+The auto-indexing image also bundles in `git`
+which can be used by `bundler`.
+
 ## v0.3.2
 
 ### Auto-indexing

--- a/Dockerfile.autoindex
+++ b/Dockerfile.autoindex
@@ -5,13 +5,13 @@ FROM --platform=linux/amd64 ruby:2.7.6-alpine3.16@sha256:b014cf3e792d7130daec772
 
 # gcompat is a glibc-musl compat library (scip-ruby links in glibc)
 # Other deps are to help build C extensions in gems.
-RUN apk add --no-cache bash wget make libstdc++ gcc g++ automake autoconf gcompat
+RUN apk add --no-cache bash wget make libstdc++ gcc g++ automake autoconf gcompat git
 
 # Use a release binary instead of building from source
 # because release builds are very time-consuming.
 #
 # The release version is verified by tools/scripts/publish-scip-ruby.sh
-RUN wget https://github.com/sourcegraph/scip-ruby/releases/download/scip-ruby-v0.3.2/scip-ruby-x86_64-linux -O /usr/bin/scip-ruby && chmod +x /usr/bin/scip-ruby
+RUN wget https://github.com/sourcegraph/scip-ruby/releases/download/scip-ruby-v0.3.3/scip-ruby-x86_64-linux -O /usr/bin/scip-ruby && chmod +x /usr/bin/scip-ruby
 
 COPY scip_indexer/autoindex.sh /usr/bin/scip-ruby-autoindex
 

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -61,7 +61,7 @@ static uint32_t fnv1a_32(const string &s) {
     return h;
 }
 
-const char scip_ruby_version[] = "0.3.2";
+const char scip_ruby_version[] = "0.3.3";
 
 // Last updated: https://github.com/sourcegraph/scip-ruby/pull/168
 const char scip_ruby_sync_upstream_sorbet_sha[] = "b8461dbcd56ba56b2854d07f546c7216b31b58e6";


### PR DESCRIPTION
### Motivation

Bundler allows git-based Gem dependencies, so it needs access to
a `git` binary while running. https://bundler.io/guides/git.html

### Test plan

Manually checked that adding `git` fixes the error Bundler runs into.
