### PR TITLE
docs: Prepare for v0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v0.4.3
+
+Adds reference relationships between constant aliases
+so that Find references on an alias Y with a definition
+Y = X also returns references to X.
+
+The converse behavior of Find references for 'X' requires
+changes to the Sourcegraph backend and no further changes
+from the indexer.
+
 ## v0.4.2
 
 Fixes a bug where reference data for constants in the `Opus`

--- a/Dockerfile.autoindex
+++ b/Dockerfile.autoindex
@@ -11,7 +11,7 @@ RUN apk add --no-cache bash wget make libstdc++ gcc g++ automake autoconf gcompa
 # because release builds are very time-consuming.
 #
 # The release version is verified by tools/scripts/publish-scip-ruby.sh
-RUN wget https://github.com/sourcegraph/scip-ruby/releases/download/scip-ruby-v0.4.2/scip-ruby-x86_64-linux -O /usr/bin/scip-ruby && chmod +x /usr/bin/scip-ruby
+RUN wget https://github.com/sourcegraph/scip-ruby/releases/download/scip-ruby-v0.4.3/scip-ruby-x86_64-linux -O /usr/bin/scip-ruby && chmod +x /usr/bin/scip-ruby
 
 COPY scip_indexer/autoindex.sh /usr/bin/scip-ruby-autoindex
 

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -61,7 +61,7 @@ static uint32_t fnv1a_32(const string &s) {
     return h;
 }
 
-const char scip_ruby_version[] = "0.4.2";
+const char scip_ruby_version[] = "0.4.3";
 
 // Last updated: https://github.com/sourcegraph/scip-ruby/pull/217
 const char scip_ruby_sync_upstream_sorbet_sha[] = "0a7b175bc0bb41e2672369554f74364e83711a84";


### PR DESCRIPTION
Adds Changelog entry + bumps versions.