### PR TITLE
fix: Avoid assertion in asSymbolRef()

### DIFF
--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -924,8 +924,9 @@ public:
             auto [namedSym, _] = symRef.value();
             auto check =
                 isMethodFileStaticInit ||
-                method == gs.lookupStaticInitForClass(namedSym.asSymbolRef().asClassOrModuleRef().data(gs)->owner,
-                                                      /*allowMissing*/ true);
+                (namedSym.kind() != GenericSymbolRef::Kind::Field &&
+                 method == gs.lookupStaticInitForClass(namedSym.asSymbolRef().asClassOrModuleRef().data(gs)->owner,
+                                                       /*allowMissing*/ true));
             absl::Status status;
             string kind;
             if (check) {


### PR DESCRIPTION
### Motivation

Fixes #180.

### Test plan

I can't quite tell when this is triggered, and I haven't been
able to reproduce the issue with other OSS projects,
but the extra check should avoid the assertion being hit.