### PR TITLE
build: Use platform constraints in gem builds

### DIFF
--- a/gems/scip-ruby/BUILD
+++ b/gems/scip-ruby/BUILD
@@ -23,8 +23,8 @@ build_gems(
         "//conditions:default": "scip-ruby",
     }),
     gem_target_os = select({
-        "//tools/config:linux": "linux",
-        "//tools/config:darwin": "darwin",
+        "@platforms//os:linux": "linux",
+        "@platforms//os:osx": "darwin",
     }),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
### Motivation

The gem build uses old constraints which are no longer applicable.

### Test plan

Tested here: https://github.com/sourcegraph/scip-ruby/actions/runs/5263217577/jobs/9513161898