### PR TITLE
fix: Stop incorrectly emitting multiline occurrences

### DIFF
--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -290,14 +290,19 @@ private:
                                     core::Loc occLoc, const SmallVec<string> &docs,
                                     const SmallVec<scip::Relationship> &rels) {
         ENFORCE(!symbolString.empty());
-
-        auto emitted = this->saveSymbolInfo(file, symbolString, docs, rels);
-
         occLoc = trimColonColonPrefix(gs, occLoc);
+        auto range = sorbet::scip_indexer::fromSorbetLoc(gs, occLoc);
+        if (range.size() == 4) {
+            // Don't emit multiline occurrences; generally this indicates a bug in the indexer.
+            // FIXME: This causes us to miss the definition for the initialize method
+            // in the struct.rb test case.
+            return absl::OkStatus();
+        }
+        auto emitted = this->saveSymbolInfo(file, symbolString, docs, rels);
         scip::Occurrence occurrence;
         occurrence.set_symbol(symbolString);
         occurrence.set_symbol_roles(scip::SymbolRole::Definition);
-        for (auto val : sorbet::scip_indexer::fromSorbetLoc(gs, occLoc)) {
+        for (auto val : range) {
             occurrence.add_range(val);
         }
         switch (emitted) {
@@ -320,7 +325,12 @@ private:
         scip::Occurrence occurrence;
         occurrence.set_symbol(symbolString);
         occurrence.set_symbol_roles(symbol_roles);
-        for (auto val : sorbet::scip_indexer::fromSorbetLoc(gs, occLoc)) {
+        auto range = sorbet::scip_indexer::fromSorbetLoc(gs, occLoc);
+        if (range.size() == 4) {
+            // Don't emit multiline occurrences; generally this indicates a bug in the indexer.
+            return;
+        }
+        for (auto val : range) {
             occurrence.add_range(val);
         }
         for (auto &doc : overrideDocs) {

--- a/test/scip/testdata/struct.snapshot.rb
+++ b/test/scip/testdata/struct.snapshot.rb
@@ -50,10 +50,6 @@
 #^^^^^ reference [..] POINT#
 #^^^^^ definition [..] POINT#
 #^^^^^ definition [..] POINT#
-#^^^^^^^^^^^^^^^^^^^^ reference [..] Struct#
-#^^^^^^^^^^^^^^^^^^^^ definition local 2~#119448696
-#^^^^^^^^^^^^^^^^^^^^ definition local 5~#119448696
-#^^^^^^^^^^^^^^^^^^^^ definition [..] POINT#initialize().
 #                    ^ definition [..] POINT#`x=`().
 #                    ^ definition [..] POINT#x().
 #                    ^ reference [..] BasicObject#

--- a/test/scip_test_runner.cc
+++ b/test/scip_test_runner.cc
@@ -311,6 +311,7 @@ struct SCIPRange final {
         auto &r = protoRange;
         if (r.size() == 4) {
             *this = SCIPRange(SCIPPosition{r[0] + 1, r[1] + 1}, SCIPPosition{r[2] + 1, r[3] + 1});
+            return;
         }
         *this = SCIPRange(SCIPPosition{r[0] + 1, r[1] + 1}, SCIPPosition{r[0] + 1, r[2] + 1});
     }
@@ -366,6 +367,7 @@ void formatSnapshot(const scip::Document &document, FormatOptions options, std::
             auto occ = occurrences[occ_i];
             auto range = SCIPRange(occ.range());
             if (range.isMultiline()) { // FIXME(varun): Handle multiline occurrences.
+                ENFORCE(false, "Got multiline occurrence which shouldn't have been emitted: {}", range.toString());
                 continue;
             }
             bool isDefinition = ((unsigned(occ.symbol_roles()) & unsigned(scip::SymbolRole::Definition)) > 0);


### PR DESCRIPTION
### Motivation

At the moment, we don't have a good reason to emit multiline occurrences,
except for indexer bugs, so let's avoid emitting those.

### Test plan
Updated snapshot and added assertion