### PR TITLE
ci: Cache Bazel data from linting step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,27 @@ jobs:
     runs-on: 'ubuntu-22.04'
     steps:
       - uses: actions/checkout@v4
+      # Keep in sync with ci.yml
+      - name: Manually evict cache entry if applicable
+        run: ACCESS_TOKEN='${{ secrets.GITHUB_TOKEN }}' python3 .github/workflows/evict.py
+      - name: "🚀 Mount Bazel build cache"
+        uses: actions/cache@v4
+        with:
+          path: ~/bazelcache/build
+          key: lint-bazel-build-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            lint-bazel-build-${{ runner.os }}-
+            lint-bazel-build-
+      - name: "🚀 Mount Bazel repo cache"
+        uses: actions/cache@v4
+        with:
+          path: ~/bazelcache/repos
+          key: lint-bazel-repos-${{ runner.os }}-${{ hashFiles('WORKSPACE') }}
+          restore-keys: |
+            lint-bazel-repos-${{ runner.os }}-
+            lint-bazel-repos-
+      - name: "⚙️ Setup Bazel"
+        run: .github/workflows/setup-bazel.sh
       - name: Format Bazel files
         run: |
           ./tools/scripts/format_build_files.sh


### PR DESCRIPTION
Right now, we keep rebuilding protoc from scratch
(as a dependency of Buildifier...?) which takes several
minutes, making the linting step slower than the
ci.yml workflow. We should just cache things.

Ideally, we would just depend on pre-built buildifier
binaries, such as in https://github.com/keith/buildifier-prebuilt,
but we don't want to have divergence in the build
config from upstream, if possible.

### Test plan

See if linting step speeds up in subsequent PRs.