### PR TITLE
fix: Update CI to use Ubuntu 22.04 as the minimum

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,4 @@
 # Stop actionlint from triggering failures
 self-hosted-runner:
   labels:
-    - ubuntu-20.04-16core-graph-team
+    - ubuntu-22.04-32core-graph-team-amd64

--- a/.github/workflows/build_gems.yml
+++ b/.github/workflows/build_gems.yml
@@ -6,7 +6,7 @@ jobs:
     name: 'Build gem'
     strategy:
       matrix:
-        platform: ['ubuntu-20.04', 'macos-13']
+        platform: ['ubuntu-22.04', 'macos-13']
         config: ['asserts', 'release']
     runs-on: ${{ matrix.platform }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-22.04'
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-22.04'
     steps:
       - uses: actions/checkout@v4
       - name: Format Bazel files

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   release-image:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-22.04'
     steps:
       - run: |
           if [ -z "$TAG" ]; then

--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   download-and-publish-gems:
     name: 'Download and publish gems'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     env:
       TAG: ${{ inputs.tag }}
     steps:

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # Use macos-14 as macos-13 runner is only offered for x86_64
-        platform: ['ubuntu-20.04-16core-graph-team', 'macos-13-xlarge']
+        platform: ['ubuntu-22.04-32core-graph-team-amd64', 'macos-13-xlarge']
         config: ['asserts', 'release']
     runs-on: ${{ matrix.platform }}
     env:
@@ -96,7 +96,7 @@ jobs:
   create-release:
     name: 'Create release (dry run)'
     needs: build-and-upload-artifacts
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     env:
       FAKE_VERSION: ${{ inputs.fakeVersion }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: 'Build and upload artifacts'
     strategy:
       matrix:
-        platform: ['ubuntu-20.04-16core-graph-team', 'macos-13-xlarge']
+        platform: ['ubuntu-22.04-32core-graph-team-amd64', 'macos-13-xlarge']
         # Keep the platform list in sync with 'Supported Configurations' in README.md
         config: ['asserts', 'release']
     runs-on: ${{ matrix.platform }}
@@ -89,7 +89,7 @@ jobs:
   create-release:
     name: 'Create release'
     needs: build-and-upload-artifacts
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     steps:
       - uses: actions/checkout@v4
       - name: Create Release


### PR DESCRIPTION
Ubuntu 20.04 is no longer supported by GitHub Actions

Fixes GRAPH-1312

### Test plan

See if tests pass.