### PR TITLE
Fix failing CI due to macos-13 deprecation

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,4 @@
 # Stop actionlint from triggering failures
 self-hosted-runner:
   labels:
-    - ubuntu-22.04-32core-graph-team-amd64
+    - ubuntu-24.04-32core-graph-team-amd64

--- a/.github/workflows/build_gems.yml
+++ b/.github/workflows/build_gems.yml
@@ -6,7 +6,7 @@ jobs:
     name: 'Build gem'
     strategy:
       matrix:
-        platform: ['ubuntu-22.04', 'macos-13']
+        platform: ['ubuntu-24.04', 'macos-14']
         config: ['asserts', 'release']
     runs-on: ${{ matrix.platform }}
     env:

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -13,8 +13,7 @@ jobs:
     name: 'Build and upload artifacts'
     strategy:
       matrix:
-        # Use macos-14 as macos-13 runner is only offered for x86_64
-        platform: ['ubuntu-22.04-32core-graph-team-amd64', 'macos-13-xlarge']
+        platform: ['ubuntu-24.04-32core-graph-team-amd64', 'macos-14-xlarge']
         config: ['asserts', 'release']
     runs-on: ${{ matrix.platform }}
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: 'Build and upload artifacts'
     strategy:
       matrix:
-        platform: ['ubuntu-22.04-32core-graph-team-amd64', 'macos-13-xlarge']
+        platform: ['ubuntu-24.04-32core-graph-team-amd64', 'macos-14-xlarge']
         # Keep the platform list in sync with 'Supported Configurations' in README.md
         config: ['asserts', 'release']
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Updated CI to use MacOS 14 and Ubuntu 24


### Motivation
MacOS 13 is deprecated in Github and Ubuntu 22.04 reached end of support


### Test plan
CI
