### PR TITLE
Fix Docker build context for base image in GitHub workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -36,7 +36,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.TAG }}
-      - uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -46,6 +50,7 @@ jobs:
         id: docker_build_base
         uses: docker/build-push-action@v6
         with:
+          builder: ${{ steps.buildx.outputs.name }}
           file: Dockerfile.base
           push: false
           load: true
@@ -57,8 +62,11 @@ jobs:
         id: docker_build_autoindex
         uses: docker/build-push-action@v6
         with:
+          builder: ${{ steps.buildx.outputs.name }}
           file: Dockerfile.autoindex
           push: true
+          build-contexts: |
+            scip-ruby-base=docker-image://scip-ruby-base:${{ env.PATCH }}
           build-args: |
             BASE_TAG=${{ env.PATCH }}
           tags: |
@@ -70,8 +78,11 @@ jobs:
         id: docker_build_scip_ruby
         uses: docker/build-push-action@v6
         with:
+          builder: ${{ steps.buildx.outputs.name }}
           file: Dockerfile
           push: true
+          build-contexts: |
+            scip-ruby-base=docker-image://scip-ruby-base:${{ env.PATCH }}
           build-args: |
             BASE_TAG=${{ env.PATCH }}
           tags: |


### PR DESCRIPTION
The base image was built locally but not accessible to subsequent build steps. Added build-contexts to pass the locally-loaded base image to both autoindex and scip-ruby image builds, resolving the 'pull access denied' error.

Amp-Thread-ID: https://ampcode.com/threads/T-04ceb0b6-e6d7-419d-83f0-6cf91cc61178

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Broken CI


### Test plan
Manual run: https://github.com/sourcegraph/scip-ruby/actions/runs/17591810408/job/49974170486
