### PR TITLE
chore: Prepare for v0.4.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v0.4.7
+
+Changes the internal symbol structure for local variables
+and parameters to be compliant with the [SCIP](https://github.com/sourcegraph/scip) specification.
+
+Sourcegraph 6.9 has stronger validation checks,
+which prevents Find references from working correctly
+with local variables. This issue is not applicable
+to later releases such as Sourcegraph 6.10 or newer.
+
 ## v0.4.6
 
 Backports upstream Sorbet fix for crashes for specific

--- a/docs/scip-ruby/CONTRIBUTING.md
+++ b/docs/scip-ruby/CONTRIBUTING.md
@@ -364,7 +364,6 @@ This will correctly use the `scip-ruby/master` branch as the target.
 
 1. Add release notes to the [CHANGELOG](/CHANGELOG.md).
 2. Bump `scip_ruby_version` in `SCIPIndexer.cc`.
-3. Bump the release version in `Dockerfile.autoindex`.
 
 Run the release script:
 

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -61,7 +61,7 @@ static uint32_t fnv1a_32(const string &s) {
     return h;
 }
 
-const char scip_ruby_version[] = "0.4.6";
+const char scip_ruby_version[] = "0.4.7";
 
 // Last updated: https://github.com/sourcegraph/scip-ruby/pull/217
 const char scip_ruby_sync_upstream_sorbet_sha[] = "0a7b175bc0bb41e2672369554f74364e83711a84";


### PR DESCRIPTION
Cut a new release with the latest fix.

### Test plan

See included automated tests.
