### PR TITLE
ci: use latest ubuntu in runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v4
       - name: Format Bazel files


### PR DESCRIPTION
ubuntu-20.04 is deprecated
```
We will soon start the deprecation process for Ubuntu 20.04. While the image is being deprecated, you may experience longer queue times during peak usage hours
```
from https://github.com/actions/runner-images/issues/11101

Updating to use the latest ubuntu.

Closes DINF-1306

### Test
Once merged, see if the blocked workflows start working once their branches are rebased