### PR TITLE
ci: Use Ubuntu 20.04 and macOS 12 in CI

### DIFF
--- a/.github/workflows/build_gems.yml
+++ b/.github/workflows/build_gems.yml
@@ -6,7 +6,7 @@ jobs:
     name: 'Build gem'
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: ['ubuntu-20.04', 'macos-12']
         config: ['debug', 'release']
     runs-on: ${{ matrix.platform }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   release-image:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-20.04'
     steps:
       - run: |
           if [ -z "$TAG" ]; then

--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   download-and-publish-gems:
     name: 'Download and publish gems'
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-20.04'
     env:
       TAG: ${{ inputs.tag }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: 'Build and upload artifacts'
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: ['ubuntu-20.04', 'macos-12']
         config: ['debug', 'release']
     runs-on: ${{ matrix.platform }}
     env:
@@ -88,7 +88,7 @@ jobs:
   create-release:
     name: 'Create release'
     needs: build-and-upload-artifacts
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v3
       - name: Create Release


### PR DESCRIPTION
### Motivation

GitHub recently changed 'ubuntu-latest' to mean Ubuntu 22.04
but that breaks the build due to libtinfo5 not being
installed. We can fix it later...

### Test plan

Run CI
