### PR TITLE
Revert "fix: avoid overlapping definition for T::Enum synthetic serialize() method"

### DIFF
--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -238,11 +238,22 @@ void TEnum::run(core::MutableContext ctx, ast::ClassDef *klass) {
             }
         }
     }
-    // NOTE: We intentionally skip generating the synthetic serialize() method definition here.
-    // T::Enum provides serialize() but emitting a definition at the class declaration location
-    // causes overlapping definitions with the class itself, which breaks Find References in
-    // Sourcegraph UI. Since serialize() is a Sorbet stdlib method (not user-defined), omitting
-    // the definition is acceptable - users can still navigate via the class inheritance.
-    (void)serializeReturnType; // Silence unused variable warning
+    if (core::isa_type<core::ClassType>(serializeReturnType) && !serializeReturnType.isUntyped() &&
+        !serializeReturnType.isBottom()) {
+        auto serializeReturnTypeClass = core::cast_type_nonnull<core::ClassType>(serializeReturnType);
+        ast::ExpressionPtr return_type_ast = ast::MK::Constant(klass->declLoc, serializeReturnTypeClass.symbol);
+        auto sig = ast::MK::Sig0(klass->declLoc, std::move(return_type_ast));
+        auto method = ast::MK::SyntheticMethod0(klass->loc, klass->declLoc, klass->name.loc(), core::Names::serialize(),
+                                                ast::MK::RaiseTypedUnimplemented(klass->declLoc));
+        ast::Send::ARGS_store nargs;
+        ast::Send::Flags flags;
+        flags.isPrivateOk = true;
+        auto visibility = ast::MK::Send(klass->declLoc, ast::MK::Self(klass->declLoc), core::Names::public_(),
+                                        klass->declLoc, 0, std::move(nargs), flags);
+
+        klass->rhs.emplace_back(std::move(visibility));
+        klass->rhs.emplace_back(std::move(sig));
+        klass->rhs.emplace_back(std::move(method));
+    }
 }
 }; // namespace sorbet::rewriter

--- a/test/scip/testdata/alias.snapshot.rb
+++ b/test/scip/testdata/alias.snapshot.rb
@@ -48,7 +48,10 @@
  
  class X < T::Enum
 #      ^ definition [..] X#
+#      ^ definition [..] X#serialize().
 #          ^ reference [..] T#
+#             ^^^^ reference [..] Module#public().
+#             ^^^^ reference [..] String#
 #             ^^^^ reference [..] T#Enum#
    enums do
      A = new("A")
@@ -67,7 +70,7 @@
 #  ^^^ definition [..] X#All.
 #               ^ reference [..] X#A.
 #                  ^ reference [..] X#B.
-#                         ^^^^^^^^ definition local 3$119448696
+#                         ^^^^^^^^ definition local 4$119448696
 #                               ^ reference [..] X#
  end
  

--- a/test/scip/testdata/enum.snapshot.rb
+++ b/test/scip/testdata/enum.snapshot.rb
@@ -2,7 +2,10 @@
  
  class X < T::Enum
 #      ^ definition [..] X#
+#      ^ definition [..] X#serialize().
 #          ^ reference [..] T#
+#             ^^^^ reference [..] Module#public().
+#             ^^^^ reference [..] String#
 #             ^^^^ reference [..] T#Enum#
    enums do
      A = new("A")
@@ -21,7 +24,7 @@
 #  ^^^ definition [..] X#All.
 #               ^ reference [..] X#A.
 #                  ^ reference [..] X#B.
-#                         ^^^^^^^^ definition local 3$119448696
+#                         ^^^^^^^^ definition local 4$119448696
 #                               ^ reference [..] X#
  end
  


### PR DESCRIPTION
Reverts sourcegraph/scip-ruby#246

Rationale: we should first have a plan on how to resolve implementation references for all Sorbet's classes that belong to the built-in type system. We should provide a uniform behavior here.