### PR TITLE
fix: Follow SCIP spec for locals syntax

### DIFF
--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -97,7 +97,7 @@ struct OwnedLocal {
     string toSCIPString(const core::GlobalState &gs, core::FileRef file) {
         // 32-bits => if there are 10k methods in a single file, the chance of at least one
         // colliding pair is about 1.1%, assuming even distribution. That seems OK.
-        return fmt::format("local {}~#{}", counter, ::fnv1a_32(owner.name(gs).show(gs)));
+        return fmt::format("local {}${}", counter, ::fnv1a_32(owner.name(gs).show(gs)));
     }
 };
 

--- a/test/scip/testdata/alias.snapshot.rb
+++ b/test/scip/testdata/alias.snapshot.rb
@@ -39,9 +39,9 @@
  
  def myfunction(myparam)
 #    ^^^^^^^^^^ definition [..] Object#myfunction().
-#               ^^^^^^^ definition local 1~#3083414419
+#               ^^^^^^^ definition local 1$3083414419
    myparam + Mod2::FEG
-#  ^^^^^^^ reference local 1~#3083414419
+#  ^^^^^^^ reference local 1$3083414419
 #            ^^^^ reference [..] Mod2#
 #                  ^^^ reference [..] Mod2#FEG.
  end
@@ -70,7 +70,7 @@
 #  ^^^ definition [..] X#All.
 #               ^ reference [..] X#A.
 #                  ^ reference [..] X#B.
-#                         ^^^^^^^^ definition local 4~#119448696
+#                         ^^^^^^^^ definition local 4$119448696
 #                               ^ reference [..] X#
  end
  

--- a/test/scip/testdata/args.snapshot.rb
+++ b/test/scip/testdata/args.snapshot.rb
@@ -2,52 +2,52 @@
  
  def args(x, y)
 #    ^^^^ definition [..] Object#args().
-#         ^ definition local 1~#2634721084
-#            ^ definition local 2~#2634721084
+#         ^ definition local 1$2634721084
+#            ^ definition local 2$2634721084
    z = x + y
-#  ^ definition local 3~#2634721084
-#      ^ reference local 1~#2634721084
-#          ^ reference local 2~#2634721084
+#  ^ definition local 3$2634721084
+#      ^ reference local 1$2634721084
+#          ^ reference local 2$2634721084
    if x == 2
-#     ^ reference local 1~#2634721084
+#     ^ reference local 1$2634721084
 #       ^^ reference [..] BasicObject#`==`().
      z += y
-#    ^ reference (write) local 3~#2634721084
-#    ^ reference local 3~#2634721084
-#         ^ reference local 2~#2634721084
+#    ^ reference (write) local 3$2634721084
+#    ^ reference local 3$2634721084
+#         ^ reference local 2$2634721084
    else
      z += x
-#    ^ reference (write) local 3~#2634721084
-#    ^ reference local 3~#2634721084
-#         ^ reference local 1~#2634721084
+#    ^ reference (write) local 3$2634721084
+#    ^ reference local 3$2634721084
+#         ^ reference local 1$2634721084
    end
    z
-#  ^ reference local 3~#2634721084
+#  ^ reference local 3$2634721084
  end
  
  def keyword_args(w:, x: 3, y: [], **kwargs)
 #    ^^^^^^^^^^^^ definition [..] Object#keyword_args().
-#                 ^^ definition local 1~#3526982640
-#                     ^^ definition local 2~#3526982640
-#                           ^^ definition local 3~#3526982640
+#                 ^^ definition local 1$3526982640
+#                     ^^ definition local 2$3526982640
+#                           ^^ definition local 3$3526982640
    y << w + x
-#  ^ reference local 3~#3526982640
-#       ^ reference local 1~#3526982640
-#           ^ reference local 2~#3526982640
+#  ^ reference local 3$3526982640
+#       ^ reference local 1$3526982640
+#           ^ reference local 2$3526982640
    y << [a]
-#  ^ reference local 3~#3526982640
+#  ^ reference local 3$3526982640
    return
  end
  
  def use_kwargs
 #    ^^^^^^^^^^ definition [..] Object#use_kwargs().
    h = { a: 3 }
-#  ^ definition local 1~#571973038
+#  ^ definition local 1$571973038
    keyword_args(w: 0, **h)
 #  ^^^^^^^^^^^^ reference [..] Object#keyword_args().
-#                       ^ reference local 1~#571973038
+#                       ^ reference local 1$571973038
    keyword_args(w: 0, x: 1, y: [2], **h)
 #  ^^^^^^^^^^^^ reference [..] Object#keyword_args().
-#                                     ^ reference local 1~#571973038
+#                                     ^ reference local 1$571973038
    return
  end

--- a/test/scip/testdata/arrays.snapshot.rb
+++ b/test/scip/testdata/arrays.snapshot.rb
@@ -2,22 +2,22 @@
  
  def arrays(a, i)
 #    ^^^^^^ definition [..] Object#arrays().
-#           ^ definition local 1~#513334479
-#              ^ definition local 2~#513334479
+#           ^ definition local 1$513334479
+#              ^ definition local 2$513334479
    a[0] = 0
-#  ^ reference local 1~#513334479
+#  ^ reference local 1$513334479
    a[1] = a[2]
-#  ^ reference local 1~#513334479
-#         ^ reference local 1~#513334479
+#  ^ reference local 1$513334479
+#         ^ reference local 1$513334479
    a[i] = a[i + 1]
-#  ^ reference local 1~#513334479
-#    ^ reference local 2~#513334479
-#         ^ reference local 1~#513334479
-#           ^ reference local 2~#513334479
+#  ^ reference local 1$513334479
+#    ^ reference local 2$513334479
+#         ^ reference local 1$513334479
+#           ^ reference local 2$513334479
    b = a[2..-1]
-#  ^ definition local 3~#513334479
-#      ^ reference local 1~#513334479
+#  ^ definition local 3$513334479
+#      ^ reference local 1$513334479
    a << a[-1]
-#  ^ reference local 1~#513334479
-#       ^ reference local 1~#513334479
+#  ^ reference local 1$513334479
+#       ^ reference local 1$513334479
  end

--- a/test/scip/testdata/blocks_lambdas_procs.snapshot.rb
+++ b/test/scip/testdata/blocks_lambdas_procs.snapshot.rb
@@ -3,161 +3,161 @@
  def blk
 #    ^^^ definition [..] Object#blk().
    y = 0
-#  ^ definition local 1~#1472469056
+#  ^ definition local 1$1472469056
    [].each { |x|
-#             ^ definition local 2~#1472469056
+#             ^ definition local 2$1472469056
      y += x
-#    ^ reference (write) local 1~#1472469056
-#    ^ reference local 1~#1472469056
-#    ^^^^^^ reference local 1~#1472469056
-#         ^ reference local 2~#1472469056
+#    ^ reference (write) local 1$1472469056
+#    ^ reference local 1$1472469056
+#    ^^^^^^ reference local 1$1472469056
+#         ^ reference local 2$1472469056
    }
    [].each do |x|
-#              ^ definition local 3~#1472469056
+#              ^ definition local 3$1472469056
      y += x
-#    ^ reference (write) local 1~#1472469056
-#    ^ reference local 1~#1472469056
-#    ^^^^^^ reference local 1~#1472469056
-#         ^ reference local 3~#1472469056
+#    ^ reference (write) local 1$1472469056
+#    ^ reference local 1$1472469056
+#    ^^^^^^ reference local 1$1472469056
+#         ^ reference local 3$1472469056
    end
  end
  
  def lam
 #    ^^^ definition [..] Object#lam().
    y = 0
-#  ^ definition local 1~#1499497673
+#  ^ definition local 1$1499497673
    l1 = ->(x) {
-#  ^^ definition local 4~#1499497673
+#  ^^ definition local 4$1499497673
 #       ^^ reference [..] Kernel#
 #       ^^ reference [..] Kernel#lambda().
-#          ^ definition local 3~#1499497673
+#          ^ definition local 3$1499497673
      y += x
-#    ^ reference (write) local 1~#1499497673
-#    ^ reference local 1~#1499497673
-#    ^^^^^^ reference local 1~#1499497673
-#         ^ reference local 3~#1499497673
+#    ^ reference (write) local 1$1499497673
+#    ^ reference local 1$1499497673
+#    ^^^^^^ reference local 1$1499497673
+#         ^ reference local 3$1499497673
    }
    l2 = lambda { |x|
-#  ^^ definition local 6~#1499497673
+#  ^^ definition local 6$1499497673
 #       ^^^^^^ reference [..] Kernel#lambda().
-#                 ^ definition local 5~#1499497673
+#                 ^ definition local 5$1499497673
      y += x
-#    ^ reference (write) local 1~#1499497673
-#    ^ reference local 1~#1499497673
-#    ^^^^^^ reference local 1~#1499497673
-#         ^ reference local 5~#1499497673
+#    ^ reference (write) local 1$1499497673
+#    ^ reference local 1$1499497673
+#    ^^^^^^ reference local 1$1499497673
+#         ^ reference local 5$1499497673
    }
    l3 = ->(x:) {
-#  ^^ definition local 9~#1499497673
+#  ^^ definition local 9$1499497673
 #       ^^ reference [..] Kernel#
 #       ^^ reference [..] Kernel#lambda().
-#          ^^ definition local 8~#1499497673
+#          ^^ definition local 8$1499497673
      y += x
-#    ^ reference (write) local 1~#1499497673
-#    ^ reference local 1~#1499497673
-#    ^^^^^^ reference local 1~#1499497673
-#         ^ reference local 8~#1499497673
+#    ^ reference (write) local 1$1499497673
+#    ^ reference local 1$1499497673
+#    ^^^^^^ reference local 1$1499497673
+#         ^ reference local 8$1499497673
    }
    l4 = lambda { |x:|
-#  ^^ definition local 11~#1499497673
+#  ^^ definition local 11$1499497673
 #       ^^^^^^ reference [..] Kernel#lambda().
-#                 ^^ definition local 10~#1499497673
+#                 ^^ definition local 10$1499497673
      y += x
-#    ^ reference (write) local 1~#1499497673
-#    ^ reference local 1~#1499497673
-#    ^^^^^^ reference local 1~#1499497673
-#         ^ reference local 10~#1499497673
+#    ^ reference (write) local 1$1499497673
+#    ^ reference local 1$1499497673
+#    ^^^^^^ reference local 1$1499497673
+#         ^ reference local 10$1499497673
    }
    l1.call(1)
-#  ^^ reference local 4~#1499497673
+#  ^^ reference local 4$1499497673
 #     ^^^^ reference [..] Proc1#call().
    l2.call(2)
-#  ^^ reference local 6~#1499497673
+#  ^^ reference local 6$1499497673
 #     ^^^^ reference [..] Proc1#call().
    l3.call(x: 3)
-#  ^^ reference local 9~#1499497673
+#  ^^ reference local 9$1499497673
 #     ^^^^ reference [..] Proc#call().
    l4.call(x: 4)
-#  ^^ reference local 11~#1499497673
+#  ^^ reference local 11$1499497673
 #     ^^^^ reference [..] Proc#call().
  end
  
  def prc
 #    ^^^ definition [..] Object#prc().
    y = 0
-#  ^ definition local 1~#1283111692
+#  ^ definition local 1$1283111692
    p1 = Proc.new { |x|
-#  ^^ definition local 4~#1283111692
+#  ^^ definition local 4$1283111692
 #       ^^^^ reference [..] Proc#
 #            ^^^ reference [..] `<Class:Proc>`#new().
-#                   ^ definition local 3~#1283111692
+#                   ^ definition local 3$1283111692
      y += x
-#    ^ reference (write) local 1~#1283111692
-#    ^ reference local 1~#1283111692
-#    ^^^^^^ reference local 1~#1283111692
-#         ^ reference local 3~#1283111692
+#    ^ reference (write) local 1$1283111692
+#    ^ reference local 1$1283111692
+#    ^^^^^^ reference local 1$1283111692
+#         ^ reference local 3$1283111692
    }
    p2 = proc { |x|
-#  ^^ definition local 6~#1283111692
+#  ^^ definition local 6$1283111692
 #       ^^^^ reference [..] Kernel#proc().
-#               ^ definition local 5~#1283111692
+#               ^ definition local 5$1283111692
      y += x
-#    ^ reference (write) local 1~#1283111692
-#    ^ reference local 1~#1283111692
-#    ^^^^^^ reference local 1~#1283111692
-#         ^ reference local 5~#1283111692
+#    ^ reference (write) local 1$1283111692
+#    ^ reference local 1$1283111692
+#    ^^^^^^ reference local 1$1283111692
+#         ^ reference local 5$1283111692
    }
    p3 = Proc.new { |x:|
-#  ^^ definition local 9~#1283111692
+#  ^^ definition local 9$1283111692
 #       ^^^^ reference [..] Proc#
 #            ^^^ reference [..] `<Class:Proc>`#new().
-#                   ^^ definition local 8~#1283111692
+#                   ^^ definition local 8$1283111692
      y += x
-#    ^ reference (write) local 1~#1283111692
-#    ^ reference local 1~#1283111692
-#    ^^^^^^ reference local 1~#1283111692
-#         ^ reference local 8~#1283111692
+#    ^ reference (write) local 1$1283111692
+#    ^ reference local 1$1283111692
+#    ^^^^^^ reference local 1$1283111692
+#         ^ reference local 8$1283111692
    }
    p4 = proc { |x:|
-#  ^^ definition local 11~#1283111692
+#  ^^ definition local 11$1283111692
 #       ^^^^ reference [..] Kernel#proc().
-#               ^^ definition local 10~#1283111692
+#               ^^ definition local 10$1283111692
      y += x
-#    ^ reference (write) local 1~#1283111692
-#    ^ reference local 1~#1283111692
-#    ^^^^^^ reference local 1~#1283111692
-#         ^ reference local 10~#1283111692
+#    ^ reference (write) local 1$1283111692
+#    ^ reference local 1$1283111692
+#    ^^^^^^ reference local 1$1283111692
+#         ^ reference local 10$1283111692
    }
    p1.call(1)
-#  ^^ reference local 4~#1283111692
+#  ^^ reference local 4$1283111692
 #     ^^^^ reference [..] Proc#call().
    p2.call(2)
-#  ^^ reference local 6~#1283111692
+#  ^^ reference local 6$1283111692
 #     ^^^^ reference [..] Proc1#call().
    p3.call(x: 3)
-#  ^^ reference local 9~#1283111692
+#  ^^ reference local 9$1283111692
 #     ^^^^ reference [..] Proc#call().
    p4.call(x: 4)
-#  ^^ reference local 11~#1283111692
+#  ^^ reference local 11$1283111692
 #     ^^^^ reference [..] Proc#call().
  end
  
  def call_block(&blk)
 #    ^^^^^^^^^^ definition [..] Object#call_block().
-#                ^^^ definition local 1~#1487178087
+#                ^^^ definition local 1$1487178087
    blk.call
-#  ^^^ reference local 1~#1487178087
+#  ^^^ reference local 1$1487178087
  end
  
  def use_block_with_defaults
 #    ^^^^^^^^^^^^^^^^^^^^^^^ definition [..] Object#use_block_with_defaults().
    call_block do |oops: nil|
 #  ^^^^^^^^^^ reference [..] Object#call_block().
-#                 ^^^^^ definition local 1~#4118119342
+#                 ^^^^^ definition local 1$4118119342
    end
  
    call_block do |oops = "nil"|
 #  ^^^^^^^^^^ reference [..] Object#call_block().
-#                 ^^^^ definition local 2~#4118119342
+#                 ^^^^ definition local 2$4118119342
    end
  end

--- a/test/scip/testdata/call.snapshot.rb
+++ b/test/scip/testdata/call.snapshot.rb
@@ -21,11 +21,11 @@
    def call()
 #      ^^^^ definition [..] Opus#MyThing#Command#GetThing#call().
      x = 1
-#    ^ definition local 1~#3018949801
+#    ^ definition local 1$3018949801
      y = x
-#    ^ definition local 2~#3018949801
-#    ^^^^^ reference local 2~#3018949801
-#        ^ reference local 1~#3018949801
+#    ^ definition local 2$3018949801
+#    ^^^^^ reference local 2$3018949801
+#        ^ reference local 1$3018949801
    end
  end
  
@@ -38,11 +38,11 @@
    def call()
 #      ^^^^ definition [..] Opus#MyThing#BadCommand#GetThing#call().
      x = 1
-#    ^ definition local 1~#3018949801
+#    ^ definition local 1$3018949801
      y = x
-#    ^ definition local 2~#3018949801
-#    ^^^^^ reference local 2~#3018949801
-#        ^ reference local 1~#3018949801
+#    ^ definition local 2$3018949801
+#    ^^^^^ reference local 2$3018949801
+#        ^ reference local 1$3018949801
    end
  end
  
@@ -54,11 +54,11 @@
    def self.call()
 #           ^^^^ definition [..] NotOpus#Command1#`<Class:GetThing>`#call().
      x = 1
-#    ^ definition local 1~#3018949801
+#    ^ definition local 1$3018949801
      y = x
-#    ^ definition local 2~#3018949801
-#    ^^^^^ reference local 2~#3018949801
-#        ^ reference local 1~#3018949801
+#    ^ definition local 2$3018949801
+#    ^^^^^ reference local 2$3018949801
+#        ^ reference local 1$3018949801
    end
  end
  
@@ -70,11 +70,11 @@
    def call()
 #      ^^^^ definition [..] NotOpus#Command2#GetThing#call().
      x = 1
-#    ^ definition local 1~#3018949801
+#    ^ definition local 1$3018949801
      y = x
-#    ^ definition local 2~#3018949801
-#    ^^^^^ reference local 2~#3018949801
-#        ^ reference local 1~#3018949801
+#    ^ definition local 2$3018949801
+#    ^^^^^ reference local 2$3018949801
+#        ^ reference local 1$3018949801
    end
  end
  

--- a/test/scip/testdata/classes.snapshot.rb
+++ b/test/scip/testdata/classes.snapshot.rb
@@ -1,18 +1,18 @@
  # typed: true
  
  _ = 0
-#^ definition local 1~#119448696
+#^ definition local 1$119448696
  
  class C1
 #      ^^ definition [..] C1#
    def f()
 #      ^ definition [..] C1#f().
      _a = C1.new
-#    ^^ definition local 1~#3809224601
+#    ^^ definition local 1$3809224601
 #         ^^ reference [..] C1#
 #            ^^^ reference [..] Class#new().
      _b = M2::C2.new
-#    ^^ definition local 3~#3809224601
+#    ^^ definition local 3$3809224601
 #         ^^ reference [..] M2#
 #             ^^ reference [..] M2#C2#
 #                ^^^ reference [..] Class#new().
@@ -35,7 +35,7 @@
  def local_class()
 #    ^^^^^^^^^^^ definition [..] Object#local_class().
    localClass = Class.new
-#  ^^^^^^^^^^ definition local 1~#552113551
+#  ^^^^^^^^^^ definition local 1$552113551
 #               ^^^^^ reference [..] Class#
 #                     ^^^ reference [..] `<Class:Class>`#new().
    # Technically, this is not supported by Sorbet (https://srb.help/3001),
@@ -45,13 +45,13 @@
      ":)"
    end
    _c = localClass.new
-#  ^^ definition local 3~#552113551
-#       ^^^^^^^^^^ reference local 1~#552113551
+#  ^^ definition local 3$552113551
+#       ^^^^^^^^^^ reference local 1$552113551
 #                  ^^^ reference [..] Class#new().
    # TODO: Missing occurrence for myMethod
    _m = localClass.myMethod
-#  ^^ definition local 4~#552113551
-#       ^^^^^^^^^^ reference local 1~#552113551
+#  ^^ definition local 4$552113551
+#       ^^^^^^^^^^ reference local 1$552113551
 #                  ^^^^^^^^ reference [..] Object#myMethod().
    return
  end
@@ -66,7 +66,7 @@
  def module_access()
 #    ^^^^^^^^^^^^^ definition [..] Object#module_access().
    _ = M4::K
-#  ^ definition local 1~#3353511840
+#  ^ definition local 1$3353511840
 #      ^^ reference [..] M4#
 #          ^ reference [..] M4#K.
    return

--- a/test/scip/testdata/enum.snapshot.rb
+++ b/test/scip/testdata/enum.snapshot.rb
@@ -24,7 +24,7 @@
 #  ^^^ definition [..] X#All.
 #               ^ reference [..] X#A.
 #                  ^ reference [..] X#B.
-#                         ^^^^^^^^ definition local 4~#119448696
+#                         ^^^^^^^^ definition local 4$119448696
 #                               ^ reference [..] X#
  end
  
@@ -48,7 +48,7 @@
  def use_abc
 #    ^^^^^^^ definition [..] Object#use_abc().
    x = X::A
-#  ^ definition local 1~#1971237871
+#  ^ definition local 1$1971237871
 #      ^ reference [..] X#
 #         ^ reference [..] X#A.
    return

--- a/test/scip/testdata/field_inheritance.snapshot.rb
+++ b/test/scip/testdata/field_inheritance.snapshot.rb
@@ -233,7 +233,7 @@
    @@x = T.let(0, Integer)
 #  ^^^ definition [..] `<Class:DD1>`#`@@x`.
 #  ^^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:DD1>`#`@@x`.
-#                 ^^^^^^^ definition local 1~#119448696
+#                 ^^^^^^^ definition local 1$119448696
 #                 ^^^^^^^ reference [..] Integer#
  end
  
@@ -302,7 +302,7 @@
      @x = T.let(0, Integer)
 #    ^^ definition [..] F1#`@x`.
 #    ^^^^^^^^^^^^^^^^^^^^^^ reference [..] F1#`@x`.
-#                  ^^^^^^^ definition local 1~#3465713227
+#                  ^^^^^^^ definition local 1$3465713227
 #                  ^^^^^^^ reference [..] Integer#
    end
  end

--- a/test/scip/testdata/fields_and_attrs.snapshot.rb
+++ b/test/scip/testdata/fields_and_attrs.snapshot.rb
@@ -113,29 +113,29 @@
 #      ^^^^^^^^^^ definition [..] P#wrong_init().
      # Check that 'r' is a method access but 'a' and 'w' are locals
      a = r
-#    ^ definition local 1~#1021288725
+#    ^ definition local 1$1021288725
 #        ^ reference [..] P#r().
      w = a
-#    ^ definition local 2~#1021288725
-#    ^^^^^ reference local 2~#1021288725
-#        ^ reference local 1~#1021288725
+#    ^ definition local 2$1021288725
+#    ^^^^^ reference local 2$1021288725
+#        ^ reference local 1$1021288725
    end
  end
  
  def useP
 #    ^^^^ definition [..] Object#useP().
    p = P.new
-#  ^ definition local 1~#2121829932
+#  ^ definition local 1$2121829932
 #      ^ reference [..] P#
 #        ^^^ reference [..] Class#new().
    p.a = p.r
-#  ^ reference local 1~#2121829932
+#  ^ reference local 1$2121829932
 #    ^^^ reference [..] P#`a=`().
-#        ^ reference local 1~#2121829932
+#        ^ reference local 1$2121829932
 #          ^ reference [..] P#r().
    p.w = p.a
-#  ^ reference local 1~#2121829932
+#  ^ reference local 1$2121829932
 #    ^^^ reference [..] P#`w=`().
-#        ^ reference local 1~#2121829932
+#        ^ reference local 1$2121829932
 #          ^ reference [..] P#a().
  end

--- a/test/scip/testdata/flatfile_dsl.snapshot.rb
+++ b/test/scip/testdata/flatfile_dsl.snapshot.rb
@@ -34,21 +34,21 @@
  end
  
  t = Flatfile.new
-#^ definition local 1~#119448696
+#^ definition local 1$119448696
 #    ^^^^^^^^ reference [..] Flatfile#
 #             ^^^ reference [..] Class#new().
  t.foo = t.foo + 1
-#^ reference local 1~#119448696
+#^ reference local 1$119448696
 #  ^^^^^ reference [..] Flatfile#`foo=`().
-#        ^ reference local 1~#119448696
+#        ^ reference local 1$119448696
 #          ^^^ reference [..] Flatfile#foo().
  t.bar = t.bar + 1
-#^ reference local 1~#119448696
+#^ reference local 1$119448696
 #  ^^^^^ reference [..] Flatfile#`bar=`().
-#        ^ reference local 1~#119448696
+#        ^ reference local 1$119448696
 #          ^^^ reference [..] Flatfile#bar().
  t.baz = t.baz + 1
-#^ reference local 1~#119448696
+#^ reference local 1$119448696
 #  ^^^^^ reference [..] Flatfile#`baz=`().
-#        ^ reference local 1~#119448696
+#        ^ reference local 1$119448696
 #          ^^^ reference [..] Flatfile#baz().

--- a/test/scip/testdata/for.snapshot.rb
+++ b/test/scip/testdata/for.snapshot.rb
@@ -3,23 +3,23 @@
  def for_loop()
 #    ^^^^^^^^ definition [..] Object#for_loop().
    y = 0
-#  ^ definition local 1~#1120785331
+#  ^ definition local 1$1120785331
    for x in [1, 2, 3]
-#      ^ definition local 2~#1120785331
+#      ^ definition local 2$1120785331
      y += x
-#    ^ reference (write) local 1~#1120785331
-#    ^ reference local 1~#1120785331
-#         ^ reference local 2~#1120785331
+#    ^ reference (write) local 1$1120785331
+#    ^ reference local 1$1120785331
+#         ^ reference local 2$1120785331
      for x in [3, 4, 5]
-#        ^ definition local 3~#1120785331
+#        ^ definition local 3$1120785331
        y += x
-#      ^ reference (write) local 1~#1120785331
-#      ^ reference local 1~#1120785331
-#      ^^^^^^ reference local 1~#1120785331
+#      ^ reference (write) local 1$1120785331
+#      ^ reference local 1$1120785331
+#      ^^^^^^ reference local 1$1120785331
 #        ^^ reference [..] Integer#+().
-#           ^ reference local 3~#1120785331
+#           ^ reference local 3$1120785331
      end
    end
    y
-#  ^ reference local 1~#1120785331
+#  ^ reference local 1$1120785331
  end

--- a/test/scip/testdata/functions.snapshot.rb
+++ b/test/scip/testdata/functions.snapshot.rb
@@ -3,26 +3,26 @@
  def globalFn1()
 #    ^^^^^^^^^ definition [..] Object#globalFn1().
    x = 10
-#  ^ definition local 1~#3846536873
+#  ^ definition local 1$3846536873
    x
-#  ^ reference local 1~#3846536873
+#  ^ reference local 1$3846536873
  end
  
  def globalFn2()
 #    ^^^^^^^^^ definition [..] Object#globalFn2().
    x = globalFn1()
-#  ^ definition local 1~#3796204016
-#  ^^^^^^^^^^^^^^^ reference local 1~#3796204016
+#  ^ definition local 1$3796204016
+#  ^^^^^^^^^^^^^^^ reference local 1$3796204016
 #      ^^^^^^^^^ reference [..] Object#globalFn1().
  end
  
  # https://stackoverflow.com/questions/64322636/whats-the-3-dots-method-argument-in-ruby
  def loopyDoopy(...)
 #    ^^^^^^^^^^ definition [..] Object#loopyDoopy().
-#               ^^^ definition local 1~#1182647655
-#               ^^^ definition local 2~#1182647655
-#               ^^^ definition local 3~#1182647655
+#               ^^^ definition local 1$1182647655
+#               ^^^ definition local 2$1182647655
+#               ^^^ definition local 3$1182647655
    loopyDoopy(...)
-#  ^^^^^^^^^^^^^^^ reference local 1~#1182647655
+#  ^^^^^^^^^^^^^^^ reference local 1$1182647655
    return
  end

--- a/test/scip/testdata/globals.snapshot.rb
+++ b/test/scip/testdata/globals.snapshot.rb
@@ -33,7 +33,7 @@
  
  $d = T.let(0, Integer)
 #^^ definition [global] `<Class:<root>>`#$d.
-#              ^^^^^^^ definition local 3~#119448696
+#              ^^^^^^^ definition local 3$119448696
 #              ^^^^^^^ reference [..] Integer#
  
  def g

--- a/test/scip/testdata/hashes.snapshot.rb
+++ b/test/scip/testdata/hashes.snapshot.rb
@@ -2,16 +2,16 @@
  
  def hashes(h, k)
 #    ^^^^^^ definition [..] Object#hashes().
-#           ^ definition local 1~#1685166589
-#              ^ definition local 2~#1685166589
+#           ^ definition local 1$1685166589
+#              ^ definition local 2$1685166589
    h["hello"] = "world"
-#  ^ reference local 1~#1685166589
+#  ^ reference local 1$1685166589
    old = h["world"]
-#  ^^^ definition local 3~#1685166589
-#        ^ reference local 1~#1685166589
+#  ^^^ definition local 3$1685166589
+#        ^ reference local 1$1685166589
    h[k] = h[old]
-#  ^ reference local 1~#1685166589
-#    ^ reference local 2~#1685166589
-#         ^ reference local 1~#1685166589
-#           ^^^ reference local 3~#1685166589
+#  ^ reference local 1$1685166589
+#    ^ reference local 2$1685166589
+#         ^ reference local 1$1685166589
+#           ^^^ reference local 3$1685166589
  end

--- a/test/scip/testdata/hoverdocs.snapshot.rb
+++ b/test/scip/testdata/hoverdocs.snapshot.rb
@@ -44,19 +44,19 @@
 #      | sig { params(c: T.untyped, b: T.untyped).returns(T::Boolean) }
 #      | def m3(c, b)
 #      | ```
-#         ^ definition local 1~#2519626513
+#         ^ definition local 1$2519626513
 #         documentation
 #         | ```ruby
 #         | c (T.untyped)
 #         | ```
-#            ^ definition local 2~#2519626513
+#            ^ definition local 2$2519626513
 #            documentation
 #            | ```ruby
 #            | b (T.untyped)
 #            | ```
      c.m2 || b
-#    ^ reference local 1~#2519626513
-#            ^ reference local 2~#2519626513
+#    ^ reference local 1$2519626513
+#            ^ reference local 2$2519626513
    end
  
    # _This_ is a
@@ -71,13 +71,13 @@
 #      documentation
 #      | _This_ is a
 #      | **doc comment.**
-#         ^^ definition local 1~#2536404132
+#         ^^ definition local 1$2536404132
 #         documentation
 #         | ```ruby
 #         | xs (T.untyped)
 #         | ```
      xs[0]
-#    ^^ reference local 1~#2536404132
+#    ^^ reference local 1$2536404132
    end
  
    # Yet another..
@@ -112,19 +112,19 @@
 #      documentation
 #      | And...
 #      | ...one more doc comment
-#         ^ definition local 1~#2569959370
+#         ^ definition local 1$2569959370
 #         documentation
 #         | ```ruby
 #         | c (T.untyped)
 #         | ```
-#            ^ definition local 2~#2569959370
+#            ^ definition local 2$2569959370
 #            documentation
 #            | ```ruby
 #            | b (T.untyped)
 #            | ```
      c.m2 || b
-#    ^ reference local 1~#2569959370
-#            ^ reference local 2~#2569959370
+#    ^ reference local 1$2569959370
+#            ^ reference local 2$2569959370
    end
  end
  

--- a/test/scip/testdata/implicit_super_arg.snapshot.rb
+++ b/test/scip/testdata/implicit_super_arg.snapshot.rb
@@ -22,8 +22,8 @@
 #      ^ definition [..] C#
    def f(a, b)
 #      ^ definition [..] C#f().
-#        ^ definition local 1~#3809224601
-#           ^ definition local 2~#3809224601
+#        ^ definition local 1$3809224601
+#           ^ definition local 2$3809224601
      super
    end
  end

--- a/test/scip/testdata/inheritance.snapshot.rb
+++ b/test/scip/testdata/inheritance.snapshot.rb
@@ -9,11 +9,11 @@
 #                     ^^^^^^^ reference [..] T#Boolean.
    def write_f(a)
 #      ^^^^^^^ definition [..] Z1#write_f().
-#              ^ definition local 1~#1000661517
+#              ^ definition local 1$1000661517
      @f = a
 #    ^^ definition [..] Z1#`@f`.
 #    ^^^^^^ reference [..] Z1#`@f`.
-#         ^ reference local 1~#1000661517
+#         ^ reference local 1$1000661517
    end
  
    sig { returns(T::Boolean) }
@@ -42,11 +42,11 @@
 #                     ^^^^^^^ reference [..] T#Boolean.
    def write_f(a)
 #      ^^^^^^^ definition [..] Z2#write_f().
-#              ^ definition local 1~#1000661517
+#              ^ definition local 1$1000661517
      @f = a
 #    ^^ definition [..] Z2#`@f`.
 #    ^^^^^^ reference [..] Z2#`@f`.
-#         ^ reference local 1~#1000661517
+#         ^ reference local 1$1000661517
    end
  end
  
@@ -76,10 +76,10 @@
 #                     ^^^^^^^ reference [..] T#Boolean.
    def write_f_plus_1(a)
 #      ^^^^^^^^^^^^^^ definition [..] Z4#write_f_plus_1().
-#                     ^ definition local 1~#3337417690
+#                     ^ definition local 1$3337417690
      write_f(a)
 #    ^^^^^^^ reference [..] Z1#write_f().
-#            ^ reference local 1~#3337417690
+#            ^ reference local 1$3337417690
      @f = read_f_plus_1?
 #    ^^ definition [..] Z4#`@f`.
 #    relation definition=[..] Z1#`@f`.

--- a/test/scip/testdata/loops_and_conditionals.snapshot.rb
+++ b/test/scip/testdata/loops_and_conditionals.snapshot.rb
@@ -3,42 +3,42 @@
  def if_elsif_else()
 #    ^^^^^^^^^^^^^ definition [..] Object#if_elsif_else().
    x = 0
-#  ^ definition local 1~#2393773952
+#  ^ definition local 1$2393773952
    y = 0
-#  ^ definition local 2~#2393773952
+#  ^ definition local 2$2393773952
    # Basic stuff
    if x == 1
-#     ^ reference local 1~#2393773952
+#     ^ reference local 1$2393773952
      y = 2
-#    ^ reference (write) local 2~#2393773952
+#    ^ reference (write) local 2$2393773952
    elsif x == 2
-#        ^ reference local 1~#2393773952
+#        ^ reference local 1$2393773952
      y = 3
-#    ^ reference (write) local 2~#2393773952
+#    ^ reference (write) local 2$2393773952
    else
      y = x
-#    ^ reference (write) local 2~#2393773952
-#        ^ reference local 1~#2393773952
+#    ^ reference (write) local 2$2393773952
+#        ^ reference local 1$2393773952
    end
  
    # More complex expressiosn
    z =
-#  ^ definition local 3~#2393773952
+#  ^ definition local 3$2393773952
      if if x == 0 then x+1 else x+2 end == 1
-#          ^ reference local 1~#2393773952
-#                      ^ reference local 1~#2393773952
-#                               ^ reference local 1~#2393773952
+#          ^ reference local 1$2393773952
+#                      ^ reference local 1$2393773952
+#                               ^ reference local 1$2393773952
 #                                       ^^ reference [..] Integer#`==`().
        x
-#      ^ reference local 1~#2393773952
+#      ^ reference local 1$2393773952
      else
        x+1
-#      ^ reference local 1~#2393773952
+#      ^ reference local 1$2393773952
      end
    z = z if z != 10
-#  ^ reference (write) local 3~#2393773952
-#      ^ reference local 3~#2393773952
-#           ^ reference local 3~#2393773952
+#  ^ reference (write) local 3$2393773952
+#      ^ reference local 3$2393773952
+#           ^ reference local 3$2393773952
 #             ^^ reference [..] BasicObject#`!=`().
  
    return
@@ -47,189 +47,189 @@
  def unless()
 #    ^^^^^^ definition [..] Object#unless().
    z = 0
-#  ^ definition local 1~#2827997891
+#  ^ definition local 1$2827997891
    x = 1
-#  ^ definition local 2~#2827997891
+#  ^ definition local 2$2827997891
    unless z == 9
-#         ^ reference local 1~#2827997891
+#         ^ reference local 1$2827997891
      z = 9
-#    ^ reference (write) local 1~#2827997891
+#    ^ reference (write) local 1$2827997891
    end
  
    unless x == 10
-#         ^ reference local 2~#2827997891
+#         ^ reference local 2$2827997891
      x = 3
-#    ^ reference (write) local 2~#2827997891
+#    ^ reference (write) local 2$2827997891
    else
      x = 2
-#    ^ reference (write) local 2~#2827997891
+#    ^ reference (write) local 2$2827997891
    end
    return
  end
  
  def case(x, y)
 #    ^^^^ definition [..] Object#case().
-#         ^ definition local 1~#2602907825
-#            ^ definition local 2~#2602907825
+#         ^ definition local 1$2602907825
+#            ^ definition local 2$2602907825
    case x
-#       ^ reference local 1~#2602907825
+#       ^ reference local 1$2602907825
      when 0
        x = 3
-#      ^ reference (write) local 1~#2602907825
+#      ^ reference (write) local 1$2602907825
      when y
-#         ^ reference local 2~#2602907825
+#         ^ reference local 2$2602907825
        x = 2
-#      ^ reference (write) local 1~#2602907825
+#      ^ reference (write) local 1$2602907825
      when (3 == (x = 1))
-#               ^^^^^^^ reference local 1~#2602907825
-#                ^ reference (write) local 1~#2602907825
+#               ^^^^^^^ reference local 1$2602907825
+#                ^ reference (write) local 1$2602907825
        x = 0
-#      ^ reference (write) local 1~#2602907825
+#      ^ reference (write) local 1$2602907825
      else
        x = 1
-#      ^ reference (write) local 1~#2602907825
+#      ^ reference (write) local 1$2602907825
    end
    return
  end
  
  def for(xs)
 #    ^^^ definition [..] Object#for().
-#        ^^ definition local 1~#2901640080
+#        ^^ definition local 1$2901640080
    for e in xs
-#      ^ definition local 2~#2901640080
-#           ^^ reference local 1~#2901640080
+#      ^ definition local 2$2901640080
+#           ^^ reference local 1$2901640080
      puts e
 #    ^^^^ reference [..] Kernel#puts().
-#         ^ reference local 2~#2901640080
+#         ^ reference local 2$2901640080
    end
  
    for f in xs
-#      ^ definition local 3~#2901640080
-#           ^^ reference local 1~#2901640080
+#      ^ definition local 3$2901640080
+#           ^^ reference local 1$2901640080
      g = f+1
-#    ^ definition local 4~#2901640080
-#        ^ reference local 3~#2901640080
+#    ^ definition local 4$2901640080
+#        ^ reference local 3$2901640080
      next if g == 0
-#            ^ reference local 4~#2901640080
+#            ^ reference local 4$2901640080
 #              ^^ reference [..] BasicObject#`==`().
      next g+1 if g == 1
-#         ^ reference local 4~#2901640080
-#                ^ reference local 4~#2901640080
+#         ^ reference local 4$2901640080
+#                ^ reference local 4$2901640080
 #                  ^^ reference [..] BasicObject#`==`().
      break if g == 2
-#             ^ reference local 4~#2901640080
+#             ^ reference local 4$2901640080
 #               ^^ reference [..] BasicObject#`==`().
      break g+1 if g == 3
-#          ^ reference local 4~#2901640080
-#                 ^ reference local 4~#2901640080
+#          ^ reference local 4$2901640080
+#                 ^ reference local 4$2901640080
 #                   ^^ reference [..] BasicObject#`==`().
      # NOTE: redo is unsupported (https://srb.help/3003)
      # but emitting a reference here does work
      redo if g == 4
-#            ^ reference local 4~#2901640080
+#            ^ reference local 4$2901640080
 #              ^^ reference [..] BasicObject#`==`().
    end
  end
  
  def while(xs)
 #    ^^^^^ definition [..] Object#while().
-#          ^^ definition local 1~#231090382
+#          ^^ definition local 1$231090382
    i = 0
-#  ^ definition local 2~#231090382
+#  ^ definition local 2$231090382
    while i < 10
-#        ^ reference local 2~#231090382
+#        ^ reference local 2$231090382
      puts xs[i]
 #    ^^^^ reference [..] Kernel#puts().
-#         ^^ reference local 1~#231090382
-#            ^ reference local 2~#231090382
+#         ^^ reference local 1$231090382
+#            ^ reference local 2$231090382
    end
  
    j = 0
-#  ^ definition local 3~#231090382
+#  ^ definition local 3$231090382
    while j < 10
-#        ^ reference local 3~#231090382
+#        ^ reference local 3$231090382
      g = xs[j]
-#    ^ definition local 4~#231090382
-#        ^^ reference local 1~#231090382
-#           ^ reference local 3~#231090382
+#    ^ definition local 4$231090382
+#        ^^ reference local 1$231090382
+#           ^ reference local 3$231090382
      next if g == 0
-#            ^ reference local 4~#231090382
+#            ^ reference local 4$231090382
 #              ^^ reference [..] BasicObject#`==`().
      next g+1 if g == 1
-#         ^ reference local 4~#231090382
-#                ^ reference local 4~#231090382
+#         ^ reference local 4$231090382
+#                ^ reference local 4$231090382
 #                  ^^ reference [..] BasicObject#`==`().
      break if g == 2
-#             ^ reference local 4~#231090382
+#             ^ reference local 4$231090382
 #               ^^ reference [..] BasicObject#`==`().
      break g+1 if g == 3
-#          ^ reference local 4~#231090382
-#                 ^ reference local 4~#231090382
+#          ^ reference local 4$231090382
+#                 ^ reference local 4$231090382
 #                   ^^ reference [..] BasicObject#`==`().
      # NOTE: redo is unsupported (https://srb.help/3003)
      # but emitting a reference here does work
      redo if g == 4
-#            ^ reference local 4~#231090382
+#            ^ reference local 4$231090382
 #              ^^ reference [..] BasicObject#`==`().
    end
  end
  
  def until(xs)
 #    ^^^^^ definition [..] Object#until().
-#          ^^ definition local 1~#3132432719
+#          ^^ definition local 1$3132432719
    i = 0
-#  ^ definition local 2~#3132432719
+#  ^ definition local 2$3132432719
    until i > 10
-#        ^ reference local 2~#3132432719
+#        ^ reference local 2$3132432719
      puts xs[i]
 #    ^^^^ reference [..] Kernel#puts().
-#         ^^ reference local 1~#3132432719
-#            ^ reference local 2~#3132432719
+#         ^^ reference local 1$3132432719
+#            ^ reference local 2$3132432719
    end
  
    j = 0
-#  ^ definition local 3~#3132432719
+#  ^ definition local 3$3132432719
    until j > 10
-#        ^ reference local 3~#3132432719
+#        ^ reference local 3$3132432719
      g = xs[j]
-#    ^ definition local 4~#3132432719
-#        ^^ reference local 1~#3132432719
-#           ^ reference local 3~#3132432719
+#    ^ definition local 4$3132432719
+#        ^^ reference local 1$3132432719
+#           ^ reference local 3$3132432719
      next if g == 0
-#            ^ reference local 4~#3132432719
+#            ^ reference local 4$3132432719
 #              ^^ reference [..] BasicObject#`==`().
      next g+1 if g == 1
-#         ^ reference local 4~#3132432719
-#                ^ reference local 4~#3132432719
+#         ^ reference local 4$3132432719
+#                ^ reference local 4$3132432719
 #                  ^^ reference [..] BasicObject#`==`().
      break if g == 2
-#             ^ reference local 4~#3132432719
+#             ^ reference local 4$3132432719
 #               ^^ reference [..] BasicObject#`==`().
      break g+1 if g == 3
-#          ^ reference local 4~#3132432719
-#                 ^ reference local 4~#3132432719
+#          ^ reference local 4$3132432719
+#                 ^ reference local 4$3132432719
 #                   ^^ reference [..] BasicObject#`==`().
      # NOTE: redo is unsupported (https://srb.help/3003)
      # but emitting a reference here does work
      redo if g == 4
-#            ^ reference local 4~#3132432719
+#            ^ reference local 4$3132432719
 #              ^^ reference [..] BasicObject#`==`().
    end
  end
  
  def flip_flop(xs)
 #    ^^^^^^^^^ definition [..] Object#flip_flop().
-#              ^^ definition local 1~#2191960030
+#              ^^ definition local 1$2191960030
    # NOTE: flip-flops are unsupported (https://srb.help/3003)
    # Unlike redo, which somehow works, we fail to emit references
    # for the conditions.
    # Keep this test anyways to check that we don't crash/mess something up
    for x in xs
-#      ^ definition local 2~#2191960030
-#           ^^ reference local 1~#2191960030
+#      ^ definition local 2$2191960030
+#           ^^ reference local 1$2191960030
      puts x if x==2..x==8
-#         ^ reference local 2~#2191960030
+#         ^ reference local 2$2191960030
      puts x+1 if x==4...x==6
-#         ^ reference local 2~#2191960030
+#         ^ reference local 2$2191960030
    end
  end

--- a/test/scip/testdata/minitest_1.snapshot.rb
+++ b/test/scip/testdata/minitest_1.snapshot.rb
@@ -8,11 +8,11 @@
      it "works outside" do
 #       ^^^^^^^^^^^^^^^ definition [..] MyTest#`<it 'works outside'>`().
          x = outside_method
-#        ^ definition local 1~#1914741329
+#        ^ definition local 1$1914741329
 #            ^^^^^^^^^^^^^^ reference [..] MyTest#outside_method().
          x = x + 1
-#        ^ reference (write) local 1~#1914741329
-#            ^ reference local 1~#1914741329
+#        ^ reference (write) local 1$1914741329
+#            ^ reference local 1$1914741329
          return
      end
  
@@ -32,8 +32,8 @@
 #      ^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Kernel#
 #      ^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Kernel#raise().
 #      ^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Module#
-#                     ^^^^^^^ definition local 1~#95163902
-#                     ^^^^^^^ definition local 3~#119448696
+#                     ^^^^^^^ definition local 1$95163902
+#                     ^^^^^^^ definition local 3$119448696
 #                     ^^^^^^^ reference [..] Integer#
      end
  
@@ -72,7 +72,7 @@
 #    ^^^^^^ definition [..] MyTest#`<before>`().
          @foo = T.let(3, Integer)
 #        ^^^^ definition [..] MyTest#`@foo`.
-#                        ^^^^^^^ definition local 1~#2938098190
+#                        ^^^^^^^ definition local 1$2938098190
 #                        ^^^^^^^ reference [..] Integer#
          instance_helper
 #        ^^^^^^^^^^^^^^^ reference [..] MyTest#instance_helper().
@@ -82,7 +82,7 @@
 #       ^^^^^^^^^^^^^^ definition [..] MyTest#`<it 'can read foo'>`().
          T.assert_type!(@foo, Integer)
 #                       ^^^^ reference [..] MyTest#`@foo`.
-#                             ^^^^^^^ definition local 1~#3909275672
+#                             ^^^^^^^ definition local 1$3909275672
 #                             ^^^^^^^ reference [..] Integer#
          instance_helper
 #        ^^^^^^^^^^^^^^^ reference [..] MyTest#instance_helper().

--- a/test/scip/testdata/minitest_3.snapshot.rb
+++ b/test/scip/testdata/minitest_3.snapshot.rb
@@ -18,10 +18,10 @@
  
    test_each([[1,2], [3,4]]) do |(a,b)|
 #  ^^^^^^^^^ reference [..] `<Class:Test>`#test_each().
-#                                 ^ definition local 1~#2288740619
-#                                 ^ definition local 1~#416088458
-#                                   ^ definition local 2~#2288740619
-#                                   ^ definition local 2~#416088458
+#                                 ^ definition local 1$2288740619
+#                                 ^ definition local 1$416088458
+#                                   ^ definition local 2$2288740619
+#                                   ^ definition local 2$416088458
  
      describe "d" do
        it "b" do
@@ -29,7 +29,7 @@
          T.reveal_type(a) # error: Revealed type: `Integer`
 #        ^ reference [..] T#
 #          ^^^^^^^^^^^ reference [..] `<Class:T>`#reveal_type().
-#                      ^ reference local 1~#416088458
+#                      ^ reference local 1$416088458
        end
      end
  
@@ -38,7 +38,7 @@
        T.reveal_type(a) # error: Revealed type: `Integer`
 #      ^ reference [..] T#
 #        ^^^^^^^^^^^ reference [..] `<Class:T>`#reveal_type().
-#                    ^ reference local 1~#2288740619
+#                    ^ reference local 1$2288740619
      end
  
    end

--- a/test/scip/testdata/multifile/basic/use_class1.snapshot.rb
+++ b/test/scip/testdata/multifile/basic/use_class1.snapshot.rb
@@ -5,7 +5,7 @@
 #^^^^^^^ reference [..] Kernel#require().
  
  b = C1.new.m1
-#^ definition local 2~#119448696
+#^ definition local 2$119448696
 #documentation
 #| ```ruby
 #| b (T::Boolean)

--- a/test/scip/testdata/opus.snapshot.rb
+++ b/test/scip/testdata/opus.snapshot.rb
@@ -27,7 +27,7 @@
 #                                                                                  ^^^^^^^^ reference [..] `<Class:T>`#class_of().
 #                                                                                           ^^^^ reference [..] Opus#
 #                                                                                                 ^^^^ reference [..] Opus#Base#
-#                                                                                                 ^^^^^^^ definition local 4~#119448696
+#                                                                                                 ^^^^^^^ definition local 4$119448696
 #                                                                                                 ^^^^^^^^ reference [..] TYPES.
  
  module ABC
@@ -41,7 +41,7 @@
 #                                                                     ^^^^^^ reference [..] Symbol#
 #                                                                                                       ^^^^ reference [..] Opus#
 #                                                                                                             ^^^^ reference [..] Opus#Base#
-#                                                                                                             ^^^^^^^ definition local 4~#119448696
+#                                                                                                             ^^^^^^^ definition local 4$119448696
 #                                                                                                             ^^^^^^^^ reference [..] ABC#TYPES_IN_MODULE.
  end
  
@@ -56,6 +56,6 @@
 #                                                                    ^^^^^^ reference [..] Symbol#
 #                                                                                                      ^^^^ reference [..] Opus#
 #                                                                                                            ^^^^ reference [..] Opus#Base#
-#                                                                                                            ^^^^^^^ definition local 4~#119448696
+#                                                                                                            ^^^^^^^ definition local 4$119448696
 #                                                                                                            ^^^^^^^^ reference [..] Other#TYPES_IN_CLASS.
  end

--- a/test/scip/testdata/prop.snapshot.rb
+++ b/test/scip/testdata/prop.snapshot.rb
@@ -21,7 +21,7 @@
 #                     ^ reference [..] T#
 #                       ^^^^^^ reference [..] `<Class:T>`#unsafe().
 #                                    ^ reference [..] T#
-#                                    ^^^^^^^^^^^^^^^^^ definition local 1~#1867563647
+#                                    ^^^^^^^^^^^^^^^^^ definition local 1$1867563647
 #                                      ^^^^^^^ reference [..] `<Class:T>`#nilable().
 #                                              ^^^^^^ reference [..] String#
      sig {params(arg0: String).returns(String)}
@@ -29,7 +29,7 @@
 #                                      ^^^^^^ reference [..] String#
      def foo2=(arg0); T.cast(nil, String); end
 #        ^^^^^ definition [..] SomeODM#`foo2=`().
-#                                 ^^^^^^ definition local 1~#2116144614
+#                                 ^^^^^^ definition local 1$2116144614
 #                                 ^^^^^^ reference [..] String#
  end
  

--- a/test/scip/testdata/rescue.snapshot.rb
+++ b/test/scip/testdata/rescue.snapshot.rb
@@ -7,10 +7,10 @@
  
  def handle(e)
 #    ^^^^^^ definition [..] Object#handle().
-#           ^ definition local 1~#780127187
+#           ^ definition local 1$780127187
    puts e.inspect.to_s 
 #  ^^^^ reference [..] Kernel#puts().
-#       ^ reference local 1~#780127187
+#       ^ reference local 1$780127187
 #         ^^^^^^^ reference [..] Kernel#inspect().
 #                 ^^^^ reference [..] Kernel#to_s().
  end
@@ -22,15 +22,15 @@
 #    ^^^^^ reference [..] Kernel#raise().
    rescue MyError => e1
 #         ^^^^^^^ reference [..] MyError#
-#                    ^^ definition local 2~#3809224601
+#                    ^^ definition local 2$3809224601
      handle(e1)
 #    ^^^^^^ reference [..] Object#handle().
-#           ^^ reference local 2~#3809224601
+#           ^^ reference local 2$3809224601
    rescue StandardError => e2
 #         ^^^^^^^^^^^^^ reference [..] StandardError#
-#                          ^^ definition local 4~#3809224601
+#                          ^^ definition local 4$3809224601
      handle(e2)
 #    ^^^^^^ reference [..] Object#handle().
-#           ^^ reference local 4~#3809224601
+#           ^^ reference local 4$3809224601
    end
  end

--- a/test/scip/testdata/struct.snapshot.rb
+++ b/test/scip/testdata/struct.snapshot.rb
@@ -21,27 +21,27 @@
  def f
 #    ^ definition [..] Object#f().
    s = S.new(prop_i: 3)
-#  ^ definition local 1~#3809224601
+#  ^ definition local 1$3809224601
 #      ^ reference [..] S#
 #        ^^^ reference [..] Class#new().
    _ = s.prop_i.to_s + s.const_s + s.const_f.to_s + s.serialize.to_s
-#  ^ definition local 3~#3809224601
-#      ^ reference local 1~#3809224601
+#  ^ definition local 3$3809224601
+#      ^ reference local 1$3809224601
 #        ^^^^^^ reference [..] S#prop_i().
 #               ^^^^ reference [..] Integer#to_s().
 #                    ^ reference [..] String#+().
-#                      ^ reference local 1~#3809224601
+#                      ^ reference local 1$3809224601
 #                        ^^^^^^^ reference [..] S#const_s().
 #                                ^ reference [..] String#+().
-#                                  ^ reference local 1~#3809224601
+#                                  ^ reference local 1$3809224601
 #                                    ^^^^^^^ reference [..] S#const_f().
 #                                            ^^^^ reference [..] Float#to_s().
 #                                                 ^ reference [..] String#+().
-#                                                   ^ reference local 1~#3809224601
+#                                                   ^ reference local 1$3809224601
 #                                                     ^^^^^^^^^ reference [..] T#Props#Serializable#serialize().
 #                                                               ^^^^ reference [..] Kernel#to_s().
    s.prop_i = 4
-#  ^ reference local 1~#3809224601
+#  ^ reference local 1$3809224601
 #    ^^^^^^^^ reference [..] S#`prop_i=`().
    return
  end
@@ -67,16 +67,16 @@
  def g
 #    ^ definition [..] Object#g().
    p = POINT.new(0, 1)
-#  ^ definition local 1~#3792446982
+#  ^ definition local 1$3792446982
 #      ^^^^^ reference [..] POINT#
 #            ^^^ reference [..] Class#new().
    a = p.array
-#  ^ definition local 3~#3792446982
-#      ^ reference local 1~#3792446982
+#  ^ definition local 3$3792446982
+#      ^ reference local 1$3792446982
 #        ^^^^^ reference [..] POINT#array().
    px = p.x
-#  ^^ definition local 4~#3792446982
-#       ^ reference local 1~#3792446982
+#  ^^ definition local 4$3792446982
+#       ^ reference local 1$3792446982
 #         ^ reference [..] POINT#x().
    return
  end

--- a/test/scip/testdata/test_case.snapshot.rb
+++ b/test/scip/testdata/test_case.snapshot.rb
@@ -16,7 +16,7 @@
 #                                           ^^^^^^^ reference [..] T#Boolean.
    def assert(test)
 #      ^^^^^^ definition [..] MyTest#assert().
-#             ^^^^ definition local 1~#2774883451
+#             ^^^^ definition local 1$2774883451
      test ? true : false
    end
  
@@ -31,7 +31,7 @@
      @a = T.let(1, Integer)
 #    ^^ definition [..] MyTest#`@a`.
 #    ^^^^^^^^^^^^^^^^^^^^^^ reference [..] MyTest#`@a`.
-#                  ^^^^^^^ definition local 1~#2938098190
+#                  ^^^^^^^ definition local 1$2938098190
 #                  ^^^^^^^ reference [..] Integer#
    end
  
@@ -83,7 +83,7 @@
      @a = T.let(1, Integer)
 #    ^^ definition [..] NoParentClass#`@a`.
 #    ^^^^^^^^^^^^^^^^^^^^^^ reference [..] NoParentClass#`@a`.
-#                  ^^^^^^^ definition local 1~#2938098190
+#                  ^^^^^^^ definition local 1$2938098190
 #                  ^^^^^^^ reference [..] Integer#
    end
  

--- a/test/scip/testdata/type_change.snapshot.rb
+++ b/test/scip/testdata/type_change.snapshot.rb
@@ -8,21 +8,21 @@
 #    | sig { params(b: T.untyped).returns(T.untyped) }
 #    | def assign_different_branches(b)
 #    | ```
-#                              ^ definition local 1~#3317016627
+#                              ^ definition local 1$3317016627
 #                              documentation
 #                              | ```ruby
 #                              | b (T.untyped)
 #                              | ```
    if b
      x = 1
-#    ^ definition local 2~#3317016627
+#    ^ definition local 2$3317016627
 #    documentation
 #    | ```ruby
 #    | x (Integer(1))
 #    | ```
    else
      x = nil
-#    ^ definition local 2~#3317016627
+#    ^ definition local 2$3317016627
 #    documentation
 #    | ```ruby
 #    | x (Integer(1))
@@ -38,27 +38,27 @@
 #    | sig { params(b: T.untyped).returns(T.untyped) }
 #    | def change_different_branches(b)
 #    | ```
-#                              ^ definition local 1~#2122680152
+#                              ^ definition local 1$2122680152
 #                              documentation
 #                              | ```ruby
 #                              | b (T.untyped)
 #                              | ```
    x = 'foo'
-#  ^ definition local 2~#2122680152
+#  ^ definition local 2$2122680152
 #  documentation
 #  | ```ruby
 #  | x (String("foo"))
 #  | ```
    if b
      x = 1
-#    ^ reference (write) local 2~#2122680152
+#    ^ reference (write) local 2$2122680152
 #    override_documentation
 #    | ```ruby
 #    | x (Integer(1))
 #    | ```
    else
      x = nil
-#    ^ reference (write) local 2~#2122680152
+#    ^ reference (write) local 2$2122680152
 #    override_documentation
 #    | ```ruby
 #    | x (NilClass)
@@ -74,47 +74,47 @@
 #    | sig { params(bs: T.untyped).returns(T.untyped) }
 #    | def loop_type_change(bs)
 #    | ```
-#                     ^^ definition local 1~#4057334513
+#                     ^^ definition local 1$4057334513
 #                     documentation
 #                     | ```ruby
 #                     | bs (T.untyped)
 #                     | ```
    x = nil
-#  ^ definition local 2~#4057334513
+#  ^ definition local 2$4057334513
 #  documentation
 #  | ```ruby
 #  | x (NilClass)
 #  | ```
    for b in bs
-#      ^ definition local 3~#4057334513
+#      ^ definition local 3$4057334513
 #      documentation
 #      | ```ruby
 #      | b (T.untyped)
 #      | ```
-#           ^^ reference local 1~#4057334513
+#           ^^ reference local 1$4057334513
      puts x
 #    ^^^^ reference [..] Kernel#puts().
-#         ^ reference local 2~#4057334513
+#         ^ reference local 2$4057334513
      if b
        x = 1
-#      ^ reference (write) local 2~#4057334513
+#      ^ reference (write) local 2$4057334513
 #      override_documentation
 #      | ```ruby
 #      | x (T.untyped)
 #      | ```
-#      ^^^^^ reference local 2~#4057334513
+#      ^^^^^ reference local 2$4057334513
 #      override_documentation
 #      | ```ruby
 #      | x = 1 (T.untyped)
 #      | ```
      else
        x = 's'
-#      ^ reference (write) local 2~#4057334513
+#      ^ reference (write) local 2$4057334513
 #      override_documentation
 #      | ```ruby
 #      | x (T.untyped)
 #      | ```
-#      ^^^^^^^ reference local 2~#4057334513
+#      ^^^^^^^ reference local 2$4057334513
 #      override_documentation
 #      | ```ruby
 #      | x = 's' (T.untyped)
@@ -144,7 +144,7 @@
 #      | sig { params(b: T.untyped).returns(T.untyped) }
 #      | def change_type(b)
 #      | ```
-#                  ^ definition local 1~#2066187318
+#                  ^ definition local 1$2066187318
 #                  documentation
 #                  | ```ruby
 #                  | b (T.untyped)
@@ -221,14 +221,14 @@
 #      | sig { params(b: T.untyped).returns(T.untyped) }
 #      | def change_type(b)
 #      | ```
-#                  ^ definition local 1~#2066187318
+#                  ^ definition local 1$2066187318
 #                  documentation
 #                  | ```ruby
 #                  | b (T.untyped)
 #                  | ```
      if !b
 #       ^ reference [..] BasicObject#`!`().
-#        ^ reference local 1~#2066187318
+#        ^ reference local 1$2066187318
        @f = 1
 #      ^^ definition [..] D#`@f`.
 #      documentation

--- a/test/scip/testdata/type_docs.snapshot.rb
+++ b/test/scip/testdata/type_docs.snapshot.rb
@@ -20,35 +20,35 @@
 #      | sig { params(x: Integer, y: String).returns(String) }
 #      | def js_add(x, y)
 #      | ```
-#             ^ definition local 1~#1239553962
+#             ^ definition local 1$1239553962
 #             documentation
 #             | ```ruby
 #             | x (Integer)
 #             | ```
-#                ^ definition local 2~#1239553962
+#                ^ definition local 2$1239553962
 #                documentation
 #                | ```ruby
 #                | y (String)
 #                | ```
      xs = x.to_s
-#    ^^ definition local 3~#1239553962
+#    ^^ definition local 3$1239553962
 #    documentation
 #    | ```ruby
 #    | xs (String)
 #    | ```
-#         ^ reference local 1~#1239553962
+#         ^ reference local 1$1239553962
 #           ^^^^ reference [..] Integer#to_s().
      ret = xs + y
-#    ^^^ definition local 4~#1239553962
+#    ^^^ definition local 4$1239553962
 #    documentation
 #    | ```ruby
 #    | ret (String)
 #    | ```
-#          ^^ reference local 3~#1239553962
+#          ^^ reference local 3$1239553962
 #             ^ reference [..] String#+().
-#               ^ reference local 2~#1239553962
+#               ^ reference local 2$1239553962
      return ret
-#    ^^^^^^^^^^ reference local 4~#1239553962
+#    ^^^^^^^^^^ reference local 4$1239553962
 #    override_documentation
 #    | ```ruby
 #    | return ret (T.noreturn)

--- a/test/scip/testdata/typed_false.snapshot.rb
+++ b/test/scip/testdata/typed_false.snapshot.rb
@@ -11,9 +11,9 @@
  
    def g(x)
 #      ^ definition [..] C#g().
-#        ^ definition local 1~#3792446982
+#        ^ definition local 1$3792446982
      x + @f + f
-#    ^ reference local 1~#3792446982
+#    ^ reference local 1$3792446982
 #        ^^ reference [..] C#`@f`.
 #             ^ reference [..] C#f().
    end


### PR DESCRIPTION
usagesForSymbol now validates well-formedness of symbols,
which breaks it for locals, where we were using ~ and #,
which are not allowed in local symbol strings per the SCIP
spec. Use $ instead.

Fixes GRAPH-1311.

### Test plan

Updated tests