### PR TITLE
Fix assertion failure in `saveQualifierReferences`

### DIFF
--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -477,7 +477,7 @@ public:
                                          ast::ExpressionPtr &constantLitExpr) {
         auto *expr = &constantLitExpr;
         while (auto *constantLit = ast::cast_tree<ast::ConstantLit>(*expr)) {
-            if (constantLit->symbol.exists() && constantLit->symbol.asClassOrModuleRef().exists()) {
+            if (constantLit->symbol.exists() && constantLit->symbol.isClassOrModule() && constantLit->symbol.asClassOrModuleRef().exists()) {
                 core::Context ctx(gs, constantLit->symbol, file);
                 auto status = this->saveReference(ctx, GenericSymbolRef::classOrModule(constantLit->symbol),
                                                   /*overrideType*/ std::nullopt, constantLit->loc, 0);

--- a/test/scip/testdata/inheritance.rb
+++ b/test/scip/testdata/inheritance.rb
@@ -47,3 +47,7 @@ class Z4 < Z3
   end
 end
 
+Z5 = Object
+class Z6 < Z5
+end
+

--- a/test/scip/testdata/inheritance.snapshot.rb
+++ b/test/scip/testdata/inheritance.snapshot.rb
@@ -89,3 +89,12 @@
    end
  end
  
+ Z5 = Object
+#^^ definition [..] Z5.
+#relation reference=[..] Object#
+#^^^^^^^^^^^ reference [..] Z5.
+#     ^^^^^^ reference [..] Object#
+ class Z6 < Z5
+#      ^^ definition [..] Z6#
+ end
+ 


### PR DESCRIPTION
Check that the symbol is a class or module before calling `asClassOrModuleRef()`. This prevents crashes when processing symbols that are not classes or modules (e.g. fields or methods) but are encountered in contexts where a class or module reference was assumed.

The error can be triggered by running the indexer against [Homebrew/brew](https://github.com/Homebrew/brew) repository.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
