### PR TITLE
Add standalone scip-ruby Docker image for CI/CD

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -42,14 +42,40 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build and push
+      - name: Build base image (not published)
+        id: docker_build_base
+        uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile.base
+          push: false
+          load: true
+          build-args: |
+            SCIP_RUBY_VERSION=${{ env.PATCH }}
+          tags: |
+            scip-ruby-base:${{ env.PATCH }}
+      - name: Build and push autoindex image
         id: docker_build_autoindex
         uses: docker/build-push-action@v6
         with:
           file: Dockerfile.autoindex
           push: true
+          build-args: |
+            BASE_TAG=${{ env.PATCH }}
           tags: |
             sourcegraph/scip-ruby:autoindex
             sourcegraph/scip-ruby:autoindex-${{ env.PATCH }}
             sourcegraph/scip-ruby:autoindex-${{ env.MINOR }}
             sourcegraph/scip-ruby:autoindex-${{ env.MAJOR }}
+      - name: Build and push scip-ruby image
+        id: docker_build_scip_ruby
+        uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile
+          push: true
+          build-args: |
+            BASE_TAG=${{ env.PATCH }}
+          tags: |
+            sourcegraph/scip-ruby:latest
+            sourcegraph/scip-ruby:${{ env.PATCH }}
+            sourcegraph/scip-ruby:${{ env.MINOR }}
+            sourcegraph/scip-ruby:${{ env.MAJOR }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# Build from the base image (local, not published)
+ARG BASE_TAG
+FROM scip-ruby-base:${BASE_TAG}
+
+# This Docker image provides scip-ruby for CI/CD pipelines
+
+# Default command is to run scip-ruby
+CMD ["scip-ruby"]

--- a/Dockerfile.autoindex
+++ b/Dockerfile.autoindex
@@ -1,20 +1,13 @@
-FROM --platform=linux/amd64 ruby:2.7.6-alpine3.16@sha256:b014cf3e792d7130daec772241a211c40be009fc7f00e2b728ffe26805649575
+# Build from the base image (local, not published)
+ARG BASE_TAG
+FROM scip-ruby-base:${BASE_TAG}
 
 # This Docker image is meant for auto-indexing support in Sourcegraph
 # and is not recommended for third-party use.
 
-# gcompat is a glibc-musl compat library (scip-ruby links in glibc)
-# Other deps are to help build C extensions in gems.
-RUN apk add --no-cache bash wget make libstdc++ gcc g++ automake autoconf gcompat git
-
-# Use a release binary instead of building from source
-# because release builds are very time-consuming.
-#
-# The release version is verified by tools/scripts/publish-scip-ruby.sh
-RUN wget https://github.com/sourcegraph/scip-ruby/releases/download/scip-ruby-v0.4.6/scip-ruby-x86_64-linux -O /usr/bin/scip-ruby && chmod +x /usr/bin/scip-ruby
-
+# Copy and install the autoindex script
 COPY scip_indexer/autoindex.sh /usr/bin/scip-ruby-autoindex
-
 RUN chmod +x /usr/bin/scip-ruby-autoindex
 
+# Default command is shell for autoindex operations
 CMD ["/bin/sh"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,35 @@
+FROM --platform=linux/amd64 \
+    ruby:2.7.6-alpine3.16@sha256:b014cf3e792d7130daec772241a211c40be009fc7f00e2b728ffe26805649575
+
+# This is the base Docker image for scip-ruby with common dependencies
+
+# Version argument to be passed during build
+ARG SCIP_RUBY_VERSION
+
+# gcompat is a glibc-musl compat library (scip-ruby links in glibc)
+# Other deps are to help build C extensions in gems.
+RUN apk add --no-cache \
+    bash \
+    wget \
+    make \
+    libstdc++ \
+    gcc \
+    g++ \
+    automake \
+    autoconf \
+    gcompat \
+    git
+
+# Use a release binary instead of building from source
+# because release builds are very time-consuming.
+#
+# The release version is verified by tools/scripts/publish-scip-ruby.sh
+# The binary at this version is guaranteed to exist because this workflow runs either:
+# 1. Manually with a specific tag that already has a release
+# 2. After the Release workflow completes (which creates the release and uploads the binary)
+RUN wget https://github.com/sourcegraph/scip-ruby/releases/download/scip-ruby-v${SCIP_RUBY_VERSION}/scip-ruby-x86_64-linux \
+    -O /usr/bin/scip-ruby && \
+    chmod +x /usr/bin/scip-ruby
+
+# Set working directory for sources
+WORKDIR /sources

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -6,6 +6,10 @@ FROM --platform=linux/amd64 \
 # Version argument to be passed during build
 ARG SCIP_RUBY_VERSION
 
+# Fail if SCIP_RUBY_VERSION is not provided
+RUN test -n "${SCIP_RUBY_VERSION}" || \
+    (echo "ERROR: SCIP_RUBY_VERSION build arg is required" && exit 1)
+
 # gcompat is a glibc-musl compat library (scip-ruby links in glibc)
 # Other deps are to help build C extensions in gems.
 RUN apk add --no-cache \


### PR DESCRIPTION
- Split Docker configuration into three files:
  - Dockerfile.base: Common dependencies and scip-ruby binary
  - Dockerfile: Standard scip-ruby image for CI/CD pipelines
  - Dockerfile.autoindex: Autoindex variant with additional script
- Update GitHub Actions workflow to build base image locally (not published)
- Both final images (scip-ruby and autoindex) are published to Docker Hub
- New image can be used in CI: docker run -v $(pwd):/sources sourcegraph/scip-ruby

Amp-Thread-ID: https://ampcode.com/threads/T-93250ea7-f00b-492f-ba56-04da7ddfe7d9

### Motivation
We currently publish autoindex images on Docker Hub. We could use an image with `scip-ruby` binary, for example in a continuous integration job.


### Test plan
Checked manually if everything builds and works as expected

Edit: Trying to rerun the checks
