### PR TITLE
fix: Correctly emit refs for entities in the Opus namespace

### DIFF
--- a/scip_indexer/SCIPSymbolRef.cc
+++ b/scip_indexer/SCIPSymbolRef.cc
@@ -12,8 +12,8 @@
 
 #include "common/FileSystem.h"
 #include "common/sort/sort.h"
-#include "core/source_generator/source_generator.h"
 #include "core/Loc.h"
+#include "core/source_generator/source_generator.h"
 #include "main/lsp/LSPLoop.h"
 
 #include "scip_indexer/Debug.h"
@@ -184,10 +184,6 @@ bool GenericSymbolRef::isSorbetInternal(const core::GlobalState &gs, core::Symbo
             if (klass == core::Symbols::Sorbet_Private() || klass == core::Symbols::T() || klass == classT) {
                 return true;
             }
-            auto name = klass.data(gs)->name;
-            if (name == core::Names::Constants::Opus()) {
-                return true;
-            }
         }
         visited.insert(sym);
         sym = sym.owner(gs);
@@ -228,7 +224,8 @@ void GenericSymbolRef::saveDocStrings(const core::GlobalState &gs, core::TypePtr
             auto ref = this->selfOrOwner.asMethodRef();
             auto recvType = ref.data(gs)->owner.data(gs)->resultType;
             checkType(recvType, fmt::format("receiver type for {}", ref.showFullName(gs)));
-            markdown = core::source_generator::prettyTypeForMethod(gs, ref, recvType, nullptr, nullptr, core::ShowOptions());
+            markdown =
+                core::source_generator::prettyTypeForMethod(gs, ref, recvType, nullptr, nullptr, core::ShowOptions());
             // FIXME(varun): For some reason, it looks like a bunch of public methods
             // get marked as private here. Avoid printing misleading info until we fix that.
             // https://github.com/sourcegraph/scip-ruby/issues/33

--- a/test/scip/testdata/encrypted_prop.snapshot.rb
+++ b/test/scip/testdata/encrypted_prop.snapshot.rb
@@ -28,11 +28,23 @@
 #           ^^^^^^^^^^^^^^ definition [..] `<Class:EncryptedProp>`#encrypted_prop().
    encrypted_prop :foo
 #  ^^^^^^^^^^^^^^^^^^^ reference [..] String#
+#  ^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#
+#  ^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#Model#
+#  ^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#Model#Mixins#
+#  ^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#Model#Mixins#Encryptable#
+#  ^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#Model#Mixins#Encryptable#EncryptedValue#
+#  ^^^^^^^^^^^^^^^^^^^ reference [..] Opus#
 #                  ^^^ definition [..] EncryptedProp#`encrypted_foo=`().
 #                  ^^^ definition [..] EncryptedProp#`foo=`().
 #                  ^^^ definition [..] EncryptedProp#encrypted_foo().
 #                  ^^^ definition [..] EncryptedProp#foo().
    encrypted_prop :bar, migrating: true, immutable: true
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#Model#Mixins#Encryptable#
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#Model#
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#Model#Mixins#
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Opus#
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#Model#Mixins#Encryptable#EncryptedValue#
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] String#
 #                  ^^^ definition [..] EncryptedProp#bar().
 #                  ^^^ definition [..] EncryptedProp#encrypted_bar().

--- a/test/scip/testdata/opus.rb
+++ b/test/scip/testdata/opus.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+class Opus::Base
+end
+
+class Opus::Derived < Opus::Base
+end
+
+TYPES = T.let({ derived: -> { Opus::Derived } }, T::Hash[Symbol, T.proc.returns(T.class_of(Opus::Base))])
+
+module ABC
+  TYPES_IN_MODULE = T.let({ derived: -> { Opus::Derived } }, T::Hash[Symbol, T.proc.returns(T.class_of(Opus::Base))])
+end
+
+class Other
+  TYPES_IN_CLASS = T.let({ derived: -> { Opus::Derived } }, T::Hash[Symbol, T.proc.returns(T.class_of(Opus::Base))])
+end

--- a/test/scip/testdata/opus.snapshot.rb
+++ b/test/scip/testdata/opus.snapshot.rb
@@ -1,0 +1,53 @@
+ # typed: true
+ 
+ class Opus::Base
+#      ^^^^ reference [..] Opus#
+#            ^^^^ definition [..] Opus#Base#
+ end
+ 
+ class Opus::Derived < Opus::Base
+#      ^^^^ reference [..] Opus#
+#            ^^^^^^^ definition [..] Opus#Derived#
+#                      ^^^^ reference [..] Opus#
+#                            ^^^^ reference [..] Opus#Base#
+ end
+ 
+ TYPES = T.let({ derived: -> { Opus::Derived } }, T::Hash[Symbol, T.proc.returns(T.class_of(Opus::Base))])
+#^^^^^ definition [..] TYPES.
+#                         ^^ reference [..] Kernel#
+#                         ^^ reference [..] Kernel#lambda().
+#                              ^^^^ reference [..] Opus#
+#                                    ^^^^^^^ reference [..] Opus#Derived#
+#                                                 ^ reference [..] T#
+#                                                    ^^^^ reference [..] T#Hash#
+#                                                         ^^^^^^ reference [..] Symbol#
+#                                                                 ^ reference [..] T#
+#                                                                   ^^^^ reference [..] `<Class:T>`#proc().
+#                                                                                ^ reference [..] T#
+#                                                                                  ^^^^^^^^ reference [..] `<Class:T>`#class_of().
+#                                                                                           ^^^^ reference [..] Opus#
+#                                                                                                 ^^^^ reference [..] Opus#Base#
+#                                                                                                 ^^^^^^^ definition local 4~#119448696
+#                                                                                                 ^^^^^^^^ reference [..] TYPES.
+ 
+ module ABC
+#       ^^^ definition [..] ABC#
+   TYPES_IN_MODULE = T.let({ derived: -> { Opus::Derived } }, T::Hash[Symbol, T.proc.returns(T.class_of(Opus::Base))])
+#  ^^^^^^^^^^^^^^^ definition [..] ABC#TYPES_IN_MODULE.
+#                                     ^^ reference [..] Kernel#
+#                                     ^^ reference [..] Kernel#lambda().
+#                                                                     ^^^^^^ reference [..] Symbol#
+#                                                                                                             ^^^^^^^ definition local 4~#119448696
+#                                                                                                             ^^^^^^^^ reference [..] ABC#TYPES_IN_MODULE.
+ end
+ 
+ class Other
+#      ^^^^^ definition [..] Other#
+   TYPES_IN_CLASS = T.let({ derived: -> { Opus::Derived } }, T::Hash[Symbol, T.proc.returns(T.class_of(Opus::Base))])
+#  ^^^^^^^^^^^^^^ definition [..] Other#TYPES_IN_CLASS.
+#                                    ^^ reference [..] Kernel#
+#                                    ^^ reference [..] Kernel#lambda().
+#                                                                    ^^^^^^ reference [..] Symbol#
+#                                                                                                            ^^^^^^^ definition local 4~#119448696
+#                                                                                                            ^^^^^^^^ reference [..] Other#TYPES_IN_CLASS.
+ end

--- a/test/scip/testdata/opus.snapshot.rb
+++ b/test/scip/testdata/opus.snapshot.rb
@@ -36,7 +36,11 @@
 #  ^^^^^^^^^^^^^^^ definition [..] ABC#TYPES_IN_MODULE.
 #                                     ^^ reference [..] Kernel#
 #                                     ^^ reference [..] Kernel#lambda().
+#                                          ^^^^ reference [..] Opus#
+#                                                ^^^^^^^ reference [..] Opus#Derived#
 #                                                                     ^^^^^^ reference [..] Symbol#
+#                                                                                                       ^^^^ reference [..] Opus#
+#                                                                                                             ^^^^ reference [..] Opus#Base#
 #                                                                                                             ^^^^^^^ definition local 4~#119448696
 #                                                                                                             ^^^^^^^^ reference [..] ABC#TYPES_IN_MODULE.
  end
@@ -47,7 +51,11 @@
 #  ^^^^^^^^^^^^^^ definition [..] Other#TYPES_IN_CLASS.
 #                                    ^^ reference [..] Kernel#
 #                                    ^^ reference [..] Kernel#lambda().
+#                                         ^^^^ reference [..] Opus#
+#                                               ^^^^^^^ reference [..] Opus#Derived#
 #                                                                    ^^^^^^ reference [..] Symbol#
+#                                                                                                      ^^^^ reference [..] Opus#
+#                                                                                                            ^^^^ reference [..] Opus#Base#
 #                                                                                                            ^^^^^^^ definition local 4~#119448696
 #                                                                                                            ^^^^^^^^ reference [..] Other#TYPES_IN_CLASS.
  end


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/GRAPH-857

### Motivation

I think I added a workaround here originally as it wasn't super clear
if the extra entities for `encrypted_prop:` would be useful.

But the problem is that the workaround would stop code nav for
other things inside the Opus namespace in other contexts.

Let's fix the immediate issue for now, I've filed a follow-up issue
for synthetic references from rewrites here.

https://linear.app/sourcegraph/issue/GRAPH-928

### Test plan

See included automated tests.
