### PR TITLE
fix: Remove incorrect diagnostic for unknown field

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -303,6 +303,8 @@ public:
     bool isSCIPRuby = true;
 
     // --- begin scip-ruby specific state
+    // Mapping describing which field references in a class are still
+    // marked as "unresolved" after name resolution is complete.
     UnorderedMap<core::ClassOrModuleRef, UnorderedSet<core::NameRef>> unresolvedFields;
     // --- end scip-ruby specific state
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -4188,6 +4188,15 @@ public:
                 gs.unresolvedFields.insert(make_move_iterator(threadResult.unresolvedFields.begin()),
                                            make_move_iterator(threadResult.unresolvedFields.end()));
             }
+            // NOTE(varun): This walker is meant to be invoked after name resolution is finished.
+            // As such, one might expect that the unresolved fields across classes stay the same
+            // across runs, as all the single-threaded merging which requires cross-file data
+            // is complete. However, that's not the case. 😕
+            //
+            // In particular, when testing on the shopify-ruby-codebase, printing the
+            // printing the number of unresolved fields for each class gave varying results
+            // (e.g. in one run, a class would have 85 unresolved fields, in another run,
+            // it would have 87 unresolved fields).
         }
 
         fast_sort(trees, [](const auto &lhs, const auto &rhs) -> bool { return lhs.file < rhs.file; });

--- a/scip_indexer/SCIPFieldResolve.cc
+++ b/scip_indexer/SCIPFieldResolve.cc
@@ -78,24 +78,6 @@ core::ClassOrModuleRef FieldResolver::findUnresolvedFieldInInheritanceChain(cons
     }
     start = FieldResolver::normalizeParentForClassVar(gs, start, fieldText);
 
-    if (gs.unresolvedFields.find(start) == gs.unresolvedFields.end() ||
-        !gs.unresolvedFields.find(start)->second.contains(field)) {
-        // Triggered by code patterns like:
-        //   # top-level
-        //   def MyClass.method
-        //     # blah
-        //   end
-        // which is not supported by Sorbet.
-        LOG_DEBUG(gs, debugLoc,
-                  fmt::format("couldn't find field {} in class {};\n"
-                              "are you using a code pattern like def MyClass.method which is unsupported by Sorbet?",
-                              field.exists() ? field.toString(gs) : "<non-existent>",
-                              start.exists() ? start.showFullName(gs) : "<non-existent>"));
-        // As a best-effort guess, assume that the definition is
-        // in this class but we somehow missed it.
-        return start;
-    }
-
     auto best = start;
     auto cur = start;
     while (cur.exists()) {


### PR DESCRIPTION
### Motivation

I'm not exactly sure why, but the result in `unresolvedFields` (after name resolution
is complete) is non-deterministic. This means that a field may show up as unresolved
in the class in one run, and resolved in another run.

Thus, if the class K is present as a key in `unresolvedFields` but doesn't have a
corresponding value for a field `@v`, it may just be an artifact of the run.
As such, we can continue with the normal path of name lookups, rather
than having a fast path for this edge case, with a potentially misleading diagnostic.

### Test plan

n/a