### PR TITLE
fix: avoid overlapping definition for T::Enum synthetic serialize() method

### DIFF
--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -238,25 +238,11 @@ void TEnum::run(core::MutableContext ctx, ast::ClassDef *klass) {
             }
         }
     }
-    if (core::isa_type<core::ClassType>(serializeReturnType) && !serializeReturnType.isUntyped() &&
-        !serializeReturnType.isBottom()) {
-        auto serializeReturnTypeClass = core::cast_type_nonnull<core::ClassType>(serializeReturnType);
-        ast::ExpressionPtr return_type_ast = ast::MK::Constant(klass->declLoc, serializeReturnTypeClass.symbol);
-        auto sig = ast::MK::Sig0(klass->declLoc, std::move(return_type_ast));
-        // Use zero-length location for the synthetic serialize() method name to avoid
-        // overlapping with the class name definition. Overlapping definitions cause
-        // issues in the Sourcegraph UI where Find References picks up the wrong symbol.
-        auto method = ast::MK::SyntheticMethod0(klass->loc, klass->declLoc, locZero, core::Names::serialize(),
-                                                ast::MK::RaiseTypedUnimplemented(klass->declLoc));
-        ast::Send::ARGS_store nargs;
-        ast::Send::Flags flags;
-        flags.isPrivateOk = true;
-        auto visibility = ast::MK::Send(klass->declLoc, ast::MK::Self(klass->declLoc), core::Names::public_(),
-                                        klass->declLoc, 0, std::move(nargs), flags);
-
-        klass->rhs.emplace_back(std::move(visibility));
-        klass->rhs.emplace_back(std::move(sig));
-        klass->rhs.emplace_back(std::move(method));
-    }
+    // NOTE: We intentionally skip generating the synthetic serialize() method definition here.
+    // T::Enum provides serialize() but emitting a definition at the class declaration location
+    // causes overlapping definitions with the class itself, which breaks Find References in
+    // Sourcegraph UI. Since serialize() is a Sorbet stdlib method (not user-defined), omitting
+    // the definition is acceptable - users can still navigate via the class inheritance.
+    (void)serializeReturnType; // Silence unused variable warning
 }
 }; // namespace sorbet::rewriter

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -243,7 +243,10 @@ void TEnum::run(core::MutableContext ctx, ast::ClassDef *klass) {
         auto serializeReturnTypeClass = core::cast_type_nonnull<core::ClassType>(serializeReturnType);
         ast::ExpressionPtr return_type_ast = ast::MK::Constant(klass->declLoc, serializeReturnTypeClass.symbol);
         auto sig = ast::MK::Sig0(klass->declLoc, std::move(return_type_ast));
-        auto method = ast::MK::SyntheticMethod0(klass->loc, klass->declLoc, klass->name.loc(), core::Names::serialize(),
+        // Use zero-length location for the synthetic serialize() method name to avoid
+        // overlapping with the class name definition. Overlapping definitions cause
+        // issues in the Sourcegraph UI where Find References picks up the wrong symbol.
+        auto method = ast::MK::SyntheticMethod0(klass->loc, klass->declLoc, locZero, core::Names::serialize(),
                                                 ast::MK::RaiseTypedUnimplemented(klass->declLoc));
         ast::Send::ARGS_store nargs;
         ast::Send::Flags flags;

--- a/test/scip/testdata/alias.snapshot.rb
+++ b/test/scip/testdata/alias.snapshot.rb
@@ -49,9 +49,6 @@
  class X < T::Enum
 #      ^ definition [..] X#
 #          ^ reference [..] T#
-#             ^^^^ definition [..] X#serialize().
-#             ^^^^ reference [..] Module#public().
-#             ^^^^ reference [..] String#
 #             ^^^^ reference [..] T#Enum#
    enums do
      A = new("A")
@@ -70,7 +67,7 @@
 #  ^^^ definition [..] X#All.
 #               ^ reference [..] X#A.
 #                  ^ reference [..] X#B.
-#                         ^^^^^^^^ definition local 4$119448696
+#                         ^^^^^^^^ definition local 3$119448696
 #                               ^ reference [..] X#
  end
  

--- a/test/scip/testdata/alias.snapshot.rb
+++ b/test/scip/testdata/alias.snapshot.rb
@@ -48,8 +48,8 @@
  
  class X < T::Enum
 #      ^ definition [..] X#
-#      ^ definition [..] X#serialize().
 #          ^ reference [..] T#
+#             ^^^^ definition [..] X#serialize().
 #             ^^^^ reference [..] Module#public().
 #             ^^^^ reference [..] String#
 #             ^^^^ reference [..] T#Enum#

--- a/test/scip/testdata/enum.snapshot.rb
+++ b/test/scip/testdata/enum.snapshot.rb
@@ -3,9 +3,6 @@
  class X < T::Enum
 #      ^ definition [..] X#
 #          ^ reference [..] T#
-#             ^^^^ definition [..] X#serialize().
-#             ^^^^ reference [..] Module#public().
-#             ^^^^ reference [..] String#
 #             ^^^^ reference [..] T#Enum#
    enums do
      A = new("A")
@@ -24,7 +21,7 @@
 #  ^^^ definition [..] X#All.
 #               ^ reference [..] X#A.
 #                  ^ reference [..] X#B.
-#                         ^^^^^^^^ definition local 4$119448696
+#                         ^^^^^^^^ definition local 3$119448696
 #                               ^ reference [..] X#
  end
  

--- a/test/scip/testdata/enum.snapshot.rb
+++ b/test/scip/testdata/enum.snapshot.rb
@@ -2,8 +2,8 @@
  
  class X < T::Enum
 #      ^ definition [..] X#
-#      ^ definition [..] X#serialize().
 #          ^ reference [..] T#
+#             ^^^^ definition [..] X#serialize().
 #             ^^^^ reference [..] Module#public().
 #             ^^^^ reference [..] String#
 #             ^^^^ reference [..] T#Enum#


### PR DESCRIPTION
CU-2372 Removes the synthetic `serialize()` definition generation.

### Motivation

When users click "Find References" on a `T::Enum` class name in Sourcegraph, the UI sometimes shows references to the `serialize()` method instead of references to the class itself.

This happens because `scip-ruby` emits two definitions at the exact same source location:
1. The class definition (e.g., `Foo#`)
2. The synthetic `serialize()` method (e.g., `Foo#serialize().`)

When the Sourcegraph frontend queries for the symbol at a position and finds multiple overlapping definitions, it may pick the wrong one, causing Find References to return incorrect results.

Now only definition for the class is provided:

  ## Problem
  
  The synthetic serialize() method definition was emitted at the T::Enum class
  declaration location, causing overlapping definitions with the class itself.
  This broke Find References in Sourcegraph UI, which would pick up serialize
  references instead of class references.
  
  ## Before
  
  ```ruby
  class Foo < T::Enum
  #     ^^^ definition [..] Foo#
  #     ^^^ definition [..] Foo#serialize().
  #           ^ reference [..] T#
  #              ^^^^ reference [..] Module#public().
  #              ^^^^ reference [..] String#
  #              ^^^^ reference [..] T#Enum#
  ```
  
  ## After
  
  ```ruby
  class Foo < T::Enum
  #     ^^^ definition [..] Foo#
  #           ^ reference [..] T#
  #              ^^^^ reference [..] T#Enum#
  ```

### Test plan

See included automated tests.
