### PR TITLE
Populate enclosing_range on SCIP definition Occurrences

### DIFF
--- a/proto/SCIP.proto
+++ b/proto/SCIP.proto
@@ -400,6 +400,14 @@ message Occurrence {
   SyntaxKind syntax_kind = 5;
   // (optional) Diagnostics that have been reported for this specific range.
   repeated Diagnostic diagnostics = 6;
+  // (optional) Using the same encoding as the sibling `range` field, half-open
+  // source range of the nearest non-trivial enclosing AST node. This range must
+  // enclose the `range` field.
+  //
+  // For definition occurrences, the enclosing range should indicate the
+  // start/end bounds of the entire definition AST node, including
+  // documentation.
+  repeated int32 enclosing_range = 7;
 }
 
 // Represents a diagnostic, such as a compiler error or warning, which should be

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -288,7 +288,8 @@ private:
 
     absl::Status saveDefinitionImpl(const core::GlobalState &gs, core::FileRef file, const string &symbolString,
                                     core::Loc occLoc, const SmallVec<string> &docs,
-                                    const SmallVec<scip::Relationship> &rels) {
+                                    const SmallVec<scip::Relationship> &rels,
+                                    optional<core::Loc> enclosingLoc = nullopt) {
         ENFORCE(!symbolString.empty());
         occLoc = trimColonColonPrefix(gs, occLoc);
         auto range = sorbet::scip_indexer::fromSorbetLoc(gs, occLoc);
@@ -304,6 +305,12 @@ private:
         occurrence.set_symbol_roles(scip::SymbolRole::Definition);
         for (auto val : range) {
             occurrence.add_range(val);
+        }
+        if (enclosingLoc.has_value() && !enclosingLoc->empty()) {
+            auto encRange = sorbet::scip_indexer::fromSorbetLoc(gs, enclosingLoc.value());
+            for (auto val : encRange) {
+                occurrence.add_enclosing_range(val);
+            }
         }
         switch (emitted) {
             case Emitted::Now:
@@ -396,7 +403,8 @@ private:
     }
 
 public:
-    absl::Status saveDefinition(const core::GlobalState &gs, core::FileRef file, OwnedLocal occ, core::TypePtr type) {
+    absl::Status saveDefinition(const core::GlobalState &gs, core::FileRef file, OwnedLocal occ, core::TypePtr type,
+                                optional<core::Loc> enclosingLoc = nullopt) {
         if (this->cacheOccurrence(gs, file, occ, scip::SymbolRole::Definition)) {
             return absl::OkStatus();
         }
@@ -407,7 +415,7 @@ public:
             ENFORCE(var.has_value(), "Failed to find source text for definition of local variable");
             docStrings.push_back(fmt::format("```ruby\n{} ({})\n```", var.value(), type.show(gs)));
         }
-        return this->saveDefinitionImpl(gs, file, occ.toSCIPString(gs, file), loc, docStrings, {});
+        return this->saveDefinitionImpl(gs, file, occ.toSCIPString(gs, file), loc, docStrings, {}, enclosingLoc);
     }
 
     void saveAliasRelationship(const core::GlobalState &gs, UntypedGenericSymbolRef aliasedSymbol,
@@ -423,7 +431,8 @@ public:
     // TODO(varun): Should we always pass in the location instead of sometimes only?
     absl::Status saveDefinition(const core::GlobalState &gs, core::FileRef file, GenericSymbolRef symRef,
                                 optional<UntypedGenericSymbolRef> aliasedSymbol,
-                                optional<core::LocOffsets> loc = nullopt) {
+                                optional<core::LocOffsets> loc = nullopt,
+                                optional<core::Loc> enclosingLoc = nullopt) {
         // In practice, there doesn't seem to be any situation which triggers
         // a duplicate definition being emitted, so skip calling cacheOccurrence here.
         auto occLoc = loc.has_value() ? core::Loc(file, loc.value()) : symRef.symbolLoc(gs);
@@ -452,7 +461,7 @@ public:
             this->saveAliasRelationship(gs, aliasedSymbol.value(), rels);
         }
 
-        return this->saveDefinitionImpl(gs, file, symbolString, occLoc, docs, rels);
+        return this->saveDefinitionImpl(gs, file, symbolString, occLoc, docs, rels, enclosingLoc);
     }
 
     absl::Status saveReference(const core::GlobalState &gs, core::FileRef file, OwnedLocal occ,
@@ -1491,7 +1500,8 @@ public:
 
         auto scipState = this->getSCIPState();
         auto sym = scip_indexer::GenericSymbolRef::classOrModule(klass.symbol);
-        auto status = scipState->saveDefinition(gs, file, sym, /*aliasedSymbol*/ nullopt, nameLoc);
+        auto klassLoc = core::Loc(file, klass.loc);
+        auto status = scipState->saveDefinition(gs, file, sym, /*aliasedSymbol*/ nullopt, nameLoc, klassLoc);
         ENFORCE(status.ok());
         auto *expr = &klass.name;
         if (auto *constantLit = ast::cast_tree<ast::ConstantLit>(*expr)) {
@@ -1513,9 +1523,10 @@ public:
             return;
         }
         auto scipState = this->getSCIPState();
+        auto methodLoc = core::Loc(file, methodDef.loc);
         if (methodDef.name != core::Names::staticInit()) {
             auto sym = scip_indexer::GenericSymbolRef::method(methodDef.symbol);
-            auto status = scipState->saveDefinition(gs, file, sym, /*aliasedSymbol*/ nullopt);
+            auto status = scipState->saveDefinition(gs, file, sym, /*aliasedSymbol*/ nullopt, /*loc*/ nullopt, methodLoc);
             ENFORCE(status.ok());
         }
 

--- a/test/scip/testdata/abstract_interface.snapshot.rb
+++ b/test/scip/testdata/abstract_interface.snapshot.rb
@@ -2,6 +2,7 @@
  
  # Exercises abstract!, interface!, final!, sealed!, mixes_in_class_methods.
  
+#⌄ enclosing_range_start [..] Drawable#
  module Drawable
 #       ^^^^^^^^ definition [..] Drawable#
    extend T::Sig
@@ -12,10 +13,14 @@
  
    sig { abstract.returns(String) }
 #                         ^^^^^^ reference [..] String#
+#  ⌄ enclosing_range_start [..] Drawable#draw().
    def draw; end
 #      ^^^^ definition [..] Drawable#draw().
+#              ⌃ enclosing_range_end [..] Drawable#draw().
  end
+#  ⌃ enclosing_range_end [..] Drawable#
  
+#⌄ enclosing_range_start [..] Shape#
  class Shape
 #      ^^^^^ definition [..] Shape#
    extend T::Sig
@@ -26,10 +31,14 @@
  
    sig { abstract.returns(Integer) }
 #                         ^^^^^^^ reference [..] Integer#
+#  ⌄ enclosing_range_start [..] Shape#area().
    def area; end
 #      ^^^^ definition [..] Shape#area().
+#              ⌃ enclosing_range_end [..] Shape#area().
  end
+#  ⌃ enclosing_range_end [..] Shape#
  
+#⌄ enclosing_range_start [..] Square#
  class Square < Shape
 #      ^^^^^^ definition [..] Square#
 #               ^^^^^ reference [..] Shape#
@@ -42,19 +51,25 @@
  
    sig { override.returns(Integer) }
 #                         ^^^^^^^ reference [..] Integer#
+#  ⌄ enclosing_range_start [..] Square#area().
    def area
 #      ^^^^ definition [..] Square#area().
      16
    end
+#    ⌃ enclosing_range_end [..] Square#area().
  
    sig { override.returns(String) }
 #                         ^^^^^^ reference [..] String#
+#  ⌄ enclosing_range_start [..] Square#draw().
    def draw
 #      ^^^^ definition [..] Square#draw().
      "square"
    end
+#    ⌃ enclosing_range_end [..] Square#draw().
  end
+#  ⌃ enclosing_range_end [..] Square#
  
+#⌄ enclosing_range_start [..] FinalLeaf#
  class FinalLeaf
 #      ^^^^^^^^^ definition [..] FinalLeaf#
    extend T::Sig
@@ -65,19 +80,25 @@
  
    sig(:final) { returns(Integer) }
 #                        ^^^^^^^ reference [..] Integer#
+#  ⌄ enclosing_range_start [..] FinalLeaf#value().
    def value
 #      ^^^^^ definition [..] FinalLeaf#value().
      42
    end
+#    ⌃ enclosing_range_end [..] FinalLeaf#value().
  end
+#  ⌃ enclosing_range_end [..] FinalLeaf#
  
+#⌄ enclosing_range_start [..] SealedHierarchy#
  module SealedHierarchy
 #       ^^^^^^^^^^^^^^^ definition [..] SealedHierarchy#
    extend T::Helpers
 #  ^^^^^^ reference [..] Kernel#extend().
    sealed!
  end
+#  ⌃ enclosing_range_end [..] SealedHierarchy#
  
+#⌄ enclosing_range_start [..] ClassMethodsMixin#
  module ClassMethodsMixin
 #       ^^^^^^^^^^^^^^^^^ definition [..] ClassMethodsMixin#
    extend T::Sig
@@ -85,12 +106,16 @@
  
    sig { returns(String) }
 #                ^^^^^^ reference [..] String#
+#  ⌄ enclosing_range_start [..] ClassMethodsMixin#class_helper().
    def class_helper
 #      ^^^^^^^^^^^^ definition [..] ClassMethodsMixin#class_helper().
      "class!"
    end
+#    ⌃ enclosing_range_end [..] ClassMethodsMixin#class_helper().
  end
+#  ⌃ enclosing_range_end [..] ClassMethodsMixin#
  
+#⌄ enclosing_range_start [..] InstanceMethodsMixin#
  module InstanceMethodsMixin
 #       ^^^^^^^^^^^^^^^^^^^^ definition [..] InstanceMethodsMixin#
    extend T::Helpers
@@ -98,7 +123,9 @@
    mixes_in_class_methods(ClassMethodsMixin)
 #                         ^^^^^^^^^^^^^^^^^ reference [..] ClassMethodsMixin#
  end
+#  ⌃ enclosing_range_end [..] InstanceMethodsMixin#
  
+#⌄ enclosing_range_start [..] WithMixedIn#
  class WithMixedIn
 #      ^^^^^^^^^^^ definition [..] WithMixedIn#
    include InstanceMethodsMixin
@@ -106,3 +133,4 @@
 #          ^^^^^^^^^^^^^^^^^^^^ reference [..] InstanceMethodsMixin#
 #          ^^^^^^^^^^^^^^^^^^^^ reference [..] InstanceMethodsMixin#
  end
+#  ⌃ enclosing_range_end [..] WithMixedIn#

--- a/test/scip/testdata/alias.snapshot.rb
+++ b/test/scip/testdata/alias.snapshot.rb
@@ -1,32 +1,41 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] X#
  class X
 #      ^ definition [..] X#
    alias_method :am_aaa, :aaa
 #  ^^^^^^^^^^^^ reference [..] Module#alias_method().
    alias :a_aaa :aaa
  
+#  ⌄ enclosing_range_start [..] X#aaa().
    def aaa
 #      ^^^ definition [..] X#aaa().
      puts "AAA"
 #    ^^^^ reference [..] Kernel#puts().
    end
+#    ⌃ enclosing_range_end [..] X#aaa().
  
+#  ⌄ enclosing_range_start [..] X#check_alias().
    def check_alias
 #      ^^^^^^^^^^^ definition [..] X#check_alias().
      return [am_aaa, a_aaa]
 #            ^^^^^^ reference [..] X#aaa().
 #                    ^^^^^ reference [..] X#aaa().
    end
+#    ⌃ enclosing_range_end [..] X#check_alias().
  end
+#  ⌃ enclosing_range_end [..] X#
  
+#⌄ enclosing_range_start [..] Mod1#
  module Mod1
 #       ^^^^ definition [..] Mod1#
    ABC = 10
 #  ^^^ definition [..] Mod1#ABC.
 #  ^^^^^^^^ reference [..] Mod1#ABC.
  end
+#  ⌃ enclosing_range_end [..] Mod1#
  
+#⌄ enclosing_range_start [..] Mod2#
  module Mod2
 #       ^^^^ definition [..] Mod2#
    FEG = Mod1::ABC
@@ -36,7 +45,9 @@
 #              ^^^ reference [..] Mod1#ABC.
 #              ^^^ reference [..] Mod2#FEG.
  end
+#  ⌃ enclosing_range_end [..] Mod2#
  
+#⌄ enclosing_range_start [..] Object#myfunction().
  def myfunction(myparam)
 #    ^^^^^^^^^^ definition [..] Object#myfunction().
 #               ^^^^^^^ definition local 1$3083414419
@@ -45,7 +56,10 @@
 #            ^^^^ reference [..] Mod2#
 #                  ^^^ reference [..] Mod2#FEG.
  end
+#  ⌃ enclosing_range_end [..] Object#myfunction().
  
+#⌄ enclosing_range_start [..] X#
+#⌄ enclosing_range_start [..] X#serialize().
  class X < T::Enum
 #      ^ definition [..] X#
 #      ^ definition [..] X#serialize().
@@ -73,9 +87,12 @@
 #                         ^^^^^^^^ definition local 4$119448696
 #                               ^ reference [..] X#
  end
+#  ⌃ enclosing_range_end [..] X#
+#  ⌃ enclosing_range_end [..] X#serialize().
  
  # Adding more cases like this is not supported (c.f. isTEnum),
  # but let's at least add a test.
+#⌄ enclosing_range_start [..] Y#
  class Y < X
 #      ^ definition [..] Y#
 #          ^ reference [..] X#
@@ -90,3 +107,4 @@
 #        ^ reference [..] X#B.
    end
  end
+#  ⌃ enclosing_range_end [..] Y#

--- a/test/scip/testdata/args.snapshot.rb
+++ b/test/scip/testdata/args.snapshot.rb
@@ -1,5 +1,6 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] Object#args().
  def args(x, y)
 #    ^^^^ definition [..] Object#args().
 #         ^ definition local 1$2634721084
@@ -24,7 +25,9 @@
    z
 #  ^ reference local 3$2634721084
  end
+#  ⌃ enclosing_range_end [..] Object#args().
  
+#⌄ enclosing_range_start [..] Object#keyword_args().
  def keyword_args(w:, x: 3, y: [], **kwargs)
 #    ^^^^^^^^^^^^ definition [..] Object#keyword_args().
 #                 ^^ definition local 1$3526982640
@@ -38,7 +41,9 @@
 #  ^ reference local 3$3526982640
    return
  end
+#  ⌃ enclosing_range_end [..] Object#keyword_args().
  
+#⌄ enclosing_range_start [..] Object#use_kwargs().
  def use_kwargs
 #    ^^^^^^^^^^ definition [..] Object#use_kwargs().
    h = { a: 3 }
@@ -51,3 +56,4 @@
 #                                     ^ reference local 1$571973038
    return
  end
+#  ⌃ enclosing_range_end [..] Object#use_kwargs().

--- a/test/scip/testdata/arrays.snapshot.rb
+++ b/test/scip/testdata/arrays.snapshot.rb
@@ -1,5 +1,6 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] Object#arrays().
  def arrays(a, i)
 #    ^^^^^^ definition [..] Object#arrays().
 #           ^ definition local 1$513334479
@@ -21,3 +22,4 @@
 #  ^ reference local 1$513334479
 #       ^ reference local 1$513334479
  end
+#  ⌃ enclosing_range_end [..] Object#arrays().

--- a/test/scip/testdata/blocks_lambdas_procs.snapshot.rb
+++ b/test/scip/testdata/blocks_lambdas_procs.snapshot.rb
@@ -1,5 +1,6 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] Object#blk().
  def blk
 #    ^^^ definition [..] Object#blk().
    y = 0
@@ -21,7 +22,9 @@
 #         ^ reference local 3$1472469056
    end
  end
+#  ⌃ enclosing_range_end [..] Object#blk().
  
+#⌄ enclosing_range_start [..] Object#lam().
  def lam
 #    ^^^ definition [..] Object#lam().
    y = 0
@@ -81,7 +84,9 @@
 #  ^^ reference local 11$1499497673
 #     ^^^^ reference [..] Proc#call().
  end
+#  ⌃ enclosing_range_end [..] Object#lam().
  
+#⌄ enclosing_range_start [..] Object#prc().
  def prc
 #    ^^^ definition [..] Object#prc().
    y = 0
@@ -141,14 +146,18 @@
 #  ^^ reference local 11$1283111692
 #     ^^^^ reference [..] Proc#call().
  end
+#  ⌃ enclosing_range_end [..] Object#prc().
  
+#⌄ enclosing_range_start [..] Object#call_block().
  def call_block(&blk)
 #    ^^^^^^^^^^ definition [..] Object#call_block().
 #                ^^^ definition local 1$1487178087
    blk.call
 #  ^^^ reference local 1$1487178087
  end
+#  ⌃ enclosing_range_end [..] Object#call_block().
  
+#⌄ enclosing_range_start [..] Object#use_block_with_defaults().
  def use_block_with_defaults
 #    ^^^^^^^^^^^^^^^^^^^^^^^ definition [..] Object#use_block_with_defaults().
    call_block do |oops: nil|
@@ -161,3 +170,4 @@
 #                 ^^^^ definition local 2$4118119342
    end
  end
+#  ⌃ enclosing_range_end [..] Object#use_block_with_defaults().

--- a/test/scip/testdata/call.snapshot.rb
+++ b/test/scip/testdata/call.snapshot.rb
@@ -4,13 +4,16 @@
  # accidentally skipping emitting references for the method body
  # due to changes in rewriter/Command.cc
  
+#⌄ enclosing_range_start [..] Opus#Command#
  class Opus::Command
 #      ^^^^ reference [..] Opus#
 #            ^^^^^^^ definition [..] Opus#Command#
  end
+#  ⌃ enclosing_range_end [..] Opus#Command#
  
  # NOTE: This is nested inside Opus as a convention,
  # but the key thing is the subclassing relationship.
+#⌄ enclosing_range_start [..] Opus#MyThing#Command#GetThing#
  class Opus::MyThing::Command::GetThing < Opus::Command
 #      ^^^^ reference [..] Opus#
 #            ^^^^^^^ reference [..] Opus#MyThing#
@@ -18,6 +21,7 @@
 #                              ^^^^^^^^ definition [..] Opus#MyThing#Command#GetThing#
 #                                         ^^^^ reference [..] Opus#
 #                                               ^^^^^^^ reference [..] Opus#Command#
+#  ⌄ enclosing_range_start [..] Opus#MyThing#Command#GetThing#call().
    def call()
 #      ^^^^ definition [..] Opus#MyThing#Command#GetThing#call().
      x = 1
@@ -27,14 +31,18 @@
 #    ^^^^^ reference local 2$3018949801
 #        ^ reference local 1$3018949801
    end
+#    ⌃ enclosing_range_end [..] Opus#MyThing#Command#GetThing#call().
  end
+#  ⌃ enclosing_range_end [..] Opus#MyThing#Command#GetThing#
  
  # Forgot < Opus::Command relationship here
+#⌄ enclosing_range_start [..] Opus#MyThing#BadCommand#GetThing#
  class Opus::MyThing::BadCommand::GetThing
 #      ^^^^ reference [..] Opus#
 #            ^^^^^^^ reference [..] Opus#MyThing#
 #                     ^^^^^^^^^^ reference [..] Opus#MyThing#BadCommand#
 #                                 ^^^^^^^^ definition [..] Opus#MyThing#BadCommand#GetThing#
+#  ⌄ enclosing_range_start [..] Opus#MyThing#BadCommand#GetThing#call().
    def call()
 #      ^^^^ definition [..] Opus#MyThing#BadCommand#GetThing#call().
      x = 1
@@ -44,13 +52,17 @@
 #    ^^^^^ reference local 2$3018949801
 #        ^ reference local 1$3018949801
    end
+#    ⌃ enclosing_range_end [..] Opus#MyThing#BadCommand#GetThing#call().
  end
+#  ⌃ enclosing_range_end [..] Opus#MyThing#BadCommand#GetThing#
  
+#⌄ enclosing_range_start [..] NotOpus#Command1#GetThing#
  class NotOpus::Command1::GetThing
 #      ^^^^^^^ reference [..] NotOpus#
 #               ^^^^^^^^ reference [..] NotOpus#Command1#
 #                         ^^^^^^^^ definition [..] NotOpus#Command1#GetThing#
    # Class method
+#  ⌄ enclosing_range_start [..] NotOpus#Command1#`<Class:GetThing>`#call().
    def self.call()
 #           ^^^^ definition [..] NotOpus#Command1#`<Class:GetThing>`#call().
      x = 1
@@ -60,13 +72,17 @@
 #    ^^^^^ reference local 2$3018949801
 #        ^ reference local 1$3018949801
    end
+#    ⌃ enclosing_range_end [..] NotOpus#Command1#`<Class:GetThing>`#call().
  end
+#  ⌃ enclosing_range_end [..] NotOpus#Command1#GetThing#
  
+#⌄ enclosing_range_start [..] NotOpus#Command2#GetThing#
  class NotOpus::Command2::GetThing
 #      ^^^^^^^ reference [..] NotOpus#
 #               ^^^^^^^^ reference [..] NotOpus#Command2#
 #                         ^^^^^^^^ definition [..] NotOpus#Command2#GetThing#
    # Instance method
+#  ⌄ enclosing_range_start [..] NotOpus#Command2#GetThing#call().
    def call()
 #      ^^^^ definition [..] NotOpus#Command2#GetThing#call().
      x = 1
@@ -76,8 +92,11 @@
 #    ^^^^^ reference local 2$3018949801
 #        ^ reference local 1$3018949801
    end
+#    ⌃ enclosing_range_end [..] NotOpus#Command2#GetThing#call().
  end
+#  ⌃ enclosing_range_end [..] NotOpus#Command2#GetThing#
  
+#⌄ enclosing_range_start [..] Object#make_call().
  def make_call()
 #    ^^^^^^^^^ definition [..] Object#make_call().
    # Should navigate to instance method
@@ -107,3 +126,4 @@
 #                              ^^^ reference [..] Class#new().
 #                                    ^^^^ reference [..] NotOpus#Command2#GetThing#call().
  end
+#  ⌃ enclosing_range_end [..] Object#make_call().

--- a/test/scip/testdata/cattr.snapshot.rb
+++ b/test/scip/testdata/cattr.snapshot.rb
@@ -1,26 +1,43 @@
  # typed: strict
  
+#⌄ enclosing_range_start [..] CR#
  class CR
 #      ^^ definition [..] CR#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
+#               ⌄ enclosing_range_start [..] CR#both().
+#               ⌄ enclosing_range_start [..] `<Class:CR>`#both().
+#                      ⌄ enclosing_range_start [..] CR#foo().
+#                      ⌄ enclosing_range_start [..] `<Class:CR>`#foo().
    cattr_reader :both, :foo
 #               ^^^^^ definition [..] CR#both().
 #               ^^^^^ definition [..] `<Class:CR>`#both().
 #                      ^^^^ definition [..] CR#foo().
 #                      ^^^^ definition [..] `<Class:CR>`#foo().
+#                   ⌃ enclosing_range_end [..] CR#both().
+#                   ⌃ enclosing_range_end [..] `<Class:CR>`#both().
+#                         ⌃ enclosing_range_end [..] CR#foo().
+#                         ⌃ enclosing_range_end [..] `<Class:CR>`#foo().
+#               ⌄ enclosing_range_start [..] `<Class:CR>`#no_instance().
    cattr_reader :no_instance, instance_accessor: false
 #               ^^^^^^^^^^^^ definition [..] `<Class:CR>`#no_instance().
+#                          ⌃ enclosing_range_end [..] `<Class:CR>`#no_instance().
+#               ⌄ enclosing_range_start [..] `<Class:CR>`#bar().
+#                     ⌄ enclosing_range_start [..] `<Class:CR>`#no_reader().
    cattr_reader :bar, :no_reader, instance_reader: false
 #               ^^^^ definition [..] `<Class:CR>`#bar().
 #                     ^^^^^^^^^^ definition [..] `<Class:CR>`#no_reader().
+#                  ⌃ enclosing_range_end [..] `<Class:CR>`#bar().
+#                              ⌃ enclosing_range_end [..] `<Class:CR>`#no_reader().
  
    sig {void}
+#  ⌄ enclosing_range_start [..] CR#usages().
    def usages
 #      ^^^^^^ definition [..] CR#usages().
      both
 #    ^^^^ reference [..] CR#both().
    end
+#    ⌃ enclosing_range_end [..] CR#usages().
  
    both
 #  ^^^^ reference [..] `<Class:CR>`#both().
@@ -29,28 +46,46 @@
    no_reader
 #  ^^^^^^^^^ reference [..] `<Class:CR>`#no_reader().
  end
+#  ⌃ enclosing_range_end [..] CR#
  
+#⌄ enclosing_range_start [..] CW#
  class CW
 #      ^^ definition [..] CW#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
+#               ⌄ enclosing_range_start [..] CW#`both=`().
+#               ⌄ enclosing_range_start [..] `<Class:CW>`#`both=`().
+#                      ⌄ enclosing_range_start [..] CW#`foo=`().
+#                      ⌄ enclosing_range_start [..] `<Class:CW>`#`foo=`().
    cattr_writer :both, :foo
 #               ^^^^^ definition [..] CW#`both=`().
 #               ^^^^^ definition [..] `<Class:CW>`#`both=`().
 #                      ^^^^ definition [..] CW#`foo=`().
 #                      ^^^^ definition [..] `<Class:CW>`#`foo=`().
+#                   ⌃ enclosing_range_end [..] CW#`both=`().
+#                   ⌃ enclosing_range_end [..] `<Class:CW>`#`both=`().
+#                         ⌃ enclosing_range_end [..] CW#`foo=`().
+#                         ⌃ enclosing_range_end [..] `<Class:CW>`#`foo=`().
+#               ⌄ enclosing_range_start [..] `<Class:CW>`#`no_instance=`().
    cattr_writer :no_instance, instance_accessor: false
 #               ^^^^^^^^^^^^ definition [..] `<Class:CW>`#`no_instance=`().
+#                          ⌃ enclosing_range_end [..] `<Class:CW>`#`no_instance=`().
+#               ⌄ enclosing_range_start [..] `<Class:CW>`#`bar=`().
+#                     ⌄ enclosing_range_start [..] `<Class:CW>`#`no_instance_writer=`().
    cattr_writer :bar, :no_instance_writer, instance_writer: false
 #               ^^^^ definition [..] `<Class:CW>`#`bar=`().
 #                     ^^^^^^^^^^^^^^^^^^^ definition [..] `<Class:CW>`#`no_instance_writer=`().
+#                  ⌃ enclosing_range_end [..] `<Class:CW>`#`bar=`().
+#                                       ⌃ enclosing_range_end [..] `<Class:CW>`#`no_instance_writer=`().
  
    sig {void}
+#  ⌄ enclosing_range_start [..] CW#usages().
    def usages
 #      ^^^^^^ definition [..] CW#usages().
      self.both = 1
 #         ^^^^^^ reference [..] CW#`both=`().
    end
+#    ⌃ enclosing_range_end [..] CW#usages().
  
    self.both = 1
 #       ^^^^^^ reference [..] `<Class:CW>`#`both=`().
@@ -59,11 +94,21 @@
    self.no_instance_writer = 1
 #       ^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:CW>`#`no_instance_writer=`().
  end
+#  ⌃ enclosing_range_end [..] CW#
  
+#⌄ enclosing_range_start [..] CA#
  class CA
 #      ^^ definition [..] CA#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
+#                 ⌄ enclosing_range_start [..] CA#`both=`().
+#                 ⌄ enclosing_range_start [..] CA#both().
+#                 ⌄ enclosing_range_start [..] `<Class:CA>`#`both=`().
+#                 ⌄ enclosing_range_start [..] `<Class:CA>`#both().
+#                        ⌄ enclosing_range_start [..] CA#`foo=`().
+#                        ⌄ enclosing_range_start [..] CA#foo().
+#                        ⌄ enclosing_range_start [..] `<Class:CA>`#`foo=`().
+#                        ⌄ enclosing_range_start [..] `<Class:CA>`#foo().
    cattr_accessor :both, :foo
 #                 ^^^^^ definition [..] CA#both().
 #                 ^^^^^ definition [..] CA#`both=`().
@@ -73,13 +118,37 @@
 #                        ^^^^ definition [..] CA#foo().
 #                        ^^^^ definition [..] `<Class:CA>`#`foo=`().
 #                        ^^^^ definition [..] `<Class:CA>`#foo().
+#                     ⌃ enclosing_range_end [..] CA#`both=`().
+#                     ⌃ enclosing_range_end [..] CA#both().
+#                     ⌃ enclosing_range_end [..] `<Class:CA>`#`both=`().
+#                     ⌃ enclosing_range_end [..] `<Class:CA>`#both().
+#                           ⌃ enclosing_range_end [..] CA#`foo=`().
+#                           ⌃ enclosing_range_end [..] CA#foo().
+#                           ⌃ enclosing_range_end [..] `<Class:CA>`#`foo=`().
+#                           ⌃ enclosing_range_end [..] `<Class:CA>`#foo().
+#                 ⌄ enclosing_range_start [..] `<Class:CA>`#`no_instance=`().
+#                 ⌄ enclosing_range_start [..] `<Class:CA>`#no_instance().
    cattr_accessor :no_instance, instance_accessor: false
 #                 ^^^^^^^^^^^^ definition [..] `<Class:CA>`#`no_instance=`().
 #                 ^^^^^^^^^^^^ definition [..] `<Class:CA>`#no_instance().
+#                            ⌃ enclosing_range_end [..] `<Class:CA>`#`no_instance=`().
+#                            ⌃ enclosing_range_end [..] `<Class:CA>`#no_instance().
+#                 ⌄ enclosing_range_start [..] CA#`no_instance_reader=`().
+#                 ⌄ enclosing_range_start [..] `<Class:CA>`#`no_instance_reader=`().
+#                 ⌄ enclosing_range_start [..] `<Class:CA>`#no_instance_reader().
    cattr_accessor :no_instance_reader, instance_reader: false
 #                 ^^^^^^^^^^^^^^^^^^^ definition [..] CA#`no_instance_reader=`().
 #                 ^^^^^^^^^^^^^^^^^^^ definition [..] `<Class:CA>`#`no_instance_reader=`().
 #                 ^^^^^^^^^^^^^^^^^^^ definition [..] `<Class:CA>`#no_instance_reader().
+#                                   ⌃ enclosing_range_end [..] CA#`no_instance_reader=`().
+#                                   ⌃ enclosing_range_end [..] `<Class:CA>`#`no_instance_reader=`().
+#                                   ⌃ enclosing_range_end [..] `<Class:CA>`#no_instance_reader().
+#                 ⌄ enclosing_range_start [..] CA#bar().
+#                 ⌄ enclosing_range_start [..] `<Class:CA>`#`bar=`().
+#                 ⌄ enclosing_range_start [..] `<Class:CA>`#bar().
+#                       ⌄ enclosing_range_start [..] CA#no_instance_writer().
+#                       ⌄ enclosing_range_start [..] `<Class:CA>`#`no_instance_writer=`().
+#                       ⌄ enclosing_range_start [..] `<Class:CA>`#no_instance_writer().
    cattr_accessor :bar, :no_instance_writer, instance_writer: false
 #                 ^^^^ definition [..] CA#bar().
 #                 ^^^^ definition [..] `<Class:CA>`#`bar=`().
@@ -87,8 +156,15 @@
 #                       ^^^^^^^^^^^^^^^^^^^ definition [..] CA#no_instance_writer().
 #                       ^^^^^^^^^^^^^^^^^^^ definition [..] `<Class:CA>`#`no_instance_writer=`().
 #                       ^^^^^^^^^^^^^^^^^^^ definition [..] `<Class:CA>`#no_instance_writer().
+#                    ⌃ enclosing_range_end [..] CA#bar().
+#                    ⌃ enclosing_range_end [..] `<Class:CA>`#`bar=`().
+#                    ⌃ enclosing_range_end [..] `<Class:CA>`#bar().
+#                                         ⌃ enclosing_range_end [..] CA#no_instance_writer().
+#                                         ⌃ enclosing_range_end [..] `<Class:CA>`#`no_instance_writer=`().
+#                                         ⌃ enclosing_range_end [..] `<Class:CA>`#no_instance_writer().
  
    sig {void}
+#  ⌄ enclosing_range_start [..] CA#usages().
    def usages
 #      ^^^^^^ definition [..] CA#usages().
      both
@@ -100,6 +176,7 @@
      no_instance_writer
 #    ^^^^^^^^^^^^^^^^^^ reference [..] CA#no_instance_writer().
    end
+#    ⌃ enclosing_range_end [..] CA#usages().
  
    both
 #  ^^^^ reference [..] `<Class:CA>`#both().
@@ -121,3 +198,4 @@
    self.no_instance_writer = 1
 #       ^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:CA>`#`no_instance_writer=`().
  end
+#  ⌃ enclosing_range_end [..] CA#

--- a/test/scip/testdata/classes.snapshot.rb
+++ b/test/scip/testdata/classes.snapshot.rb
@@ -3,8 +3,10 @@
  _ = 0
 #^ definition local 1$119448696
  
+#⌄ enclosing_range_start [..] C1#
  class C1
 #      ^^ definition [..] C1#
+#  ⌄ enclosing_range_start [..] C1#f().
    def f()
 #      ^ definition [..] C1#f().
      _a = C1.new
@@ -18,20 +20,29 @@
 #                ^^^ reference [..] Class#new().
      return
    end
+#    ⌃ enclosing_range_end [..] C1#f().
  end
+#  ⌃ enclosing_range_end [..] C1#
  
+#⌄ enclosing_range_start [..] M2#
  module M2
 #       ^^ definition [..] M2#
+#  ⌄ enclosing_range_start [..] M2#C2#
    class C2
 #        ^^ definition [..] M2#C2#
    end
+#    ⌃ enclosing_range_end [..] M2#C2#
  end
+#  ⌃ enclosing_range_end [..] M2#
  
+#⌄ enclosing_range_start [..] M3#C3#
  class M3::C3
 #      ^^ reference [..] M3#
 #          ^^ definition [..] M3#C3#
  end
+#  ⌃ enclosing_range_end [..] M3#C3#
  
+#⌄ enclosing_range_start [..] Object#local_class().
  def local_class()
 #    ^^^^^^^^^^^ definition [..] Object#local_class().
    localClass = Class.new
@@ -40,10 +51,12 @@
 #                     ^^^ reference [..] `<Class:Class>`#new().
    # Technically, this is not supported by Sorbet (https://srb.help/3001),
    # but make sure we don't crash or do something weird.
+#  ⌄ enclosing_range_start [..] Object#myMethod().
    def localClass.myMethod()
 #                 ^^^^^^^^ definition [..] Object#myMethod().
      ":)"
    end
+#    ⌃ enclosing_range_end [..] Object#myMethod().
    _c = localClass.new
 #  ^^ definition local 3$552113551
 #       ^^^^^^^^^^ reference local 1$552113551
@@ -55,14 +68,18 @@
 #                  ^^^^^^^^ reference [..] Object#myMethod().
    return
  end
+#  ⌃ enclosing_range_end [..] Object#local_class().
  
+#⌄ enclosing_range_start [..] M4#
  module M4
 #       ^^ definition [..] M4#
    K = 0
 #  ^ definition [..] M4#K.
 #  ^^^^^ reference [..] M4#K.
  end
+#  ⌃ enclosing_range_end [..] M4#
  
+#⌄ enclosing_range_start [..] Object#module_access().
  def module_access()
 #    ^^^^^^^^^^^^^ definition [..] Object#module_access().
    _ = M4::K
@@ -71,16 +88,23 @@
 #          ^ reference [..] M4#K.
    return
  end
+#  ⌃ enclosing_range_end [..] Object#module_access().
  
+#⌄ enclosing_range_start [..] M5#
  module M5
 #       ^^ definition [..] M5#
+#  ⌄ enclosing_range_start [..] M5#M6#
    module M6
 #         ^^ definition [..] M5#M6#
+#    ⌄ enclosing_range_start [..] M5#`<Class:M6>`#g().
      def self.g()
 #             ^ definition [..] M5#`<Class:M6>`#g().
      end
+#      ⌃ enclosing_range_end [..] M5#`<Class:M6>`#g().
    end
+#    ⌃ enclosing_range_end [..] M5#M6#
  
+#  ⌄ enclosing_range_start [..] `<Class:M5>`#h().
    def self.h()
 #           ^ definition [..] `<Class:M5>`#h().
      M6.g()
@@ -88,17 +112,25 @@
 #       ^ reference [..] M5#`<Class:M6>`#g().
      return
    end
+#    ⌃ enclosing_range_end [..] `<Class:M5>`#h().
  end
+#  ⌃ enclosing_range_end [..] M5#
  
+#⌄ enclosing_range_start [..] C7#
  class C7
 #      ^^ definition [..] C7#
+#  ⌄ enclosing_range_start [..] C7#M8#
    module M8
 #         ^^ definition [..] C7#M8#
+#    ⌄ enclosing_range_start [..] C7#`<Class:M8>`#i().
      def self.i()
 #             ^ definition [..] C7#`<Class:M8>`#i().
      end
+#      ⌃ enclosing_range_end [..] C7#`<Class:M8>`#i().
    end
+#    ⌃ enclosing_range_end [..] C7#M8#
  
+#  ⌄ enclosing_range_start [..] C7#j().
    def j()
 #      ^ definition [..] C7#j().
      M8.i()
@@ -106,4 +138,6 @@
 #       ^ reference [..] C7#`<Class:M8>`#i().
      return
    end
+#    ⌃ enclosing_range_end [..] C7#j().
  end
+#  ⌃ enclosing_range_end [..] C7#

--- a/test/scip/testdata/def_delegator.snapshot.rb
+++ b/test/scip/testdata/def_delegator.snapshot.rb
@@ -3,66 +3,106 @@
  require 'forwardable'
 #^^^^^^^ reference [..] Kernel#require().
  
+#⌄ enclosing_range_start [..] MyArray1#
  class MyArray1
 #      ^^^^^^^^ definition [..] MyArray1#
+#  ⌄ enclosing_range_start [..] MyArray1#`inner_array=`().
+#  ⌄ enclosing_range_start [..] MyArray1#inner_array().
    attr_accessor :inner_array
 #                 ^^^^^^^^^^^ definition [..] MyArray1#`inner_array=`().
 #                 ^^^^^^^^^^^ definition [..] MyArray1#inner_array().
+#                           ⌃ enclosing_range_end [..] MyArray1#`inner_array=`().
+#                           ⌃ enclosing_range_end [..] MyArray1#inner_array().
    extend Forwardable
 #  ^^^^^^ reference [..] Kernel#extend().
 #         ^^^^^^^^^^^ reference [..] Forwardable#
+#  ⌄ enclosing_range_start [..] MyArray1#get_at_index().
    def_delegator :@inner_array, :[], :get_at_index
 #  ^^^^^^^^^^^^^ reference [..] Forwardable#def_delegator().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Proc#
 #                                    ^^^^^^^^^^^^^ definition [..] MyArray1#get_at_index().
+#                                                ⌃ enclosing_range_end [..] MyArray1#get_at_index().
  end
+#  ⌃ enclosing_range_end [..] MyArray1#
  
+#⌄ enclosing_range_start [..] MyArray2#
  class MyArray2
 #      ^^^^^^^^ definition [..] MyArray2#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
+#  ⌄ enclosing_range_start [..] MyArray2#`inner_array=`().
+#  ⌄ enclosing_range_start [..] MyArray2#inner_array().
    attr_accessor :inner_array
 #                 ^^^^^^^^^^^ definition [..] MyArray2#`inner_array=`().
 #                 ^^^^^^^^^^^ definition [..] MyArray2#inner_array().
+#                           ⌃ enclosing_range_end [..] MyArray2#`inner_array=`().
+#                           ⌃ enclosing_range_end [..] MyArray2#inner_array().
    extend Forwardable
 #  ^^^^^^ reference [..] Kernel#extend().
 #         ^^^^^^^^^^^ reference [..] Forwardable#
+#  ⌄ enclosing_range_start [..] MyArray2#get_at_index().
    def_delegator :@inner_array, :[], :get_at_index
 #  ^^^^^^^^^^^^^ reference [..] Forwardable#def_delegator().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Proc#
 #                                    ^^^^^^^^^^^^^ definition [..] MyArray2#get_at_index().
+#                                                ⌃ enclosing_range_end [..] MyArray2#get_at_index().
  end
+#  ⌃ enclosing_range_end [..] MyArray2#
  
+#⌄ enclosing_range_start [..] MyArray3#
  class MyArray3
 #      ^^^^^^^^ definition [..] MyArray3#
+#  ⌄ enclosing_range_start [..] MyArray3#`inner_array=`().
+#  ⌄ enclosing_range_start [..] MyArray3#inner_array().
    attr_accessor :inner_array
 #                 ^^^^^^^^^^^ definition [..] MyArray3#`inner_array=`().
 #                 ^^^^^^^^^^^ definition [..] MyArray3#inner_array().
+#                           ⌃ enclosing_range_end [..] MyArray3#`inner_array=`().
+#                           ⌃ enclosing_range_end [..] MyArray3#inner_array().
    extend Forwardable
 #  ^^^^^^ reference [..] Kernel#extend().
 #         ^^^^^^^^^^^ reference [..] Forwardable#
+#  ⌄ enclosing_range_start [..] MyArray3#`<<`().
+#  ⌄ enclosing_range_start [..] MyArray3#map().
+#  ⌄ enclosing_range_start [..] MyArray3#size().
    def_delegators :@inner_array, :size, :<<, :map
 #  ^^^^^^^^^^^^^^ reference [..] Forwardable#def_delegators().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Proc#
 #                                ^^^^^ definition [..] MyArray3#size().
 #                                       ^^^ definition [..] MyArray3#`<<`().
 #                                            ^^^^ definition [..] MyArray3#map().
+#                                               ⌃ enclosing_range_end [..] MyArray3#`<<`().
+#                                               ⌃ enclosing_range_end [..] MyArray3#map().
+#                                               ⌃ enclosing_range_end [..] MyArray3#size().
  end
+#  ⌃ enclosing_range_end [..] MyArray3#
  
+#⌄ enclosing_range_start [..] MyArray4#
  class MyArray4
 #      ^^^^^^^^ definition [..] MyArray4#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
+#  ⌄ enclosing_range_start [..] MyArray4#`inner_array=`().
+#  ⌄ enclosing_range_start [..] MyArray4#inner_array().
    attr_accessor :inner_array
 #                 ^^^^^^^^^^^ definition [..] MyArray4#`inner_array=`().
 #                 ^^^^^^^^^^^ definition [..] MyArray4#inner_array().
+#                           ⌃ enclosing_range_end [..] MyArray4#`inner_array=`().
+#                           ⌃ enclosing_range_end [..] MyArray4#inner_array().
    extend Forwardable
 #  ^^^^^^ reference [..] Kernel#extend().
 #         ^^^^^^^^^^^ reference [..] Forwardable#
+#  ⌄ enclosing_range_start [..] MyArray4#`<<`().
+#  ⌄ enclosing_range_start [..] MyArray4#map().
+#  ⌄ enclosing_range_start [..] MyArray4#size().
    def_delegators :@inner_array, :size, :<<, :map
 #  ^^^^^^^^^^^^^^ reference [..] Forwardable#def_delegators().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Proc#
 #                                ^^^^^ definition [..] MyArray4#size().
 #                                       ^^^ definition [..] MyArray4#`<<`().
 #                                            ^^^^ definition [..] MyArray4#map().
+#                                               ⌃ enclosing_range_end [..] MyArray4#`<<`().
+#                                               ⌃ enclosing_range_end [..] MyArray4#map().
+#                                               ⌃ enclosing_range_end [..] MyArray4#size().
  end
+#  ⌃ enclosing_range_end [..] MyArray4#

--- a/test/scip/testdata/delegate.snapshot.rb
+++ b/test/scip/testdata/delegate.snapshot.rb
@@ -1,22 +1,34 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] MethodNameManipulation#
  class MethodNameManipulation
 #      ^^^^^^^^^^^^^^^^^^^^^^ definition [..] MethodNameManipulation#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
+#  ⌄ enclosing_range_start [..] MethodNameManipulation#ball().
    delegate :ball, to: :thing, private: true, allow_nil: true
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Proc#
 #           ^^^^^ definition [..] MethodNameManipulation#ball().
+#                                                           ⌃ enclosing_range_end [..] MethodNameManipulation#ball().
+#  ⌄ enclosing_range_start [..] MethodNameManipulation#string_bar().
+#  ⌄ enclosing_range_start [..] MethodNameManipulation#string_foo().
    delegate :foo, :bar, prefix: 'string', to: :thing
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Proc#
 #           ^^^^ definition [..] MethodNameManipulation#string_foo().
 #                 ^^^^ definition [..] MethodNameManipulation#string_bar().
+#                                                  ⌃ enclosing_range_end [..] MethodNameManipulation#string_bar().
+#                                                  ⌃ enclosing_range_end [..] MethodNameManipulation#string_foo().
+#  ⌄ enclosing_range_start [..] MethodNameManipulation#symbol_bar().
+#  ⌄ enclosing_range_start [..] MethodNameManipulation#symbol_foo().
    delegate :foo, :bar, prefix: :symbol, to: :thing
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Proc#
 #           ^^^^ definition [..] MethodNameManipulation#symbol_foo().
 #                 ^^^^ definition [..] MethodNameManipulation#symbol_bar().
+#                                                 ⌃ enclosing_range_end [..] MethodNameManipulation#symbol_bar().
+#                                                 ⌃ enclosing_range_end [..] MethodNameManipulation#symbol_foo().
  
    sig {void}
+#  ⌄ enclosing_range_start [..] MethodNameManipulation#usages().
    def usages
 #      ^^^^^^ definition [..] MethodNameManipulation#usages().
      ball(thing: 0) {}
@@ -30,4 +42,6 @@
      symbol_bar(1, 2) {}
 #    ^^^^^^^^^^ reference [..] MethodNameManipulation#symbol_bar().
    end
+#    ⌃ enclosing_range_end [..] MethodNameManipulation#usages().
  end
+#  ⌃ enclosing_range_end [..] MethodNameManipulation#

--- a/test/scip/testdata/encrypted_prop.snapshot.rb
+++ b/test/scip/testdata/encrypted_prop.snapshot.rb
@@ -1,11 +1,14 @@
  # typed: true
  
  # Minimal stub of Chalk implementation to support encrypted_prop
+#⌄ enclosing_range_start [..] Chalk#ODM#Document#
  class Chalk::ODM::Document
 #      ^^^^^ reference [..] Chalk#
 #             ^^^ reference [..] Chalk#ODM#
 #                  ^^^^^^^^ definition [..] Chalk#ODM#Document#
  end
+#  ⌃ enclosing_range_end [..] Chalk#ODM#Document#
+#⌄ enclosing_range_start [..] Opus#DB#Model#Mixins#Encryptable#EncryptedValue#
  class Opus::DB::Model::Mixins::Encryptable::EncryptedValue < Chalk::ODM::Document
 #      ^^^^ reference [..] Opus#
 #            ^^ reference [..] Opus#DB#
@@ -17,15 +20,23 @@
 #                                                                    ^^^ reference [..] Chalk#ODM#
 #                                                                         ^^^^^^^^ reference [..] Chalk#ODM#Document#
  end
+#  ⌃ enclosing_range_end [..] Opus#DB#Model#Mixins#Encryptable#EncryptedValue#
  
+#⌄ enclosing_range_start [..] EncryptedProp#
  class EncryptedProp
 #      ^^^^^^^^^^^^^ definition [..] EncryptedProp#
    include T::Props
 #  ^^^^^^^ reference [..] Module#include().
 #          ^ reference [..] T#
 #             ^^^^^ reference [..] T#Props#
+#  ⌄ enclosing_range_start [..] `<Class:EncryptedProp>`#encrypted_prop().
    def self.encrypted_prop(opts={}); end
 #           ^^^^^^^^^^^^^^ definition [..] `<Class:EncryptedProp>`#encrypted_prop().
+#                                      ⌃ enclosing_range_end [..] `<Class:EncryptedProp>`#encrypted_prop().
+#  ⌄ enclosing_range_start [..] EncryptedProp#`encrypted_foo=`().
+#  ⌄ enclosing_range_start [..] EncryptedProp#`foo=`().
+#  ⌄ enclosing_range_start [..] EncryptedProp#encrypted_foo().
+#  ⌄ enclosing_range_start [..] EncryptedProp#foo().
    encrypted_prop :foo
 #  ^^^^^^^^^^^^^^^^^^^ reference [..] String#
 #  ^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#
@@ -38,6 +49,12 @@
 #                  ^^^ definition [..] EncryptedProp#`foo=`().
 #                  ^^^ definition [..] EncryptedProp#encrypted_foo().
 #                  ^^^ definition [..] EncryptedProp#foo().
+#                    ⌃ enclosing_range_end [..] EncryptedProp#`encrypted_foo=`().
+#                    ⌃ enclosing_range_end [..] EncryptedProp#`foo=`().
+#                    ⌃ enclosing_range_end [..] EncryptedProp#encrypted_foo().
+#                    ⌃ enclosing_range_end [..] EncryptedProp#foo().
+#  ⌄ enclosing_range_start [..] EncryptedProp#bar().
+#  ⌄ enclosing_range_start [..] EncryptedProp#encrypted_bar().
    encrypted_prop :bar, migrating: true, immutable: true
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#Model#Mixins#Encryptable#
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Opus#DB#
@@ -48,9 +65,13 @@
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] String#
 #                  ^^^ definition [..] EncryptedProp#bar().
 #                  ^^^ definition [..] EncryptedProp#encrypted_bar().
+#                                                      ⌃ enclosing_range_end [..] EncryptedProp#bar().
+#                                                      ⌃ enclosing_range_end [..] EncryptedProp#encrypted_bar().
  end
+#  ⌃ enclosing_range_end [..] EncryptedProp#
  
  
+#⌄ enclosing_range_start [..] Object#f().
  def f
 #    ^ definition [..] Object#f().
    EncryptedProp.new.foo = "hello"
@@ -66,3 +87,4 @@
 #                       ^^^ reference [..] Class#new().
 #                           ^^^^^^^^^^^^^ reference [..] EncryptedProp#encrypted_foo().
  end
+#  ⌃ enclosing_range_end [..] Object#f().

--- a/test/scip/testdata/enum.snapshot.rb
+++ b/test/scip/testdata/enum.snapshot.rb
@@ -1,5 +1,7 @@
  # typed: strict
  
+#⌄ enclosing_range_start [..] X#
+#⌄ enclosing_range_start [..] X#serialize().
  class X < T::Enum
 #      ^ definition [..] X#
 #      ^ definition [..] X#serialize().
@@ -27,9 +29,12 @@
 #                         ^^^^^^^^ definition local 4$119448696
 #                               ^ reference [..] X#
  end
+#  ⌃ enclosing_range_end [..] X#
+#  ⌃ enclosing_range_end [..] X#serialize().
  
  # Adding more cases like this is not supported (c.f. isTEnum),
  # but let's at least add a test.
+#⌄ enclosing_range_start [..] Y#
  class Y < X
 #      ^ definition [..] Y#
 #          ^ reference [..] X#
@@ -44,7 +49,9 @@
 #        ^ reference [..] X#B.
    end
  end
+#  ⌃ enclosing_range_end [..] Y#
  
+#⌄ enclosing_range_start [..] Object#use_abc().
  def use_abc
 #    ^^^^^^^ definition [..] Object#use_abc().
    x = X::A
@@ -53,3 +60,4 @@
 #         ^ reference [..] X#A.
    return
  end
+#  ⌃ enclosing_range_end [..] Object#use_abc().

--- a/test/scip/testdata/field_inheritance.snapshot.rb
+++ b/test/scip/testdata/field_inheritance.snapshot.rb
@@ -3,26 +3,40 @@
  # First, check that instance variables are propagated through
  # the inheritance chain.
  
+#⌄ enclosing_range_start [..] C1#
  class C1
 #      ^^ definition [..] C1#
+#  ⌄ enclosing_range_start [..] C1#`h=`().
+#  ⌄ enclosing_range_start [..] C1#h().
    attr_accessor :h
 #                 ^ definition [..] C1#`h=`().
 #                 ^ definition [..] C1#h().
+#                 ⌃ enclosing_range_end [..] C1#`h=`().
+#                 ⌃ enclosing_range_end [..] C1#h().
+#  ⌄ enclosing_range_start [..] C1#`i=`().
+#  ⌄ enclosing_range_start [..] C1#i().
    attr_accessor :i
 #                 ^ definition [..] C1#`i=`().
 #                 ^ definition [..] C1#i().
+#                 ⌃ enclosing_range_end [..] C1#`i=`().
+#                 ⌃ enclosing_range_end [..] C1#i().
  
+#  ⌄ enclosing_range_start [..] C1#set_ivar().
    def set_ivar
 #      ^^^^^^^^ definition [..] C1#set_ivar().
      @f = 1
 #    ^^ definition [..] C1#`@f`.
      return
    end
+#    ⌃ enclosing_range_end [..] C1#set_ivar().
  end
+#  ⌃ enclosing_range_end [..] C1#
  
+#⌄ enclosing_range_start [..] C2#
  class C2 < C1
 #      ^^ definition [..] C2#
 #           ^^ reference [..] C1#
+#  ⌄ enclosing_range_start [..] C2#get_inherited_ivar().
    def get_inherited_ivar
 #      ^^^^^^^^^^^^^^^^^^ definition [..] C2#get_inherited_ivar().
      return @f + @h
@@ -31,7 +45,9 @@
 #                ^^ reference [..] C2#`@h`.
 #                relation definition=[..] C1#`@h`.
    end
+#    ⌃ enclosing_range_end [..] C2#get_inherited_ivar().
  
+#  ⌄ enclosing_range_start [..] C2#set_inherited_ivar().
    def set_inherited_ivar
 #      ^^^^^^^^^^^^^^^^^^ definition [..] C2#set_inherited_ivar().
      @f = 10
@@ -39,24 +55,32 @@
 #    relation definition=[..] C1#`@f`.
      return
    end
+#    ⌃ enclosing_range_end [..] C2#set_inherited_ivar().
  
+#  ⌄ enclosing_range_start [..] C2#set_new_ivar().
    def set_new_ivar
 #      ^^^^^^^^^^^^ definition [..] C2#set_new_ivar().
      @g = 1
 #    ^^ definition [..] C2#`@g`.
      return
    end
+#    ⌃ enclosing_range_end [..] C2#set_new_ivar().
  
+#  ⌄ enclosing_range_start [..] C2#get_new_ivar().
    def get_new_ivar
 #      ^^^^^^^^^^^^ definition [..] C2#get_new_ivar().
      return @g
 #    ^^^^^^^^^ reference [..] C2#`@g`.
    end
+#    ⌃ enclosing_range_end [..] C2#get_new_ivar().
  end
+#  ⌃ enclosing_range_end [..] C2#
  
+#⌄ enclosing_range_start [..] C3#
  class C3 < C2
 #      ^^ definition [..] C3#
 #           ^^ reference [..] C2#
+#  ⌄ enclosing_range_start [..] C3#refs().
    def refs
 #      ^^^^ definition [..] C3#refs().
      @f = @g + @i
@@ -68,8 +92,11 @@
 #              relation definition=[..] C1#`@i`.
      return
    end
+#    ⌃ enclosing_range_end [..] C3#refs().
  end
+#  ⌃ enclosing_range_end [..] C3#
  
+#⌄ enclosing_range_start [..] Object#c_check().
  def c_check
 #    ^^^^^^^ definition [..] Object#c_check().
    C1.new.instance_variable_get(:@f)
@@ -120,14 +147,17 @@
 #         ^^^^^^^^^^^^^^^^^^^^^ reference [..] Kernel#instance_variable_get().
    return
  end
+#  ⌃ enclosing_range_end [..] Object#c_check().
  
  # Now, check that class variables work as expected.
  
+#⌄ enclosing_range_start [..] D1#
  class D1
 #      ^^ definition [..] D1#
    @@d1_v = 0
 #  ^^^^^^ definition [..] `<Class:D1>`#`@@d1_v`.
  
+#  ⌄ enclosing_range_start [..] `<Class:D1>`#set_x().
    def self.set_x
 #           ^^^^^ definition [..] `<Class:D1>`#set_x().
      @@d1_x = @@d1_v
@@ -135,10 +165,13 @@
 #             ^^^^^^ reference [..] `<Class:D1>`#`@@d1_v`.
      return
    end
+#    ⌃ enclosing_range_end [..] `<Class:D1>`#set_x().
  
    # BUG: Emitting a definition for 'self' here seems wrong.
+#  ⌄ enclosing_range_start [..] `<Class:D1>`#
    class << self
 #           ^^^^ definition [..] `<Class:D1>`#
+#    ⌄ enclosing_range_start [..] `<Class:D1>`#set_y().
      def set_y
 #        ^^^^^ definition [..] `<Class:D1>`#set_y().
        @@d1_y = @@d1_v
@@ -146,12 +179,17 @@
 #      ^^^^^^^^^^^^^^^ reference [..] `<Class:D1>`#`@@d1_y`.
 #               ^^^^^^ reference [..] `<Class:D1>`#`@@d1_v`.
      end
+#      ⌃ enclosing_range_end [..] `<Class:D1>`#set_y().
    end
+#    ⌃ enclosing_range_end [..] `<Class:D1>`#
  end
+#  ⌃ enclosing_range_end [..] D1#
  
+#⌄ enclosing_range_start [..] D2#
  class D2 < D1
 #      ^^ definition [..] D2#
 #           ^^ reference [..] D1#
+#  ⌄ enclosing_range_start [..] `<Class:D2>`#get().
    def self.get
 #           ^^^ definition [..] `<Class:D2>`#get().
      @@d2_x = @@d1_v + @@d1_x
@@ -166,11 +204,15 @@
 #             ^^^^^^ reference [..] `<Class:D2>`#`@@d1_z`.
      return
    end
+#    ⌃ enclosing_range_end [..] `<Class:D2>`#get().
  end
+#  ⌃ enclosing_range_end [..] D2#
  
+#⌄ enclosing_range_start [..] D3#
  class D3 < D2
 #      ^^ definition [..] D3#
 #           ^^ reference [..] D2#
+#  ⌄ enclosing_range_start [..] `<Class:D3>`#get_2().
    def self.get_2
 #           ^^^^^ definition [..] `<Class:D3>`#get_2().
      @@d1_v + @@d1_x
@@ -188,8 +230,11 @@
 #    relation definition=[..] `<Class:D2>`#`@@d2_x`.
      return
    end
+#    ⌃ enclosing_range_end [..] `<Class:D3>`#get_2().
  end
+#  ⌃ enclosing_range_end [..] D3#
  
+#⌄ enclosing_range_start [..] Object#f().
  def f
 #    ^ definition [..] Object#f().
    D2.class_variable_get(:@@d1_v)
@@ -225,9 +270,11 @@
 #     ^^^^^^^^^^^^^^^^^^ reference [..] Module#class_variable_get().
    return
  end
+#  ⌃ enclosing_range_end [..] Object#f().
  
  ## Check that pre-declared class variables work too
  
+#⌄ enclosing_range_start [..] DD1#
  class DD1
 #      ^^^ definition [..] DD1#
    @@x = T.let(0, Integer)
@@ -236,25 +283,32 @@
 #                 ^^^^^^^ definition local 1$119448696
 #                 ^^^^^^^ reference [..] Integer#
  end
+#  ⌃ enclosing_range_end [..] DD1#
  
+#⌄ enclosing_range_start [..] DD2#
  class DD2 < DD1
 #      ^^^ definition [..] DD2#
 #            ^^^ reference [..] DD1#
+#  ⌄ enclosing_range_start [..] `<Class:DD2>`#get_x().
    def self.get_x
 #           ^^^^^ definition [..] `<Class:DD2>`#get_x().
      @@x
 #    ^^^ reference [..] `<Class:DD2>`#`@@x`.
 #    relation definition=[..] `<Class:DD1>`#`@@x`.
    end
+#    ⌃ enclosing_range_end [..] `<Class:DD2>`#get_x().
  end
+#  ⌃ enclosing_range_end [..] DD2#
  
  # Class instance variables are not inherited.
  
+#⌄ enclosing_range_start [..] E1#
  class E1
 #      ^^ definition [..] E1#
    @x = 0
 #  ^^ definition [..] `<Class:E1>`#`@x`.
  
+#  ⌄ enclosing_range_start [..] `<Class:E1>`#set_x().
    def self.set_x
 #           ^^^^^ definition [..] `<Class:E1>`#set_x().
      @x = @y
@@ -262,21 +316,27 @@
 #         ^^ reference [..] `<Class:E1>`#`@y`.
      return
    end
+#    ⌃ enclosing_range_end [..] `<Class:E1>`#set_x().
  
+#  ⌄ enclosing_range_start [..] `<Class:E1>`#set_y().
    def self.set_y
 #           ^^^^^ definition [..] `<Class:E1>`#set_y().
      @y = 10
 #    ^^ definition [..] `<Class:E1>`#`@y`.
      return
    end
+#    ⌃ enclosing_range_end [..] `<Class:E1>`#set_y().
  end
+#  ⌃ enclosing_range_end [..] E1#
  
+#⌄ enclosing_range_start [..] E2#
  class E2 < E1
 #      ^^ definition [..] E2#
 #           ^^ reference [..] E1#
    @x = 0
 #  ^^ definition [..] `<Class:E2>`#`@x`.
  
+#  ⌄ enclosing_range_start [..] `<Class:E2>`#set_x_2().
    def self.set_x_2
 #           ^^^^^^^ definition [..] `<Class:E2>`#set_x_2().
      @x = @y
@@ -284,19 +344,25 @@
 #         ^^ reference [..] `<Class:E2>`#`@y`.
      return
    end
+#    ⌃ enclosing_range_end [..] `<Class:E2>`#set_x_2().
  
+#  ⌄ enclosing_range_start [..] `<Class:E2>`#set_y_2().
    def self.set_y_2
 #           ^^^^^^^ definition [..] `<Class:E2>`#set_y_2().
      @y = 10
 #    ^^ definition [..] `<Class:E2>`#`@y`.
 #    ^^^^^^^ reference [..] `<Class:E2>`#`@y`.
    end
+#    ⌃ enclosing_range_end [..] `<Class:E2>`#set_y_2().
  end
+#  ⌃ enclosing_range_end [..] E2#
  
  # Declared fields are inherited the same way as undeclared fields
  
+#⌄ enclosing_range_start [..] F1#
  class F1
 #      ^^ definition [..] F1#
+#  ⌄ enclosing_range_start [..] F1#initialize().
    def initialize
 #      ^^^^^^^^^^ definition [..] F1#initialize().
      @x = T.let(0, Integer)
@@ -305,13 +371,19 @@
 #                  ^^^^^^^ definition local 1$3465713227
 #                  ^^^^^^^ reference [..] Integer#
    end
+#    ⌃ enclosing_range_end [..] F1#initialize().
  end
+#  ⌃ enclosing_range_end [..] F1#
  
+#⌄ enclosing_range_start [..] F2#
  class F2
 #      ^^ definition [..] F2#
+#  ⌄ enclosing_range_start [..] F2#get_x().
    def get_x
 #      ^^^^^ definition [..] F2#get_x().
      @x
 #    ^^ reference [..] F2#`@x`.
    end
+#    ⌃ enclosing_range_end [..] F2#get_x().
  end
+#  ⌃ enclosing_range_end [..] F2#

--- a/test/scip/testdata/fields_and_attrs.snapshot.rb
+++ b/test/scip/testdata/fields_and_attrs.snapshot.rb
@@ -3,8 +3,10 @@
  # Useful SO discussion with examples for class variables and instance variables,
  # and how they interact with inheritance: https://stackoverflow.com/a/15773671/2682729
  
+#⌄ enclosing_range_start [..] K#
  class K
 #      ^ definition [..] K#
+#  ⌄ enclosing_range_start [..] K#m1().
    def m1
 #      ^^ definition [..] K#m1().
      @f = 0
@@ -14,6 +16,8 @@
 #         ^^ reference [..] K#`@f`.
      return
    end
+#    ⌃ enclosing_range_end [..] K#m1().
+#  ⌄ enclosing_range_start [..] K#m2().
    def m2
 #      ^^ definition [..] K#m2().
      @f = @g
@@ -21,11 +25,15 @@
 #         ^^ reference [..] K#`@g`.
      return
    end
+#    ⌃ enclosing_range_end [..] K#m2().
  end
+#  ⌃ enclosing_range_end [..] K#
  
  # Extended
+#⌄ enclosing_range_start [..] K#
  class K
 #      ^ definition [..] K#
+#  ⌄ enclosing_range_start [..] K#m3().
    def m3
 #      ^^ definition [..] K#m3().
      @g = @f
@@ -33,15 +41,19 @@
 #         ^^ reference [..] K#`@f`.
      return
    end
+#    ⌃ enclosing_range_end [..] K#m3().
  end
+#  ⌃ enclosing_range_end [..] K#
  
  # Class instance var
+#⌄ enclosing_range_start [..] L#
  class L
 #      ^ definition [..] L#
    @x = 10
 #  ^^ definition [..] `<Class:L>`#`@x`.
    @y = 9
 #  ^^ definition [..] `<Class:L>`#`@y`.
+#  ⌄ enclosing_range_start [..] `<Class:L>`#m1().
    def self.m1
 #           ^^ definition [..] `<Class:L>`#m1().
      @y = @x
@@ -49,22 +61,28 @@
 #         ^^ reference [..] `<Class:L>`#`@x`.
      return
    end
+#    ⌃ enclosing_range_end [..] `<Class:L>`#m1().
  
+#  ⌄ enclosing_range_start [..] L#m2().
    def m2
 #      ^^ definition [..] L#m2().
      # FIXME: Missing references
      self.class.y = self.class.x
      return
    end
+#    ⌃ enclosing_range_end [..] L#m2().
  end
+#  ⌃ enclosing_range_end [..] L#
  
  # Class var
+#⌄ enclosing_range_start [..] N#
  class N
 #      ^ definition [..] N#
    @@a = 0
 #  ^^^ definition [..] `<Class:N>`#`@@a`.
    @@b = 1
 #  ^^^ definition [..] `<Class:N>`#`@@b`.
+#  ⌄ enclosing_range_start [..] `<Class:N>`#m1().
    def self.m1
 #           ^^ definition [..] `<Class:N>`#m1().
      @@b = @@a
@@ -72,7 +90,9 @@
 #          ^^^ reference [..] `<Class:N>`#`@@a`.
      return
    end
+#    ⌃ enclosing_range_end [..] `<Class:N>`#m1().
  
+#  ⌄ enclosing_range_start [..] N#m2().
    def m2
 #      ^^ definition [..] N#m2().
      @@b = @@a
@@ -80,25 +100,39 @@
 #          ^^^ reference [..] `<Class:N>`#`@@a`.
      return
    end
+#    ⌃ enclosing_range_end [..] N#m2().
  
+#  ⌄ enclosing_range_start [..] N#m3().
    def m3
 #      ^^ definition [..] N#m3().
      # FIXME: Missing references
      self.class.b = self.class.a
    end
+#    ⌃ enclosing_range_end [..] N#m3().
  end
+#  ⌃ enclosing_range_end [..] N#
  
  # Accessors
+#⌄ enclosing_range_start [..] P#
  class P
 #      ^ definition [..] P#
+#  ⌄ enclosing_range_start [..] P#`a=`().
+#  ⌄ enclosing_range_start [..] P#a().
    attr_accessor :a
 #                 ^ definition [..] P#`a=`().
 #                 ^ definition [..] P#a().
+#                 ⌃ enclosing_range_end [..] P#`a=`().
+#                 ⌃ enclosing_range_end [..] P#a().
+#  ⌄ enclosing_range_start [..] P#r().
    attr_reader :r
 #               ^ definition [..] P#r().
+#               ⌃ enclosing_range_end [..] P#r().
+#  ⌄ enclosing_range_start [..] P#`w=`().
    attr_writer :w
 #               ^ definition [..] P#`w=`().
+#               ⌃ enclosing_range_end [..] P#`w=`().
  
+#  ⌄ enclosing_range_start [..] P#init().
    def init
 #      ^^^^ definition [..] P#init().
      self.a = self.r
@@ -108,7 +142,9 @@
 #         ^^^ reference [..] P#`w=`().
 #                  ^ reference [..] P#a().
    end
+#    ⌃ enclosing_range_end [..] P#init().
  
+#  ⌄ enclosing_range_start [..] P#wrong_init().
    def wrong_init
 #      ^^^^^^^^^^ definition [..] P#wrong_init().
      # Check that 'r' is a method access but 'a' and 'w' are locals
@@ -120,8 +156,11 @@
 #    ^^^^^ reference local 2$1021288725
 #        ^ reference local 1$1021288725
    end
+#    ⌃ enclosing_range_end [..] P#wrong_init().
  end
+#  ⌃ enclosing_range_end [..] P#
  
+#⌄ enclosing_range_start [..] Object#useP().
  def useP
 #    ^^^^ definition [..] Object#useP().
    p = P.new
@@ -139,3 +178,4 @@
 #        ^ reference local 1$2121829932
 #          ^ reference [..] P#a().
  end
+#  ⌃ enclosing_range_end [..] Object#useP().

--- a/test/scip/testdata/flatfile_dsl.snapshot.rb
+++ b/test/scip/testdata/flatfile_dsl.snapshot.rb
@@ -1,37 +1,61 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] Record#
  class Record
 #      ^^^^^^ definition [..] Record#
+#  ⌄ enclosing_range_start [..] `<Class:Record>`#flatfile().
    def self.flatfile; end
 #           ^^^^^^^^ definition [..] `<Class:Record>`#flatfile().
+#                       ⌃ enclosing_range_end [..] `<Class:Record>`#flatfile().
+#  ⌄ enclosing_range_start [..] `<Class:Record>`#from().
    def self.from(*_); end
 #           ^^^^ definition [..] `<Class:Record>`#from().
+#                       ⌃ enclosing_range_end [..] `<Class:Record>`#from().
+#  ⌄ enclosing_range_start [..] `<Class:Record>`#pattern().
    def self.pattern(*_); end
 #           ^^^^^^^ definition [..] `<Class:Record>`#pattern().
+#                          ⌃ enclosing_range_end [..] `<Class:Record>`#pattern().
+#  ⌄ enclosing_range_start [..] `<Class:Record>`#field().
    def self.field(*_); end
 #           ^^^^^ definition [..] `<Class:Record>`#field().
+#                        ⌃ enclosing_range_end [..] `<Class:Record>`#field().
  end
+#  ⌃ enclosing_range_end [..] Record#
  
+#⌄ enclosing_range_start [..] Flatfile#
  class Flatfile < Record
 #      ^^^^^^^^ definition [..] Flatfile#
 #                 ^^^^^^ reference [..] Record#
    flatfile do
 #  ^^^^^^^^ reference [..] `<Class:Record>`#flatfile().
+#    ⌄ enclosing_range_start [..] Flatfile#`foo=`().
+#    ⌄ enclosing_range_start [..] Flatfile#foo().
      from   1..2, :foo
 #    ^^^^ reference [..] `<Class:Record>`#from().
 #                 ^^^^ definition [..] Flatfile#`foo=`().
 #                 ^^^^ definition [..] Flatfile#foo().
+#                    ⌃ enclosing_range_end [..] Flatfile#`foo=`().
+#                    ⌃ enclosing_range_end [..] Flatfile#foo().
+#    ⌄ enclosing_range_start [..] Flatfile#`bar=`().
+#    ⌄ enclosing_range_start [..] Flatfile#bar().
      pattern(/A-Za-z/, :bar)
 #    ^^^^^^^ reference [..] `<Class:Record>`#pattern().
 #            ^^^^^^^^ reference [..] Regexp#
 #                      ^^^^ definition [..] Flatfile#`bar=`().
 #                      ^^^^ definition [..] Flatfile#bar().
+#                          ⌃ enclosing_range_end [..] Flatfile#`bar=`().
+#                          ⌃ enclosing_range_end [..] Flatfile#bar().
+#    ⌄ enclosing_range_start [..] Flatfile#`baz=`().
+#    ⌄ enclosing_range_start [..] Flatfile#baz().
      field :baz
 #    ^^^^^ reference [..] `<Class:Record>`#field().
 #          ^^^^ definition [..] Flatfile#`baz=`().
 #          ^^^^ definition [..] Flatfile#baz().
+#             ⌃ enclosing_range_end [..] Flatfile#`baz=`().
+#             ⌃ enclosing_range_end [..] Flatfile#baz().
    end
  end
+#  ⌃ enclosing_range_end [..] Flatfile#
  
  t = Flatfile.new
 #^ definition local 1$119448696

--- a/test/scip/testdata/for.snapshot.rb
+++ b/test/scip/testdata/for.snapshot.rb
@@ -1,5 +1,6 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] Object#for_loop().
  def for_loop()
 #    ^^^^^^^^ definition [..] Object#for_loop().
    y = 0
@@ -23,3 +24,4 @@
    y
 #  ^ reference local 1$1120785331
  end
+#  ⌃ enclosing_range_end [..] Object#for_loop().

--- a/test/scip/testdata/freeze_constants.snapshot.rb
+++ b/test/scip/testdata/freeze_constants.snapshot.rb
@@ -27,6 +27,7 @@
 #| ```
 #         ^ reference [..] X.
  
+#⌄ enclosing_range_start [..] M#
  module M
 #       ^ definition [..] M#
 #       documentation
@@ -53,3 +54,4 @@
 #  | ```
 #           ^ reference [..] X.
  end
+#  ⌃ enclosing_range_end [..] M#

--- a/test/scip/testdata/functions.snapshot.rb
+++ b/test/scip/testdata/functions.snapshot.rb
@@ -1,5 +1,6 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] Object#globalFn1().
  def globalFn1()
 #    ^^^^^^^^^ definition [..] Object#globalFn1().
    x = 10
@@ -7,7 +8,9 @@
    x
 #  ^ reference local 1$3846536873
  end
+#  ⌃ enclosing_range_end [..] Object#globalFn1().
  
+#⌄ enclosing_range_start [..] Object#globalFn2().
  def globalFn2()
 #    ^^^^^^^^^ definition [..] Object#globalFn2().
    x = globalFn1()
@@ -15,8 +18,10 @@
 #  ^^^^^^^^^^^^^^^ reference local 1$3796204016
 #      ^^^^^^^^^ reference [..] Object#globalFn1().
  end
+#  ⌃ enclosing_range_end [..] Object#globalFn2().
  
  # https://stackoverflow.com/questions/64322636/whats-the-3-dots-method-argument-in-ruby
+#⌄ enclosing_range_start [..] Object#loopyDoopy().
  def loopyDoopy(...)
 #    ^^^^^^^^^^ definition [..] Object#loopyDoopy().
 #               ^^^ definition local 1$1182647655
@@ -26,3 +31,4 @@
 #  ^^^^^^^^^^^^^^^ reference local 1$1182647655
    return
  end
+#  ⌃ enclosing_range_end [..] Object#loopyDoopy().

--- a/test/scip/testdata/gem_metadata.snapshot.rb
+++ b/test/scip/testdata/gem_metadata.snapshot.rb
@@ -1,16 +1,22 @@
  # typed: true
  # gem-metadata: leet@1.3.3.7
  
+#⌄ enclosing_range_start leet 1.3.3.7 C#
  class C
 #      ^ definition leet 1.3.3.7 C#
+#  ⌄ enclosing_range_start leet 1.3.3.7 C#m().
    def m
 #      ^ definition leet 1.3.3.7 C#m().
      n
 #    ^ reference leet 1.3.3.7 C#n().
    end
+#    ⌃ enclosing_range_end leet 1.3.3.7 C#m().
+#  ⌄ enclosing_range_start leet 1.3.3.7 C#n().
    def n
 #      ^ definition leet 1.3.3.7 C#n().
      m
 #    ^ reference leet 1.3.3.7 C#m().
    end
+#    ⌃ enclosing_range_end leet 1.3.3.7 C#n().
  end
+#  ⌃ enclosing_range_end leet 1.3.3.7 C#

--- a/test/scip/testdata/generics.snapshot.rb
+++ b/test/scip/testdata/generics.snapshot.rb
@@ -4,6 +4,7 @@
  # scip_indexer/SCIPSymbolRef.cc symbolForExpr (Descriptor::TypeParameter,
  # Descriptor::Type).
  
+#⌄ enclosing_range_start [..] GenericBox#
  class GenericBox
 #      ^^^^^^^^^^ definition [..] GenericBox#
    extend T::Sig
@@ -16,6 +17,7 @@
  
    sig { params(x: Elem).void }
 #                  ^^^^ definition local 2$3465713227
+#  ⌄ enclosing_range_start [..] GenericBox#initialize().
    def initialize(x)
 #      ^^^^^^^^^^ definition [..] GenericBox#initialize().
 #                 ^ definition local 1$3465713227
@@ -24,15 +26,20 @@
 #    ^^^^^^ reference [..] GenericBox#`@x`.
 #         ^ reference local 1$3465713227
    end
+#    ⌃ enclosing_range_end [..] GenericBox#initialize().
  
    sig { returns(Elem) }
+#  ⌄ enclosing_range_start [..] GenericBox#get().
    def get
 #      ^^^ definition [..] GenericBox#get().
      @x
 #    ^^ reference [..] GenericBox#`@x`.
    end
+#    ⌃ enclosing_range_end [..] GenericBox#get().
  end
+#  ⌃ enclosing_range_end [..] GenericBox#
  
+#⌄ enclosing_range_start [..] MyGenericMixin#
  module MyGenericMixin
 #       ^^^^^^^^^^^^^^ definition [..] MyGenericMixin#
    extend T::Generic
@@ -41,7 +48,9 @@
    Item = type_member
 #  ^^^^ definition local 2$119448696
  end
+#  ⌃ enclosing_range_end [..] MyGenericMixin#
  
+#⌄ enclosing_range_start [..] WithTypeTemplate#
  class WithTypeTemplate
 #      ^^^^^^^^^^^^^^^^ definition [..] WithTypeTemplate#
    extend T::Generic
@@ -50,21 +59,27 @@
    Tag = type_template
 #  ^^^ definition local 2$119448696
  end
+#  ⌃ enclosing_range_end [..] WithTypeTemplate#
  
+#⌄ enclosing_range_start [..] WithTypeParameters#
  class WithTypeParameters
 #      ^^^^^^^^^^^^^^^^^^ definition [..] WithTypeParameters#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
  
    sig { type_parameters(:U).params(x: T.type_parameter(:U)).returns(T.type_parameter(:U)) }
+#  ⌄ enclosing_range_start [..] WithTypeParameters#identity().
    def identity(x)
 #      ^^^^^^^^ definition [..] WithTypeParameters#identity().
 #               ^ definition local 1$2839884955
      x
 #    ^ reference local 1$2839884955
    end
+#    ⌃ enclosing_range_end [..] WithTypeParameters#identity().
  end
+#  ⌃ enclosing_range_end [..] WithTypeParameters#
  
+#⌄ enclosing_range_start [..] Object#use_generics().
  def use_generics
 #    ^^^^^^^^^^^^ definition [..] Object#use_generics().
    box = GenericBox.new(1)
@@ -82,3 +97,4 @@
 #                             ^^^^^^^^ reference [..] WithTypeParameters#identity().
    return
  end
+#  ⌃ enclosing_range_end [..] Object#use_generics().

--- a/test/scip/testdata/globals.snapshot.rb
+++ b/test/scip/testdata/globals.snapshot.rb
@@ -3,6 +3,7 @@
  $aa = 0
 #^^^ definition [global] `<Class:<root>>`#$aa.
  
+#⌄ enclosing_range_start [..] Object#f().
  def f
 #    ^ definition [..] Object#f().
    $aa = 10
@@ -15,9 +16,12 @@
 #        ^^^ reference [global] `<Class:<root>>`#$bb.
    return
  end
+#  ⌃ enclosing_range_end [..] Object#f().
  
+#⌄ enclosing_range_start [..] C#
  class C
 #      ^ definition [..] C#
+#  ⌄ enclosing_range_start [..] C#g().
    def g
 #      ^ definition [..] C#g().
      $c = $bb
@@ -25,7 +29,9 @@
 #    ^^^^^^^^ reference [global] `<Class:<root>>`#$c.
 #         ^^^ reference [global] `<Class:<root>>`#$bb.
    end
+#    ⌃ enclosing_range_end [..] C#g().
  end
+#  ⌃ enclosing_range_end [..] C#
  
  puts $c
 #^^^^ reference [..] Kernel#puts().
@@ -36,8 +42,10 @@
 #              ^^^^^^^ definition local 3$119448696
 #              ^^^^^^^ reference [..] Integer#
  
+#⌄ enclosing_range_start [..] Object#g().
  def g
 #    ^ definition [..] Object#g().
    $d
 #  ^^ reference [global] `<Class:<root>>`#$d.
  end
+#  ⌃ enclosing_range_end [..] Object#g().

--- a/test/scip/testdata/hashes.snapshot.rb
+++ b/test/scip/testdata/hashes.snapshot.rb
@@ -1,5 +1,6 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] Object#hashes().
  def hashes(h, k)
 #    ^^^^^^ definition [..] Object#hashes().
 #           ^ definition local 1$1685166589
@@ -15,3 +16,4 @@
 #         ^ reference local 1$1685166589
 #           ^^^ reference local 3$1685166589
  end
+#  ⌃ enclosing_range_end [..] Object#hashes().

--- a/test/scip/testdata/hoverdocs.snapshot.rb
+++ b/test/scip/testdata/hoverdocs.snapshot.rb
@@ -2,6 +2,7 @@
  # options: showDocs
  
  # Class doc comment
+#⌄ enclosing_range_start [..] C1#
  class C1
 #      ^^ definition [..] C1#
 #      documentation
@@ -13,6 +14,7 @@
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
  
+#  ⌄ enclosing_range_start [..] C1#m1().
    def m1
 #      ^^ definition [..] C1#m1().
 #      documentation
@@ -21,9 +23,11 @@
 #      | def m1
 #      | ```
    end
+#    ⌃ enclosing_range_end [..] C1#m1().
  
    sig { returns(T::Boolean) }
 #                   ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] C1#m2().
    def m2
 #      ^^ definition [..] C1#m2().
 #      documentation
@@ -33,10 +37,12 @@
 #      | ```
      true
    end
+#    ⌃ enclosing_range_end [..] C1#m2().
  
    sig { params(C, T::Boolean).returns(T::Boolean) }
 #                     ^^^^^^^ reference [..] T#Boolean.
 #                                         ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] C1#m3().
    def m3(c, b)
 #      ^^ definition [..] C1#m3().
 #      documentation
@@ -58,9 +64,11 @@
 #    ^ reference local 1$2519626513
 #            ^ reference local 2$2519626513
    end
+#    ⌃ enclosing_range_end [..] C1#m3().
  
    # _This_ is a
    # **doc comment.**
+#  ⌄ enclosing_range_start [..] C1#m4().
    def m4(xs)
 #      ^^ definition [..] C1#m4().
 #      documentation
@@ -79,11 +87,13 @@
      xs[0]
 #    ^^ reference local 1$2536404132
    end
+#    ⌃ enclosing_range_end [..] C1#m4().
  
    # Yet another..
    # ...doc comment
    sig { returns(T::Boolean) }
 #                   ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] C1#m5().
    def m5
 #      ^^ definition [..] C1#m5().
 #      documentation
@@ -96,12 +106,14 @@
 #      | ...doc comment
      true
    end
+#    ⌃ enclosing_range_end [..] C1#m5().
  
    # And...
    # ...one more doc comment
    sig { params(C, T::Boolean).returns(T::Boolean) }
 #                     ^^^^^^^ reference [..] T#Boolean.
 #                                         ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] C1#m6().
    def m6(c, b)
 #      ^^ definition [..] C1#m6().
 #      documentation
@@ -126,8 +138,11 @@
 #    ^ reference local 1$2569959370
 #            ^ reference local 2$2569959370
    end
+#    ⌃ enclosing_range_end [..] C1#m6().
  end
+#  ⌃ enclosing_range_end [..] C1#
  
+#⌄ enclosing_range_start [..] C2#
  class C2 # undocumented class
 #      ^^ definition [..] C2#
 #      documentation
@@ -135,10 +150,12 @@
 #      | class C2
 #      | ```
  end
+#  ⌃ enclosing_range_end [..] C2#
  
  # Module doc comment
  #
  # Some stuff
+#⌄ enclosing_range_start [..] M1#
  module M1
 #       ^^ definition [..] M1#
 #       documentation
@@ -150,6 +167,7 @@
 #       | 
 #       | Some stuff
    # This class is nested inside M1
+#  ⌄ enclosing_range_start [..] M1#C3#
    class C3
 #        ^^ definition [..] M1#C3#
 #        documentation
@@ -159,8 +177,10 @@
 #        documentation
 #        | This class is nested inside M1
    end
+#    ⌃ enclosing_range_end [..] M1#C3#
  
    # This module is nested inside M1
+#  ⌄ enclosing_range_start [..] M1#M2#
    module M2
 #         ^^ definition [..] M1#M2#
 #         documentation
@@ -175,6 +195,7 @@
      # This method is inside M1::M2
      sig { returns(T::Boolean) }
 #                     ^^^^^^^ reference [..] T#Boolean.
+#    ⌄ enclosing_range_start [..] M1#M2#n1().
      def n1
 #        ^^ definition [..] M1#M2#n1().
 #        documentation
@@ -186,8 +207,10 @@
 #        | This method is inside M1::M2
        true
      end
+#      ⌃ enclosing_range_end [..] M1#M2#n1().
  
      # This method is also inside M1::M2
+#    ⌄ enclosing_range_start [..] M1#M2#n2().
      def n2
 #        ^^ definition [..] M1#M2#n2().
 #        documentation
@@ -198,10 +221,14 @@
 #        documentation
 #        | This method is also inside M1::M2
      end
+#      ⌃ enclosing_range_end [..] M1#M2#n2().
    end
+#    ⌃ enclosing_range_end [..] M1#M2#
  end
+#  ⌃ enclosing_range_end [..] M1#
  
  # This is a global function
+#⌄ enclosing_range_start [..] Object#f1().
  def f1
 #    ^^ definition [..] Object#f1().
 #    documentation
@@ -218,12 +245,14 @@
 #  ^^ reference [..] M1#
 #      ^^ reference [..] M1#M2#
  end
+#  ⌃ enclosing_range_end [..] Object#f1().
  
  # Yet another global function
  sig { returns(T::Integer) }
 #^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #      ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #              ^ reference [..] T#
+#⌄ enclosing_range_start [..] Object#f2().
  def f2
 #    ^^ definition [..] Object#f2().
 #    documentation
@@ -235,7 +264,9 @@
 #    | Yet another global function
    return 10
  end
+#  ⌃ enclosing_range_end [..] Object#f2().
  
+#⌄ enclosing_range_start [..] Object#f3().
  def f3 # undocumented global function
 #    ^^ definition [..] Object#f3().
 #    documentation
@@ -244,6 +275,7 @@
 #    | def f3
 #    | ```
  end
+#  ⌃ enclosing_range_end [..] Object#f3().
  
  extend T::Sig
 #^^^^^^ reference [..] Kernel#extend().
@@ -254,6 +286,7 @@
 #^^^ reference [..] Sorbet#Private#`<Class:Static>`#sig().
 #      ^^^^^^^ reference [..] T#Private#Methods#DeclBuilder#returns().
 #              ^ reference [..] T#
+#⌄ enclosing_range_start [..] Object#f4().
  def f4 # another undocumented global function
 #    ^^ definition [..] Object#f4().
 #    documentation
@@ -263,8 +296,10 @@
 #    | ```
    return 10
  end
+#  ⌃ enclosing_range_end [..] Object#f4().
  
  # Parent class
+#⌄ enclosing_range_start [..] K1#
  class K1
 #      ^^ definition [..] K1#
 #      documentation
@@ -274,6 +309,7 @@
 #      documentation
 #      | Parent class
    # sets @x and @@y
+#  ⌄ enclosing_range_start [..] K1#p1().
    def p1
 #      ^^ definition [..] K1#p1().
 #      documentation
@@ -297,8 +333,10 @@
 #    | @@y (Integer(10))
 #    | ```
    end
+#    ⌃ enclosing_range_end [..] K1#p1().
  
    # lorem ipsum, you get it
+#  ⌄ enclosing_range_start [..] `<Class:K1>`#p2().
    def self.p2
 #           ^^ definition [..] `<Class:K1>`#p2().
 #           documentation
@@ -316,9 +354,12 @@
 #    | @z (Integer(10))
 #    | ```
    end
+#    ⌃ enclosing_range_end [..] `<Class:K1>`#p2().
  end
+#  ⌃ enclosing_range_end [..] K1#
  
  # Subclass
+#⌄ enclosing_range_start [..] K2#
  class K2 < K1
 #      ^^ definition [..] K2#
 #      documentation
@@ -339,6 +380,7 @@
 #  | doc comment on class var ooh
  
    # overrides K1's p1
+#  ⌄ enclosing_range_start [..] K2#p1().
    def p1
 #      ^^ definition [..] K2#p1().
 #      documentation
@@ -369,4 +411,6 @@
 #          | ```
 #          relation definition=[..] K1#`@x`.
    end
+#    ⌃ enclosing_range_end [..] K2#p1().
  end
+#  ⌃ enclosing_range_end [..] K2#

--- a/test/scip/testdata/implicit_super_arg.snapshot.rb
+++ b/test/scip/testdata/implicit_super_arg.snapshot.rb
@@ -18,12 +18,16 @@
  #     <statTemp>$6: Symbol(:<super>) = :<super>
  #     <returnMethodTemp>$2: T.untyped = <cfgAlias>$4: T.class_of(<Magic>).<call-with-block>(<self>: C, <statTemp>$6: Symbol(:<super>), <blk>: T.untyped, a: T.untyped, b: T.untyped)
  #     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
+#⌄ enclosing_range_start [..] C#
  class C
 #      ^ definition [..] C#
+#  ⌄ enclosing_range_start [..] C#f().
    def f(a, b)
 #      ^ definition [..] C#f().
 #        ^ definition local 1$3809224601
 #           ^ definition local 2$3809224601
      super
    end
+#    ⌃ enclosing_range_end [..] C#f().
  end
+#  ⌃ enclosing_range_end [..] C#

--- a/test/scip/testdata/inheritance.snapshot.rb
+++ b/test/scip/testdata/inheritance.snapshot.rb
@@ -1,5 +1,6 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] Z1#
  class Z1
 #      ^^ definition [..] Z1#
    extend T::Sig
@@ -7,6 +8,7 @@
  
    sig { params(a: T::Boolean).void }
 #                     ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] Z1#write_f().
    def write_f(a)
 #      ^^^^^^^ definition [..] Z1#write_f().
 #              ^ definition local 1$1000661517
@@ -15,16 +17,21 @@
 #    ^^^^^^ reference [..] Z1#`@f`.
 #         ^ reference local 1$1000661517
    end
+#    ⌃ enclosing_range_end [..] Z1#write_f().
  
    sig { returns(T::Boolean) }
 #                   ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] Z1#`read_f?`().
    def read_f?
 #      ^^^^^^^ definition [..] Z1#`read_f?`().
      @f
 #    ^^ reference [..] Z1#`@f`.
    end
+#    ⌃ enclosing_range_end [..] Z1#`read_f?`().
  end
+#  ⌃ enclosing_range_end [..] Z1#
  
+#⌄ enclosing_range_start [..] Z2#
  class Z2
 #      ^^ definition [..] Z2#
    extend T::Sig
@@ -32,14 +39,17 @@
  
    sig { returns(T::Boolean) }
 #                   ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] Z2#`read_f?`().
    def read_f?
 #      ^^^^^^^ definition [..] Z2#`read_f?`().
      @f
 #    ^^ reference [..] Z2#`@f`.
    end
+#    ⌃ enclosing_range_end [..] Z2#`read_f?`().
  
    sig { params(a: T::Boolean).void }
 #                     ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] Z2#write_f().
    def write_f(a)
 #      ^^^^^^^ definition [..] Z2#write_f().
 #              ^ definition local 1$1000661517
@@ -48,8 +58,11 @@
 #    ^^^^^^ reference [..] Z2#`@f`.
 #         ^ reference local 1$1000661517
    end
+#    ⌃ enclosing_range_end [..] Z2#write_f().
  end
+#  ⌃ enclosing_range_end [..] Z2#
  
+#⌄ enclosing_range_start [..] Z3#
  class Z3 < Z1
 #      ^^ definition [..] Z3#
 #           ^^ reference [..] Z1#
@@ -58,14 +71,18 @@
  
    sig { returns(T::Boolean) }
 #                   ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] Z3#`read_f_plus_1?`().
    def read_f_plus_1?
 #      ^^^^^^^^^^^^^^ definition [..] Z3#`read_f_plus_1?`().
      @f + 1
 #    ^^ reference [..] Z3#`@f`.
 #    relation definition=[..] Z1#`@f`.
    end
+#    ⌃ enclosing_range_end [..] Z3#`read_f_plus_1?`().
  end
+#  ⌃ enclosing_range_end [..] Z3#
  
+#⌄ enclosing_range_start [..] Z4#
  class Z4 < Z3
 #      ^^ definition [..] Z4#
 #           ^^ reference [..] Z3#
@@ -74,6 +91,7 @@
  
    sig { params(a: T::Boolean).void }
 #                     ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] Z4#write_f_plus_1().
    def write_f_plus_1(a)
 #      ^^^^^^^^^^^^^^ definition [..] Z4#write_f_plus_1().
 #                     ^ definition local 1$3337417690
@@ -87,5 +105,7 @@
 #    relation definition=[..] Z1#`@f`.
 #         ^^^^^^^^^^^^^^ reference [..] Z3#`read_f_plus_1?`().
    end
+#    ⌃ enclosing_range_end [..] Z4#write_f_plus_1().
  end
+#  ⌃ enclosing_range_end [..] Z4#
  

--- a/test/scip/testdata/loops_and_conditionals.snapshot.rb
+++ b/test/scip/testdata/loops_and_conditionals.snapshot.rb
@@ -1,5 +1,6 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] Object#if_elsif_else().
  def if_elsif_else()
 #    ^^^^^^^^^^^^^ definition [..] Object#if_elsif_else().
    x = 0
@@ -43,7 +44,9 @@
  
    return
  end
+#  ⌃ enclosing_range_end [..] Object#if_elsif_else().
  
+#⌄ enclosing_range_start [..] Object#unless().
  def unless()
 #    ^^^^^^ definition [..] Object#unless().
    z = 0
@@ -66,7 +69,9 @@
    end
    return
  end
+#  ⌃ enclosing_range_end [..] Object#unless().
  
+#⌄ enclosing_range_start [..] Object#case().
  def case(x, y)
 #    ^^^^ definition [..] Object#case().
 #         ^ definition local 1$2602907825
@@ -91,7 +96,9 @@
    end
    return
  end
+#  ⌃ enclosing_range_end [..] Object#case().
  
+#⌄ enclosing_range_start [..] Object#for().
  def for(xs)
 #    ^^^ definition [..] Object#for().
 #        ^^ definition local 1$2901640080
@@ -130,7 +137,9 @@
 #              ^^ reference [..] BasicObject#`==`().
    end
  end
+#  ⌃ enclosing_range_end [..] Object#for().
  
+#⌄ enclosing_range_start [..] Object#while().
  def while(xs)
 #    ^^^^^ definition [..] Object#while().
 #          ^^ definition local 1$231090382
@@ -173,7 +182,9 @@
 #              ^^ reference [..] BasicObject#`==`().
    end
  end
+#  ⌃ enclosing_range_end [..] Object#while().
  
+#⌄ enclosing_range_start [..] Object#until().
  def until(xs)
 #    ^^^^^ definition [..] Object#until().
 #          ^^ definition local 1$3132432719
@@ -216,7 +227,9 @@
 #              ^^ reference [..] BasicObject#`==`().
    end
  end
+#  ⌃ enclosing_range_end [..] Object#until().
  
+#⌄ enclosing_range_start [..] Object#flip_flop().
  def flip_flop(xs)
 #    ^^^^^^^^^ definition [..] Object#flip_flop().
 #              ^^ definition local 1$2191960030
@@ -233,3 +246,4 @@
 #         ^ reference local 2$2191960030
    end
  end
+#  ⌃ enclosing_range_end [..] Object#flip_flop().

--- a/test/scip/testdata/mattr.snapshot.rb
+++ b/test/scip/testdata/mattr.snapshot.rb
@@ -1,26 +1,43 @@
  # typed: strict
  
+#⌄ enclosing_range_start [..] MR#
  class MR
 #      ^^ definition [..] MR#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
+#               ⌄ enclosing_range_start [..] MR#both().
+#               ⌄ enclosing_range_start [..] `<Class:MR>`#both().
+#                      ⌄ enclosing_range_start [..] MR#foo().
+#                      ⌄ enclosing_range_start [..] `<Class:MR>`#foo().
    mattr_reader :both, :foo
 #               ^^^^^ definition [..] MR#both().
 #               ^^^^^ definition [..] `<Class:MR>`#both().
 #                      ^^^^ definition [..] MR#foo().
 #                      ^^^^ definition [..] `<Class:MR>`#foo().
+#                   ⌃ enclosing_range_end [..] MR#both().
+#                   ⌃ enclosing_range_end [..] `<Class:MR>`#both().
+#                         ⌃ enclosing_range_end [..] MR#foo().
+#                         ⌃ enclosing_range_end [..] `<Class:MR>`#foo().
+#               ⌄ enclosing_range_start [..] `<Class:MR>`#no_instance().
    mattr_reader :no_instance, instance_accessor: false
 #               ^^^^^^^^^^^^ definition [..] `<Class:MR>`#no_instance().
+#                          ⌃ enclosing_range_end [..] `<Class:MR>`#no_instance().
+#               ⌄ enclosing_range_start [..] `<Class:MR>`#bar().
+#                     ⌄ enclosing_range_start [..] `<Class:MR>`#no_instance_reader().
    mattr_reader :bar, :no_instance_reader, instance_reader: false
 #               ^^^^ definition [..] `<Class:MR>`#bar().
 #                     ^^^^^^^^^^^^^^^^^^^ definition [..] `<Class:MR>`#no_instance_reader().
+#                  ⌃ enclosing_range_end [..] `<Class:MR>`#bar().
+#                                       ⌃ enclosing_range_end [..] `<Class:MR>`#no_instance_reader().
  
    sig {void}
+#  ⌄ enclosing_range_start [..] MR#usages().
    def usages
 #      ^^^^^^ definition [..] MR#usages().
      both
 #    ^^^^ reference [..] MR#both().
    end
+#    ⌃ enclosing_range_end [..] MR#usages().
  
    both
 #  ^^^^ reference [..] `<Class:MR>`#both().
@@ -29,28 +46,46 @@
    no_instance_reader
 #  ^^^^^^^^^^^^^^^^^^ reference [..] `<Class:MR>`#no_instance_reader().
  end
+#  ⌃ enclosing_range_end [..] MR#
  
+#⌄ enclosing_range_start [..] MW#
  class MW
 #      ^^ definition [..] MW#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
+#               ⌄ enclosing_range_start [..] MW#`both=`().
+#               ⌄ enclosing_range_start [..] `<Class:MW>`#`both=`().
+#                      ⌄ enclosing_range_start [..] MW#`foo=`().
+#                      ⌄ enclosing_range_start [..] `<Class:MW>`#`foo=`().
    mattr_writer :both, :foo
 #               ^^^^^ definition [..] MW#`both=`().
 #               ^^^^^ definition [..] `<Class:MW>`#`both=`().
 #                      ^^^^ definition [..] MW#`foo=`().
 #                      ^^^^ definition [..] `<Class:MW>`#`foo=`().
+#                   ⌃ enclosing_range_end [..] MW#`both=`().
+#                   ⌃ enclosing_range_end [..] `<Class:MW>`#`both=`().
+#                         ⌃ enclosing_range_end [..] MW#`foo=`().
+#                         ⌃ enclosing_range_end [..] `<Class:MW>`#`foo=`().
+#               ⌄ enclosing_range_start [..] `<Class:MW>`#`no_instance=`().
    mattr_writer :no_instance, instance_accessor: false
 #               ^^^^^^^^^^^^ definition [..] `<Class:MW>`#`no_instance=`().
+#                          ⌃ enclosing_range_end [..] `<Class:MW>`#`no_instance=`().
+#               ⌄ enclosing_range_start [..] `<Class:MW>`#`bar=`().
+#                     ⌄ enclosing_range_start [..] `<Class:MW>`#`no_instance_writer=`().
    mattr_writer :bar, :no_instance_writer, instance_writer: false
 #               ^^^^ definition [..] `<Class:MW>`#`bar=`().
 #                     ^^^^^^^^^^^^^^^^^^^ definition [..] `<Class:MW>`#`no_instance_writer=`().
+#                  ⌃ enclosing_range_end [..] `<Class:MW>`#`bar=`().
+#                                       ⌃ enclosing_range_end [..] `<Class:MW>`#`no_instance_writer=`().
  
    sig {void}
+#  ⌄ enclosing_range_start [..] MW#usages().
    def usages
 #      ^^^^^^ definition [..] MW#usages().
      self.both = 1
 #         ^^^^^^ reference [..] MW#`both=`().
    end
+#    ⌃ enclosing_range_end [..] MW#usages().
  
    self.both = 1
 #       ^^^^^^ reference [..] `<Class:MW>`#`both=`().
@@ -59,11 +94,21 @@
    self.no_instance_writer = 1
 #       ^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:MW>`#`no_instance_writer=`().
  end
+#  ⌃ enclosing_range_end [..] MW#
  
+#⌄ enclosing_range_start [..] MA#
  class MA
 #      ^^ definition [..] MA#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
+#                 ⌄ enclosing_range_start [..] MA#`both=`().
+#                 ⌄ enclosing_range_start [..] MA#both().
+#                 ⌄ enclosing_range_start [..] `<Class:MA>`#`both=`().
+#                 ⌄ enclosing_range_start [..] `<Class:MA>`#both().
+#                        ⌄ enclosing_range_start [..] MA#`foo=`().
+#                        ⌄ enclosing_range_start [..] MA#foo().
+#                        ⌄ enclosing_range_start [..] `<Class:MA>`#`foo=`().
+#                        ⌄ enclosing_range_start [..] `<Class:MA>`#foo().
    mattr_accessor :both, :foo
 #                 ^^^^^ definition [..] MA#both().
 #                 ^^^^^ definition [..] MA#`both=`().
@@ -73,13 +118,37 @@
 #                        ^^^^ definition [..] MA#foo().
 #                        ^^^^ definition [..] `<Class:MA>`#`foo=`().
 #                        ^^^^ definition [..] `<Class:MA>`#foo().
+#                     ⌃ enclosing_range_end [..] MA#`both=`().
+#                     ⌃ enclosing_range_end [..] MA#both().
+#                     ⌃ enclosing_range_end [..] `<Class:MA>`#`both=`().
+#                     ⌃ enclosing_range_end [..] `<Class:MA>`#both().
+#                           ⌃ enclosing_range_end [..] MA#`foo=`().
+#                           ⌃ enclosing_range_end [..] MA#foo().
+#                           ⌃ enclosing_range_end [..] `<Class:MA>`#`foo=`().
+#                           ⌃ enclosing_range_end [..] `<Class:MA>`#foo().
+#                 ⌄ enclosing_range_start [..] `<Class:MA>`#`no_instance=`().
+#                 ⌄ enclosing_range_start [..] `<Class:MA>`#no_instance().
    mattr_accessor :no_instance, instance_accessor: false
 #                 ^^^^^^^^^^^^ definition [..] `<Class:MA>`#`no_instance=`().
 #                 ^^^^^^^^^^^^ definition [..] `<Class:MA>`#no_instance().
+#                            ⌃ enclosing_range_end [..] `<Class:MA>`#`no_instance=`().
+#                            ⌃ enclosing_range_end [..] `<Class:MA>`#no_instance().
+#                 ⌄ enclosing_range_start [..] MA#`no_instance_reader=`().
+#                 ⌄ enclosing_range_start [..] `<Class:MA>`#`no_instance_reader=`().
+#                 ⌄ enclosing_range_start [..] `<Class:MA>`#no_instance_reader().
    mattr_accessor :no_instance_reader, instance_reader: false
 #                 ^^^^^^^^^^^^^^^^^^^ definition [..] MA#`no_instance_reader=`().
 #                 ^^^^^^^^^^^^^^^^^^^ definition [..] `<Class:MA>`#`no_instance_reader=`().
 #                 ^^^^^^^^^^^^^^^^^^^ definition [..] `<Class:MA>`#no_instance_reader().
+#                                   ⌃ enclosing_range_end [..] MA#`no_instance_reader=`().
+#                                   ⌃ enclosing_range_end [..] `<Class:MA>`#`no_instance_reader=`().
+#                                   ⌃ enclosing_range_end [..] `<Class:MA>`#no_instance_reader().
+#                 ⌄ enclosing_range_start [..] MA#bar().
+#                 ⌄ enclosing_range_start [..] `<Class:MA>`#`bar=`().
+#                 ⌄ enclosing_range_start [..] `<Class:MA>`#bar().
+#                       ⌄ enclosing_range_start [..] MA#no_instance_writer().
+#                       ⌄ enclosing_range_start [..] `<Class:MA>`#`no_instance_writer=`().
+#                       ⌄ enclosing_range_start [..] `<Class:MA>`#no_instance_writer().
    mattr_accessor :bar, :no_instance_writer, instance_writer: false
 #                 ^^^^ definition [..] MA#bar().
 #                 ^^^^ definition [..] `<Class:MA>`#`bar=`().
@@ -87,8 +156,15 @@
 #                       ^^^^^^^^^^^^^^^^^^^ definition [..] MA#no_instance_writer().
 #                       ^^^^^^^^^^^^^^^^^^^ definition [..] `<Class:MA>`#`no_instance_writer=`().
 #                       ^^^^^^^^^^^^^^^^^^^ definition [..] `<Class:MA>`#no_instance_writer().
+#                    ⌃ enclosing_range_end [..] MA#bar().
+#                    ⌃ enclosing_range_end [..] `<Class:MA>`#`bar=`().
+#                    ⌃ enclosing_range_end [..] `<Class:MA>`#bar().
+#                                         ⌃ enclosing_range_end [..] MA#no_instance_writer().
+#                                         ⌃ enclosing_range_end [..] `<Class:MA>`#`no_instance_writer=`().
+#                                         ⌃ enclosing_range_end [..] `<Class:MA>`#no_instance_writer().
  
    sig {void}
+#  ⌄ enclosing_range_start [..] MA#usages().
    def usages
 #      ^^^^^^ definition [..] MA#usages().
      both
@@ -102,6 +178,7 @@
      no_instance_writer
 #    ^^^^^^^^^^^^^^^^^^ reference [..] MA#no_instance_writer().
    end
+#    ⌃ enclosing_range_end [..] MA#usages().
  
    both
 #  ^^^^ reference [..] `<Class:MA>`#both().
@@ -123,3 +200,4 @@
    self.no_instance_writer = 1
 #       ^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:MA>`#`no_instance_writer=`().
  end
+#  ⌃ enclosing_range_end [..] MA#

--- a/test/scip/testdata/metaprog.snapshot.rb
+++ b/test/scip/testdata/metaprog.snapshot.rb
@@ -4,6 +4,7 @@
  # indexer (define_method body is a normal block; method_missing / respond_to_missing?
  # are normal method defs).
  
+#⌄ enclosing_range_start [..] Dynamo#
  class Dynamo
 #      ^^^^^^ definition [..] Dynamo#
    define_method(:dynamic) do |x|
@@ -13,6 +14,7 @@
 #    ^ reference local 1$119448696
    end
  
+#  ⌄ enclosing_range_start [..] Dynamo#method_missing().
    def method_missing(name, *args, &blk)
 #      ^^^^^^^^^^^^^^ definition [..] Dynamo#method_missing().
 #                     ^^^^ definition local 1$2090704463
@@ -20,13 +22,18 @@
 #                ^^^^ reference local 1$2090704463
 #                     ^^^^ reference [..] Kernel#to_s().
    end
+#    ⌃ enclosing_range_end [..] Dynamo#method_missing().
  
+#  ⌄ enclosing_range_start [..] Dynamo#`respond_to_missing?`().
    def respond_to_missing?(name, include_private = false)
 #      ^^^^^^^^^^^^^^^^^^^ definition [..] Dynamo#`respond_to_missing?`().
      true
    end
+#    ⌃ enclosing_range_end [..] Dynamo#`respond_to_missing?`().
  end
+#  ⌃ enclosing_range_end [..] Dynamo#
  
+#⌄ enclosing_range_start [..] Object#use_meta().
  def use_meta
 #    ^^^^^^^^ definition [..] Object#use_meta().
    Dynamo.new.dynamic(1)
@@ -36,3 +43,4 @@
 #  ^^^^^^ reference [..] Dynamo#
 #         ^^^ reference [..] Class#new().
  end
+#  ⌃ enclosing_range_end [..] Object#use_meta().

--- a/test/scip/testdata/method_inheritance.snapshot.rb
+++ b/test/scip/testdata/method_inheritance.snapshot.rb
@@ -1,22 +1,32 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] C1#
  class C1
 #      ^^ definition [..] C1#
+#  ⌄ enclosing_range_start [..] C1#m1().
    def m1
 #      ^^ definition [..] C1#m1().
    end
+#    ⌃ enclosing_range_end [..] C1#m1().
  
+#  ⌄ enclosing_range_start [..] C1#m2().
    def m2
 #      ^^ definition [..] C1#m2().
    end
+#    ⌃ enclosing_range_end [..] C1#m2().
  end
+#  ⌃ enclosing_range_end [..] C1#
  
+#⌄ enclosing_range_start [..] C2#
  class C2 < C1
 #      ^^ definition [..] C2#
 #           ^^ reference [..] C1#
+#  ⌄ enclosing_range_start [..] C2#m2().
    def m2
 #      ^^ definition [..] C2#m2().
    end
+#    ⌃ enclosing_range_end [..] C2#m2().
+#  ⌄ enclosing_range_start [..] C2#m3().
    def m3
 #      ^^ definition [..] C2#m3().
      m1
@@ -24,14 +34,20 @@
      m2
 #    ^^ reference [..] C2#m2().
    end
+#    ⌃ enclosing_range_end [..] C2#m3().
  end
+#  ⌃ enclosing_range_end [..] C2#
  
+#⌄ enclosing_range_start [..] C3#
  class C3 < C2
 #      ^^ definition [..] C3#
 #           ^^ reference [..] C2#
+#  ⌄ enclosing_range_start [..] C3#m4().
    def m4
 #      ^^ definition [..] C3#m4().
      m1
 #    ^^ reference [..] C1#m1().
    end
+#    ⌃ enclosing_range_end [..] C3#m4().
  end
+#  ⌃ enclosing_range_end [..] C3#

--- a/test/scip/testdata/minitest_1.snapshot.rb
+++ b/test/scip/testdata/minitest_1.snapshot.rb
@@ -1,10 +1,14 @@
  # typed: true
+#⌄ enclosing_range_start [..] MyTest#
  class MyTest
 #      ^^^^^^ definition [..] MyTest#
+#    ⌄ enclosing_range_start [..] MyTest#outside_method().
      def outside_method
 #        ^^^^^^^^^^^^^^ definition [..] MyTest#outside_method().
      end
+#      ⌃ enclosing_range_end [..] MyTest#outside_method().
  
+#    ⌄ enclosing_range_start [..] MyTest#`<it 'works outside'>`().
      it "works outside" do
 #       ^^^^^^^^^^^^^^^ definition [..] MyTest#`<it 'works outside'>`().
          x = outside_method
@@ -15,7 +19,9 @@
 #            ^ reference local 1$1914741329
          return
      end
+#      ⌃ enclosing_range_end [..] MyTest#`<it 'works outside'>`().
  
+#    ⌄ enclosing_range_start [..] MyTest#`<it 'allows constants inside of IT'>`().
      it "allows constants inside of IT" do
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyTest#`<it 'allows constants inside of IT'>`().
        CONST = 10
@@ -24,7 +30,9 @@
 #      ^^^^^^^^^^ reference [..] Kernel#raise().
 #      ^^^^^^^^^^ reference [..] Module#
      end
+#      ⌃ enclosing_range_end [..] MyTest#`<it 'allows constants inside of IT'>`().
  
+#    ⌄ enclosing_range_start [..] MyTest#`<it 'allows let-ed constants inside of IT'>`().
      it "allows let-ed constants inside of IT" do
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyTest#`<it 'allows let-ed constants inside of IT'>`().
        C2 = T.let(10, Integer)
@@ -36,7 +44,9 @@
 #                     ^^^^^^^ definition local 3$119448696
 #                     ^^^^^^^ reference [..] Integer#
      end
+#      ⌃ enclosing_range_end [..] MyTest#`<it 'allows let-ed constants inside of IT'>`().
  
+#    ⌄ enclosing_range_start [..] MyTest#`<it 'allows path constants inside of IT'>`().
      it "allows path constants inside of IT" do
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyTest#`<it 'allows path constants inside of IT'>`().
        C3 = Mod::C
@@ -48,14 +58,19 @@
 #      ^^ reference [..] MyTest#C3.
 #         ^^^ reference [..] Class#new().
      end
+#      ⌃ enclosing_range_end [..] MyTest#`<it 'allows path constants inside of IT'>`().
  
+#    ⌄ enclosing_range_start [..] MyTest#`<describe 'some inner tests'>`#
      describe "some inner tests" do
 #             ^^^^^^^^^^^^^^^^^^ reference [..] MyTest#
 #             ^^^^^^^^^^^^^^^^^^ definition [..] MyTest#`<describe 'some inner tests'>`#
+#        ⌄ enclosing_range_start [..] MyTest#`<describe 'some inner tests'>`#inside_method().
          def inside_method
 #            ^^^^^^^^^^^^^ definition [..] MyTest#`<describe 'some inner tests'>`#inside_method().
          end
+#          ⌃ enclosing_range_end [..] MyTest#`<describe 'some inner tests'>`#inside_method().
  
+#        ⌄ enclosing_range_start [..] MyTest#`<describe 'some inner tests'>`#`<it 'works inside'>`().
          it "works inside" do
 #           ^^^^^^^^^^^^^^ definition [..] MyTest#`<describe 'some inner tests'>`#`<it 'works inside'>`().
              outside_method
@@ -63,11 +78,16 @@
              inside_method
 #            ^^^^^^^^^^^^^ reference [..] MyTest#`<describe 'some inner tests'>`#inside_method().
          end
+#          ⌃ enclosing_range_end [..] MyTest#`<describe 'some inner tests'>`#`<it 'works inside'>`().
      end
+#      ⌃ enclosing_range_end [..] MyTest#`<describe 'some inner tests'>`#
  
+#    ⌄ enclosing_range_start [..] MyTest#instance_helper().
      def instance_helper; end
 #        ^^^^^^^^^^^^^^^ definition [..] MyTest#instance_helper().
+#                           ⌃ enclosing_range_end [..] MyTest#instance_helper().
  
+#    ⌄ enclosing_range_start [..] MyTest#`<before>`().
      before do
 #    ^^^^^^ definition [..] MyTest#`<before>`().
          @foo = T.let(3, Integer)
@@ -77,7 +97,9 @@
          instance_helper
 #        ^^^^^^^^^^^^^^^ reference [..] MyTest#instance_helper().
      end
+#      ⌃ enclosing_range_end [..] MyTest#`<before>`().
  
+#    ⌄ enclosing_range_start [..] MyTest#`<it 'can read foo'>`().
      it 'can read foo' do
 #       ^^^^^^^^^^^^^^ definition [..] MyTest#`<it 'can read foo'>`().
          T.assert_type!(@foo, Integer)
@@ -87,27 +109,38 @@
          instance_helper
 #        ^^^^^^^^^^^^^^^ reference [..] MyTest#instance_helper().
      end
+#      ⌃ enclosing_range_end [..] MyTest#`<it 'can read foo'>`().
  
+#    ⌄ enclosing_range_start [..] `<Class:MyTest>`#random_method().
      def self.random_method
 #             ^^^^^^^^^^^^^ definition [..] `<Class:MyTest>`#random_method().
      end
+#      ⌃ enclosing_range_end [..] `<Class:MyTest>`#random_method().
  
+#    ⌄ enclosing_range_start [..] MyTest#`<describe 'Object'>`#
      describe Object do
 #             ^^^^^^ reference [..] MyTest#
 #             ^^^^^^ definition [..] MyTest#`<describe 'Object'>`#
+#        ⌄ enclosing_range_start [..] MyTest#`<describe 'Object'>`#`<it 'Object'>`().
          it Object do
 #           ^^^^^^ definition [..] MyTest#`<describe 'Object'>`#`<it 'Object'>`().
 #           ^^^^^^ definition [..] MyTest#`<describe 'Object'>`#`<it 'Object'>`().
 #           ^^^^^^ reference [..] Object#
          end
+#          ⌃ enclosing_range_end [..] MyTest#`<describe 'Object'>`#`<it 'Object'>`().
+#        ⌄ enclosing_range_start [..] MyTest#`<describe 'Object'>`#`<it 'Object'>`().
          it Object do
 #           ^^^^^^ reference [..] Object#
          end
+#          ⌃ enclosing_range_end [..] MyTest#`<describe 'Object'>`#`<it 'Object'>`().
      end
+#      ⌃ enclosing_range_end [..] MyTest#`<describe 'Object'>`#
  
+#    ⌄ enclosing_range_start [..] `<Class:MyTest>`#it().
      def self.it(*args)
 #             ^^ definition [..] `<Class:MyTest>`#it().
      end
+#      ⌃ enclosing_range_end [..] `<Class:MyTest>`#it().
      it "ignores methods without a block"
 #    ^^ reference [..] `<Class:MyTest>`#it().
  
@@ -117,27 +150,40 @@
 #        ^^^^ reference [..] Object#junk().
      end
  
+#    ⌄ enclosing_range_start [..] MyTest#`<describe 'a non-ideal situation'>`#
      describe "a non-ideal situation" do
 #             ^^^^^^^^^^^^^^^^^^^^^^^ reference [..] MyTest#
 #             ^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyTest#`<describe 'a non-ideal situation'>`#
+#      ⌄ enclosing_range_start [..] MyTest#`<describe 'a non-ideal situation'>`#`<it 'contains nested describes'>`().
        it "contains nested describes" do
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyTest#`<describe 'a non-ideal situation'>`#`<it 'contains nested describes'>`().
+#        ⌄ enclosing_range_start [..] MyTest#`<describe 'a non-ideal situation'>`#`<describe 'nobody should write this but we should still parse it'>`#
          describe "nobody should write this but we should still parse it" do
 #                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] MyTest#`<describe 'a non-ideal situation'>`#
 #                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyTest#`<describe 'a non-ideal situation'>`#`<describe 'nobody should write this but we should still parse it'>`#
          end
+#          ⌃ enclosing_range_end [..] MyTest#`<describe 'a non-ideal situation'>`#`<describe 'nobody should write this but we should still parse it'>`#
        end
+#        ⌃ enclosing_range_end [..] MyTest#`<describe 'a non-ideal situation'>`#`<it 'contains nested describes'>`().
      end
+#      ⌃ enclosing_range_end [..] MyTest#`<describe 'a non-ideal situation'>`#
  end
+#  ⌃ enclosing_range_end [..] MyTest#
  
+#⌄ enclosing_range_start [..] Object#junk().
  def junk
 #    ^^^^ definition [..] Object#junk().
  end
+#  ⌃ enclosing_range_end [..] Object#junk().
  
  
+#⌄ enclosing_range_start [..] Mod#
  module Mod
 #       ^^^ definition [..] Mod#
+#  ⌄ enclosing_range_start [..] Mod#C#
    class C
 #        ^ definition [..] Mod#C#
    end
+#    ⌃ enclosing_range_end [..] Mod#C#
  end
+#  ⌃ enclosing_range_end [..] Mod#

--- a/test/scip/testdata/minitest_2.snapshot.rb
+++ b/test/scip/testdata/minitest_2.snapshot.rb
@@ -1,17 +1,26 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] Test#
  class Test
 #      ^^^^ definition [..] Test#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
+#  ⌄ enclosing_range_start [..] `<Class:Test>`#test_each().
    def self.test_each(arg, &blk); end
 #           ^^^^^^^^^ definition [..] `<Class:Test>`#test_each().
+#                                   ⌃ enclosing_range_end [..] `<Class:Test>`#test_each().
+#  ⌄ enclosing_range_start [..] `<Class:Test>`#it().
    def self.it(name, &blk); end
 #           ^^ definition [..] `<Class:Test>`#it().
+#                             ⌃ enclosing_range_end [..] `<Class:Test>`#it().
+#  ⌄ enclosing_range_start [..] `<Class:Test>`#describe().
    def self.describe(name, &blk); end
 #           ^^^^^^^^ definition [..] `<Class:Test>`#describe().
+#                                   ⌃ enclosing_range_end [..] `<Class:Test>`#describe().
  end
+#  ⌃ enclosing_range_end [..] Test#
  
+#⌄ enclosing_range_start [..] Foo#
  class Foo < Test
 #      ^^^ definition [..] Foo#
 #            ^^^^ reference [..] Test#
@@ -20,11 +29,16 @@
 #  ^^^^^^^^^ reference [..] `<Class:Test>`#test_each().
                             # ^^ error: Hint: this "do" token
  
+#  ⌄ enclosing_range_start [..] Foo#`<it 'it block 1'>`().
    it "it block 1" do
 #     ^^^^^^^^^^^^ definition [..] Foo#`<it 'it block 1'>`().
    end
+#    ⌃ enclosing_range_end [..] Foo#`<it 'it block 1'>`().
  
+#  ⌄ enclosing_range_start [..] Foo#`<it 'it block 2'>`().
    it "it block 2" do
 #     ^^^^^^^^^^^^ definition [..] Foo#`<it 'it block 2'>`().
    end
+#    ⌃ enclosing_range_end [..] Foo#`<it 'it block 2'>`().
  end # error: unexpected token "end of file"
+#  ⌃ enclosing_range_end [..] Foo#

--- a/test/scip/testdata/minitest_3.snapshot.rb
+++ b/test/scip/testdata/minitest_3.snapshot.rb
@@ -4,17 +4,24 @@
 #       ^ reference [..] T#
 #          ^^^ reference [..] T#Sig#
  
+#⌄ enclosing_range_start [..] Test#
  class Test
 #      ^^^^ definition [..] Test#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
  
+#  ⌄ enclosing_range_start [..] `<Class:Test>`#test_each().
    def self.test_each(iter, &blk); end
 #           ^^^^^^^^^ definition [..] `<Class:Test>`#test_each().
+#                                    ⌃ enclosing_range_end [..] `<Class:Test>`#test_each().
+#  ⌄ enclosing_range_start [..] `<Class:Test>`#it().
    def self.it(name, &blk); end
 #           ^^ definition [..] `<Class:Test>`#it().
+#                             ⌃ enclosing_range_end [..] `<Class:Test>`#it().
+#  ⌄ enclosing_range_start [..] `<Class:Test>`#describe().
    def self.describe(name, &blk); end
 #           ^^^^^^^^ definition [..] `<Class:Test>`#describe().
+#                                   ⌃ enclosing_range_end [..] `<Class:Test>`#describe().
  
    test_each([[1,2], [3,4]]) do |(a,b)|
 #  ^^^^^^^^^ reference [..] `<Class:Test>`#test_each().
@@ -24,6 +31,7 @@
 #                                   ^ definition local 2$416088458
  
      describe "d" do
+#      ⌄ enclosing_range_start [..] Test#`<it 'b'>`().
        it "b" do
 #         ^^^ definition [..] Test#`<it 'b'>`().
          T.reveal_type(a) # error: Revealed type: `Integer`
@@ -31,8 +39,10 @@
 #          ^^^^^^^^^^^ reference [..] `<Class:T>`#reveal_type().
 #                      ^ reference local 1$416088458
        end
+#        ⌃ enclosing_range_end [..] Test#`<it 'b'>`().
      end
  
+#    ⌄ enclosing_range_start [..] Test#`<it 'a'>`().
      it "a" do
 #       ^^^ definition [..] Test#`<it 'a'>`().
        T.reveal_type(a) # error: Revealed type: `Integer`
@@ -40,6 +50,8 @@
 #        ^^^^^^^^^^^ reference [..] `<Class:T>`#reveal_type().
 #                    ^ reference local 1$2288740619
      end
+#      ⌃ enclosing_range_end [..] Test#`<it 'a'>`().
  
    end
  end
+#  ⌃ enclosing_range_end [..] Test#

--- a/test/scip/testdata/mixin.snapshot.rb
+++ b/test/scip/testdata/mixin.snapshot.rb
@@ -1,29 +1,40 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] M#
  module M
 #       ^ definition [..] M#
+#  ⌄ enclosing_range_start [..] M#f().
    def f; puts 'M.f'; end
 #      ^ definition [..] M#f().
+#                       ⌃ enclosing_range_end [..] M#f().
  end
+#  ⌃ enclosing_range_end [..] M#
  
+#⌄ enclosing_range_start [..] C1#
  class C1
 #      ^^ definition [..] C1#
    include M
 #  ^^^^^^^ reference [..] Module#include().
 #          ^ reference [..] M#
 #          ^ reference [..] M#
+#  ⌄ enclosing_range_start [..] C1#f().
    def f; puts 'C1.f'; end
 #      ^ definition [..] C1#f().
 #         ^^^^ reference [..] Kernel#puts().
+#                        ⌃ enclosing_range_end [..] C1#f().
  end
+#  ⌃ enclosing_range_end [..] C1#
  
  # f refers to C1.f
+#⌄ enclosing_range_start [..] C2#
  class C2 < C1
 #      ^^ definition [..] C2#
 #           ^^ reference [..] C1#
  end
+#  ⌃ enclosing_range_end [..] C2#
  
  # f refers to C1.f
+#⌄ enclosing_range_start [..] C3#
  class C3 < C1
 #      ^^ definition [..] C3#
 #           ^^ reference [..] C1#
@@ -32,14 +43,20 @@
 #          ^ reference [..] M#
 #          ^ reference [..] M#
  end
+#  ⌃ enclosing_range_end [..] C3#
  
+#⌄ enclosing_range_start [..] D1#
  class D1
 #      ^^ definition [..] D1#
+#  ⌄ enclosing_range_start [..] D1#f().
    def f; puts 'D1.f'; end
 #      ^ definition [..] D1#f().
 #         ^^^^ reference [..] Kernel#puts().
+#                        ⌃ enclosing_range_end [..] D1#f().
  end
+#  ⌃ enclosing_range_end [..] D1#
  
+#⌄ enclosing_range_start [..] D2#
  class D2
 #      ^^ definition [..] D2#
    include M
@@ -47,6 +64,7 @@
 #          ^ reference [..] M#
 #          ^ reference [..] M#
  end
+#  ⌃ enclosing_range_end [..] D2#
  
  C1.new.f # C1.f
 #^^ reference [..] C1#
@@ -72,45 +90,63 @@
  
  # Definition in directly included module and Self
  
+#⌄ enclosing_range_start [..] T0#
  module T0
 #       ^^ definition [..] T0#
+#  ⌄ enclosing_range_start [..] T0#M#
    module M
 #         ^ definition [..] T0#M#
+#    ⌄ enclosing_range_start [..] T0#M#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T0#M#set_f_0().
 #                 ^^ definition [..] T0#M#`@f`.
 #                 ^^^^^^ reference [..] T0#M#`@f`.
+#                           ⌃ enclosing_range_end [..] T0#M#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T0#M#
  
+#  ⌄ enclosing_range_start [..] T0#C#
    class C
 #        ^ definition [..] T0#C#
      include M
 #    ^^^^^^^ reference [..] Module#include().
 #            ^ reference [..] T0#M#
 #            ^ reference [..] T0#M#
+#    ⌄ enclosing_range_start [..] T0#C#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T0#C#set_f_1().
 #                 ^^ definition [..] T0#C#`@f`.
 #                 relation reference=[..] T0#M#`@f`.
 #                 ^^^^^^ reference [..] T0#C#`@f`.
+#                           ⌃ enclosing_range_end [..] T0#C#set_f_1().
+#    ⌄ enclosing_range_start [..] T0#C#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T0#C#get_f().
 #               ^^ reference [..] T0#C#`@f`.
+#                     ⌃ enclosing_range_end [..] T0#C#get_f().
    end
+#    ⌃ enclosing_range_end [..] T0#C#
  end
+#  ⌃ enclosing_range_end [..] T0#
  
  # Definition in transitively included module and Self
  
+#⌄ enclosing_range_start [..] T1#
  module T1
 #       ^^ definition [..] T1#
+#  ⌄ enclosing_range_start [..] T1#M0#
    module M0
 #         ^^ definition [..] T1#M0#
+#    ⌄ enclosing_range_start [..] T1#M0#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T1#M0#set_f_0().
 #                 ^^ definition [..] T1#M0#`@f`.
 #                 ^^^^^^ reference [..] T1#M0#`@f`.
+#                           ⌃ enclosing_range_end [..] T1#M0#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T1#M0#
  
+#  ⌄ enclosing_range_start [..] T1#M1#
    module M1
 #         ^^ definition [..] T1#M1#
      include M0
@@ -118,60 +154,84 @@
 #            ^^ reference [..] T1#M0#
 #            ^^ reference [..] T1#M0#
    end
+#    ⌃ enclosing_range_end [..] T1#M1#
  
+#  ⌄ enclosing_range_start [..] T1#C#
    class C
 #        ^ definition [..] T1#C#
      include M1
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T1#M1#
 #            ^^ reference [..] T1#M1#
+#    ⌄ enclosing_range_start [..] T1#C#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T1#C#set_f_1().
 #                 ^^ definition [..] T1#C#`@f`.
 #                 relation reference=[..] T1#M0#`@f`.
 #                 ^^^^^^ reference [..] T1#C#`@f`.
+#                           ⌃ enclosing_range_end [..] T1#C#set_f_1().
+#    ⌄ enclosing_range_start [..] T1#C#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T1#C#get_f().
 #               ^^ reference [..] T1#C#`@f`.
+#                     ⌃ enclosing_range_end [..] T1#C#get_f().
    end
+#    ⌃ enclosing_range_end [..] T1#C#
  end
+#  ⌃ enclosing_range_end [..] T1#
  
  # Definition in directly included module only
  
+#⌄ enclosing_range_start [..] T2#
  module T2
 #       ^^ definition [..] T2#
+#  ⌄ enclosing_range_start [..] T2#M#
    module M
 #         ^ definition [..] T2#M#
+#    ⌄ enclosing_range_start [..] T2#M#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T2#M#set_f_0().
 #                 ^^ definition [..] T2#M#`@f`.
 #                 ^^^^^^ reference [..] T2#M#`@f`.
+#                           ⌃ enclosing_range_end [..] T2#M#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T2#M#
  
+#  ⌄ enclosing_range_start [..] T2#C#
    class C
 #        ^ definition [..] T2#C#
      include M
 #    ^^^^^^^ reference [..] Module#include().
 #            ^ reference [..] T2#M#
 #            ^ reference [..] T2#M#
+#    ⌄ enclosing_range_start [..] T2#C#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T2#C#get_f().
 #               ^^ reference [..] T2#C#`@f`.
+#                     ⌃ enclosing_range_end [..] T2#C#get_f().
    end
+#    ⌃ enclosing_range_end [..] T2#C#
  end
+#  ⌃ enclosing_range_end [..] T2#
  
  # Definition in transitively included module only
  
+#⌄ enclosing_range_start [..] T3#
  module T3
 #       ^^ definition [..] T3#
+#  ⌄ enclosing_range_start [..] T3#M0#
    module M0
 #         ^^ definition [..] T3#M0#
+#    ⌄ enclosing_range_start [..] T3#M0#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T3#M0#set_f_0().
 #                 ^^ definition [..] T3#M0#`@f`.
 #                 ^^^^^^ reference [..] T3#M0#`@f`.
+#                           ⌃ enclosing_range_end [..] T3#M0#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T3#M0#
  
+#  ⌄ enclosing_range_start [..] T3#M1#
    module M1
 #         ^^ definition [..] T3#M1#
      include M0
@@ -179,39 +239,55 @@
 #            ^^ reference [..] T3#M0#
 #            ^^ reference [..] T3#M0#
    end
+#    ⌃ enclosing_range_end [..] T3#M1#
  
+#  ⌄ enclosing_range_start [..] T3#C#
    class C
 #        ^ definition [..] T3#C#
      include M1
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T3#M1#
 #            ^^ reference [..] T3#M1#
+#    ⌄ enclosing_range_start [..] T3#C#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T3#C#get_f().
 #               ^^ reference [..] T3#C#`@f`.
+#                     ⌃ enclosing_range_end [..] T3#C#get_f().
    end
+#    ⌃ enclosing_range_end [..] T3#C#
  end
+#  ⌃ enclosing_range_end [..] T3#
  
  # Definition in directly included module & superclass & Self
  
+#⌄ enclosing_range_start [..] T4#
  module T4
 #       ^^ definition [..] T4#
+#  ⌄ enclosing_range_start [..] T4#M#
    module M
 #         ^ definition [..] T4#M#
+#    ⌄ enclosing_range_start [..] T4#M#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T4#M#set_f_0().
 #                 ^^ definition [..] T4#M#`@f`.
 #                 ^^^^^^ reference [..] T4#M#`@f`.
+#                           ⌃ enclosing_range_end [..] T4#M#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T4#M#
  
+#  ⌄ enclosing_range_start [..] T4#C0#
    class C0
 #        ^^ definition [..] T4#C0#
+#    ⌄ enclosing_range_start [..] T4#C0#set_f_2().
      def set_f_2; @f = 2; end
 #        ^^^^^^^ definition [..] T4#C0#set_f_2().
 #                 ^^ definition [..] T4#C0#`@f`.
 #                 ^^^^^^ reference [..] T4#C0#`@f`.
+#                           ⌃ enclosing_range_end [..] T4#C0#set_f_2().
    end
+#    ⌃ enclosing_range_end [..] T4#C0#
  
+#  ⌄ enclosing_range_start [..] T4#C1#
    class C1 < C0
 #        ^^ definition [..] T4#C1#
 #             ^^ reference [..] T4#C0#
@@ -219,31 +295,43 @@
 #    ^^^^^^^ reference [..] Module#include().
 #            ^ reference [..] T4#M#
 #            ^ reference [..] T4#M#
+#    ⌄ enclosing_range_start [..] T4#C1#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T4#C1#set_f_1().
 #                 ^^ definition [..] T4#C1#`@f`.
 #                 relation definition=[..] T4#C0#`@f`. reference=[..] T4#M#`@f`.
 #                 ^^^^^^ reference [..] T4#C1#`@f`.
 #                 relation definition=[..] T4#C0#`@f`. reference=[..] T4#M#`@f`.
+#                           ⌃ enclosing_range_end [..] T4#C1#set_f_1().
+#    ⌄ enclosing_range_start [..] T4#C1#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T4#C1#get_f().
 #               ^^ reference [..] T4#C1#`@f`.
 #               relation definition=[..] T4#C0#`@f`. reference=[..] T4#M#`@f`.
+#                     ⌃ enclosing_range_end [..] T4#C1#get_f().
    end
+#    ⌃ enclosing_range_end [..] T4#C1#
  end
+#  ⌃ enclosing_range_end [..] T4#
  
  # Definition in transitively included module & superclass & Self
  
+#⌄ enclosing_range_start [..] T5#
  module T5
 #       ^^ definition [..] T5#
+#  ⌄ enclosing_range_start [..] T5#M0#
    module M0
 #         ^^ definition [..] T5#M0#
+#    ⌄ enclosing_range_start [..] T5#M0#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T5#M0#set_f_0().
 #                 ^^ definition [..] T5#M0#`@f`.
 #                 ^^^^^^ reference [..] T5#M0#`@f`.
+#                           ⌃ enclosing_range_end [..] T5#M0#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T5#M0#
  
+#  ⌄ enclosing_range_start [..] T5#M1#
    module M1
 #         ^^ definition [..] T5#M1#
      include M0
@@ -251,15 +339,21 @@
 #            ^^ reference [..] T5#M0#
 #            ^^ reference [..] T5#M0#
    end
+#    ⌃ enclosing_range_end [..] T5#M1#
  
+#  ⌄ enclosing_range_start [..] T5#C0#
    class C0
 #        ^^ definition [..] T5#C0#
+#    ⌄ enclosing_range_start [..] T5#C0#set_f_2().
      def set_f_2; @f = 2; end
 #        ^^^^^^^ definition [..] T5#C0#set_f_2().
 #                 ^^ definition [..] T5#C0#`@f`.
 #                 ^^^^^^ reference [..] T5#C0#`@f`.
+#                           ⌃ enclosing_range_end [..] T5#C0#set_f_2().
    end
+#    ⌃ enclosing_range_end [..] T5#C0#
  
+#  ⌄ enclosing_range_start [..] T5#C1#
    class C1 < C0
 #        ^^ definition [..] T5#C1#
 #             ^^ reference [..] T5#C0#
@@ -267,61 +361,87 @@
 #    ^^^^^^^ reference [..] Module#include().
 #            ^ reference [..] M#
 #            ^ reference [..] M#
+#    ⌄ enclosing_range_start [..] T5#C1#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T5#C1#set_f_1().
 #                 ^^ definition [..] T5#C1#`@f`.
 #                 relation definition=[..] T5#C0#`@f`.
 #                 ^^^^^^ reference [..] T5#C1#`@f`.
 #                 relation definition=[..] T5#C0#`@f`.
+#                           ⌃ enclosing_range_end [..] T5#C1#set_f_1().
+#    ⌄ enclosing_range_start [..] T5#C1#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T5#C1#get_f().
 #               ^^ reference [..] T5#C1#`@f`.
 #               relation definition=[..] T5#C0#`@f`.
+#                     ⌃ enclosing_range_end [..] T5#C1#get_f().
    end
+#    ⌃ enclosing_range_end [..] T5#C1#
  end
+#  ⌃ enclosing_range_end [..] T5#
  
  # Definition in directly included module & superclass only
  
+#⌄ enclosing_range_start [..] T6#
  module T6
 #       ^^ definition [..] T6#
+#  ⌄ enclosing_range_start [..] T6#M#
    module M
 #         ^ definition [..] T6#M#
+#    ⌄ enclosing_range_start [..] T6#M#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T6#M#set_f_0().
 #                 ^^ definition [..] T6#M#`@f`.
 #                 ^^^^^^ reference [..] T6#M#`@f`.
+#                           ⌃ enclosing_range_end [..] T6#M#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T6#M#
  
+#  ⌄ enclosing_range_start [..] T6#C0#
    class C0
 #        ^^ definition [..] T6#C0#
+#    ⌄ enclosing_range_start [..] T6#C0#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T6#C0#set_f_1().
 #                 ^^ definition [..] T6#C0#`@f`.
 #                 ^^^^^^ reference [..] T6#C0#`@f`.
+#                           ⌃ enclosing_range_end [..] T6#C0#set_f_1().
    end
+#    ⌃ enclosing_range_end [..] T6#C0#
  
+#  ⌄ enclosing_range_start [..] T6#C1#
    class C1 < C0
 #        ^^ definition [..] T6#C1#
 #             ^^ reference [..] T6#C0#
+#    ⌄ enclosing_range_start [..] T6#C1#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T6#C1#get_f().
 #               ^^ reference [..] T6#C1#`@f`.
 #               relation definition=[..] T6#C0#`@f`.
+#                     ⌃ enclosing_range_end [..] T6#C1#get_f().
    end
+#    ⌃ enclosing_range_end [..] T6#C1#
  end
+#  ⌃ enclosing_range_end [..] T6#
  
  # Definition in transitively included module & superclass only
  
+#⌄ enclosing_range_start [..] T7#
  module T7
 #       ^^ definition [..] T7#
+#  ⌄ enclosing_range_start [..] T7#M0#
    module M0
 #         ^^ definition [..] T7#M0#
+#    ⌄ enclosing_range_start [..] T7#M0#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T7#M0#set_f_0().
 #                 ^^ definition [..] T7#M0#`@f`.
 #                 ^^^^^^ reference [..] T7#M0#`@f`.
+#                           ⌃ enclosing_range_end [..] T7#M0#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T7#M0#
  
+#  ⌄ enclosing_range_start [..] T7#M1#
    module M1
 #         ^^ definition [..] T7#M1#
      include M0
@@ -329,113 +449,159 @@
 #            ^^ reference [..] T7#M0#
 #            ^^ reference [..] T7#M0#
    end
+#    ⌃ enclosing_range_end [..] T7#M1#
  
+#  ⌄ enclosing_range_start [..] T7#C0#
    class C0
 #        ^^ definition [..] T7#C0#
+#    ⌄ enclosing_range_start [..] T7#C0#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T7#C0#set_f_1().
 #                 ^^ definition [..] T7#C0#`@f`.
 #                 ^^^^^^ reference [..] T7#C0#`@f`.
+#                           ⌃ enclosing_range_end [..] T7#C0#set_f_1().
    end
+#    ⌃ enclosing_range_end [..] T7#C0#
  
+#  ⌄ enclosing_range_start [..] T7#C1#
    class C1 < C0
 #        ^^ definition [..] T7#C1#
 #             ^^ reference [..] T7#C0#
+#    ⌄ enclosing_range_start [..] T7#C1#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T7#C1#get_f().
 #               ^^ reference [..] T7#C1#`@f`.
 #               relation definition=[..] T7#C0#`@f`.
+#                     ⌃ enclosing_range_end [..] T7#C1#get_f().
    end
+#    ⌃ enclosing_range_end [..] T7#C1#
  end
+#  ⌃ enclosing_range_end [..] T7#
  
  # Definition in module included via superclass & superclass & Self
  
+#⌄ enclosing_range_start [..] T8#
  module T8
 #       ^^ definition [..] T8#
+#  ⌄ enclosing_range_start [..] T8#M#
    module M
 #         ^ definition [..] T8#M#
+#    ⌄ enclosing_range_start [..] T8#M#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T8#M#set_f_0().
 #                 ^^ definition [..] T8#M#`@f`.
 #                 ^^^^^^ reference [..] T8#M#`@f`.
+#                           ⌃ enclosing_range_end [..] T8#M#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T8#M#
  
+#  ⌄ enclosing_range_start [..] T8#C0#
    class C0
 #        ^^ definition [..] T8#C0#
      include M
 #    ^^^^^^^ reference [..] Module#include().
 #            ^ reference [..] T8#M#
 #            ^ reference [..] T8#M#
+#    ⌄ enclosing_range_start [..] T8#C0#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T8#C0#set_f_1().
 #                 ^^ definition [..] T8#C0#`@f`.
 #                 relation reference=[..] T8#M#`@f`.
 #                 ^^^^^^ reference [..] T8#C0#`@f`.
+#                           ⌃ enclosing_range_end [..] T8#C0#set_f_1().
    end
+#    ⌃ enclosing_range_end [..] T8#C0#
  
+#  ⌄ enclosing_range_start [..] T8#C1#
    class C1 < C0
 #        ^^ definition [..] T8#C1#
 #             ^^ reference [..] T8#C0#
+#    ⌄ enclosing_range_start [..] T8#C1#set_f_2().
      def set_f_2; @f = 2; end
 #        ^^^^^^^ definition [..] T8#C1#set_f_2().
 #                 ^^ definition [..] T8#C1#`@f`.
 #                 relation definition=[..] T8#C0#`@f`.
 #                 ^^^^^^ reference [..] T8#C1#`@f`.
 #                 relation definition=[..] T8#C0#`@f`.
+#                           ⌃ enclosing_range_end [..] T8#C1#set_f_2().
+#    ⌄ enclosing_range_start [..] T8#C1#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T8#C1#get_f().
 #               ^^ reference [..] T8#C1#`@f`.
 #               relation definition=[..] T8#C0#`@f`.
+#                     ⌃ enclosing_range_end [..] T8#C1#get_f().
    end
+#    ⌃ enclosing_range_end [..] T8#C1#
  end
+#  ⌃ enclosing_range_end [..] T8#
  
  # Definition in module included via superclass & superclass only
  
+#⌄ enclosing_range_start [..] T9#
  module T9
 #       ^^ definition [..] T9#
+#  ⌄ enclosing_range_start [..] T9#M#
    module M
 #         ^ definition [..] T9#M#
+#    ⌄ enclosing_range_start [..] T9#M#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T9#M#set_f_0().
 #                 ^^ definition [..] T9#M#`@f`.
 #                 ^^^^^^ reference [..] T9#M#`@f`.
+#                           ⌃ enclosing_range_end [..] T9#M#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T9#M#
  
+#  ⌄ enclosing_range_start [..] T9#C0#
    class C0
 #        ^^ definition [..] T9#C0#
      include M
 #    ^^^^^^^ reference [..] Module#include().
 #            ^ reference [..] T9#M#
 #            ^ reference [..] T9#M#
+#    ⌄ enclosing_range_start [..] T9#C0#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T9#C0#set_f_1().
 #                 ^^ definition [..] T9#C0#`@f`.
 #                 relation reference=[..] T9#M#`@f`.
 #                 ^^^^^^ reference [..] T9#C0#`@f`.
+#                           ⌃ enclosing_range_end [..] T9#C0#set_f_1().
    end
+#    ⌃ enclosing_range_end [..] T9#C0#
  
+#  ⌄ enclosing_range_start [..] T9#C1#
    class C1 < C0
 #        ^^ definition [..] T9#C1#
 #             ^^ reference [..] T9#C0#
+#    ⌄ enclosing_range_start [..] T9#C1#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T9#C1#get_f().
 #               ^^ reference [..] T9#C1#`@f`.
 #               relation definition=[..] T9#C0#`@f`.
+#                     ⌃ enclosing_range_end [..] T9#C1#get_f().
    end
+#    ⌃ enclosing_range_end [..] T9#C1#
  end
+#  ⌃ enclosing_range_end [..] T9#
  
  # Definition in module included via superclass & Self
  
+#⌄ enclosing_range_start [..] T10#
  module T10
 #       ^^^ definition [..] T10#
+#  ⌄ enclosing_range_start [..] T10#M#
    module M
 #         ^ definition [..] T10#M#
+#    ⌄ enclosing_range_start [..] T10#M#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T10#M#set_f_0().
 #                 ^^ definition [..] T10#M#`@f`.
 #                 ^^^^^^ reference [..] T10#M#`@f`.
+#                           ⌃ enclosing_range_end [..] T10#M#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T10#M#
  
+#  ⌄ enclosing_range_start [..] T10#C0#
    class C0
 #        ^^ definition [..] T10#C0#
      include M
@@ -443,32 +609,46 @@
 #            ^ reference [..] T10#M#
 #            ^ reference [..] T10#M#
    end
+#    ⌃ enclosing_range_end [..] T10#C0#
  
+#  ⌄ enclosing_range_start [..] T10#C1#
    class C1 < C0
 #        ^^ definition [..] T10#C1#
 #             ^^ reference [..] T10#C0#
+#    ⌄ enclosing_range_start [..] T10#C1#set_f_2().
      def set_f_2; @f = 2; end
 #        ^^^^^^^ definition [..] T10#C1#set_f_2().
 #                 ^^ definition [..] T10#C1#`@f`.
 #                 ^^^^^^ reference [..] T10#C1#`@f`.
+#                           ⌃ enclosing_range_end [..] T10#C1#set_f_2().
+#    ⌄ enclosing_range_start [..] T10#C1#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T10#C1#get_f().
 #               ^^ reference [..] T10#C1#`@f`.
+#                     ⌃ enclosing_range_end [..] T10#C1#get_f().
    end
+#    ⌃ enclosing_range_end [..] T10#C1#
  end
+#  ⌃ enclosing_range_end [..] T10#
  
  # Definition in module included via superclass only
  
+#⌄ enclosing_range_start [..] T11#
  module T11
 #       ^^^ definition [..] T11#
+#  ⌄ enclosing_range_start [..] T11#M#
    module M
 #         ^ definition [..] T11#M#
+#    ⌄ enclosing_range_start [..] T11#M#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T11#M#set_f_0().
 #                 ^^ definition [..] T11#M#`@f`.
 #                 ^^^^^^ reference [..] T11#M#`@f`.
+#                           ⌃ enclosing_range_end [..] T11#M#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T11#M#
  
+#  ⌄ enclosing_range_start [..] T11#C0#
    class C0
 #        ^^ definition [..] T11#C0#
      include M
@@ -476,36 +656,52 @@
 #            ^ reference [..] T11#M#
 #            ^ reference [..] T11#M#
    end
+#    ⌃ enclosing_range_end [..] T11#C0#
  
+#  ⌄ enclosing_range_start [..] T11#C1#
    class C1 < C0
 #        ^^ definition [..] T11#C1#
 #             ^^ reference [..] T11#C0#
+#    ⌄ enclosing_range_start [..] T11#C1#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T11#C1#get_f().
 #               ^^ reference [..] T11#C1#`@f`.
+#                     ⌃ enclosing_range_end [..] T11#C1#get_f().
    end
+#    ⌃ enclosing_range_end [..] T11#C1#
  end
+#  ⌃ enclosing_range_end [..] T11#
  
  # Definition in multiple transitively included modules & common child & Self
  
+#⌄ enclosing_range_start [..] T12#
  module T12
 #       ^^^ definition [..] T12#
+#  ⌄ enclosing_range_start [..] T12#M0#
    module M0
 #         ^^ definition [..] T12#M0#
+#    ⌄ enclosing_range_start [..] T12#M0#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T12#M0#set_f_0().
 #                 ^^ definition [..] T12#M0#`@f`.
 #                 ^^^^^^ reference [..] T12#M0#`@f`.
+#                           ⌃ enclosing_range_end [..] T12#M0#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T12#M0#
  
+#  ⌄ enclosing_range_start [..] T12#M1#
    module M1
 #         ^^ definition [..] T12#M1#
+#    ⌄ enclosing_range_start [..] T12#M1#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T12#M1#set_f_1().
 #                 ^^ definition [..] T12#M1#`@f`.
 #                 ^^^^^^ reference [..] T12#M1#`@f`.
+#                           ⌃ enclosing_range_end [..] T12#M1#set_f_1().
    end
+#    ⌃ enclosing_range_end [..] T12#M1#
  
+#  ⌄ enclosing_range_start [..] T12#M2#
    module M2
 #         ^^ definition [..] T12#M2#
      include M0
@@ -516,50 +712,70 @@
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T12#M1#
 #            ^^ reference [..] T12#M1#
+#    ⌄ enclosing_range_start [..] T12#M2#set_f_2().
      def set_f_2; @f = 2; end
 #        ^^^^^^^ definition [..] T12#M2#set_f_2().
 #                 ^^ definition [..] T12#M2#`@f`.
 #                 relation reference=[..] T12#M0#`@f`. reference=[..] T12#M1#`@f`.
 #                 ^^^^^^ reference [..] T12#M2#`@f`.
+#                           ⌃ enclosing_range_end [..] T12#M2#set_f_2().
    end
+#    ⌃ enclosing_range_end [..] T12#M2#
  
+#  ⌄ enclosing_range_start [..] T12#C#
    class C
 #        ^ definition [..] T12#C#
      include M2
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T12#M2#
 #            ^^ reference [..] T12#M2#
+#    ⌄ enclosing_range_start [..] T12#C#set_f_3().
      def set_f_3; @f = 3; end
 #        ^^^^^^^ definition [..] T12#C#set_f_3().
 #                 ^^ definition [..] T12#C#`@f`.
 #                 relation reference=[..] T12#M0#`@f`. reference=[..] T12#M1#`@f`. reference=[..] T12#M2#`@f`.
 #                 ^^^^^^ reference [..] T12#C#`@f`.
+#                           ⌃ enclosing_range_end [..] T12#C#set_f_3().
+#    ⌄ enclosing_range_start [..] T12#C#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T12#C#get_f().
 #               ^^ reference [..] T12#C#`@f`.
+#                     ⌃ enclosing_range_end [..] T12#C#get_f().
    end
+#    ⌃ enclosing_range_end [..] T12#C#
  end
+#  ⌃ enclosing_range_end [..] T12#
  
  # Definition in multiple transitively included modules & common child only
  
+#⌄ enclosing_range_start [..] T13#
  module T13
 #       ^^^ definition [..] T13#
+#  ⌄ enclosing_range_start [..] T13#M0#
    module M0
 #         ^^ definition [..] T13#M0#
+#    ⌄ enclosing_range_start [..] T13#M0#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T13#M0#set_f_0().
 #                 ^^ definition [..] T13#M0#`@f`.
 #                 ^^^^^^ reference [..] T13#M0#`@f`.
+#                           ⌃ enclosing_range_end [..] T13#M0#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T13#M0#
  
+#  ⌄ enclosing_range_start [..] T13#M1#
    module M1
 #         ^^ definition [..] T13#M1#
+#    ⌄ enclosing_range_start [..] T13#M1#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T13#M1#set_f_1().
 #                 ^^ definition [..] T13#M1#`@f`.
 #                 ^^^^^^ reference [..] T13#M1#`@f`.
+#                           ⌃ enclosing_range_end [..] T13#M1#set_f_1().
    end
+#    ⌃ enclosing_range_end [..] T13#M1#
  
+#  ⌄ enclosing_range_start [..] T13#M2#
    module M2
 #         ^^ definition [..] T13#M2#
      include M0
@@ -570,45 +786,63 @@
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T13#M1#
 #            ^^ reference [..] T13#M1#
+#    ⌄ enclosing_range_start [..] T13#M2#set_f_2().
      def set_f_2; @f = 2; end
 #        ^^^^^^^ definition [..] T13#M2#set_f_2().
 #                 ^^ definition [..] T13#M2#`@f`.
 #                 relation reference=[..] T13#M0#`@f`. reference=[..] T13#M1#`@f`.
 #                 ^^^^^^ reference [..] T13#M2#`@f`.
+#                           ⌃ enclosing_range_end [..] T13#M2#set_f_2().
    end
+#    ⌃ enclosing_range_end [..] T13#M2#
  
+#  ⌄ enclosing_range_start [..] T13#C#
    class C
 #        ^ definition [..] T13#C#
      include M2
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T13#M2#
 #            ^^ reference [..] T13#M2#
+#    ⌄ enclosing_range_start [..] T13#C#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T13#C#get_f().
 #               ^^ reference [..] T13#C#`@f`.
+#                     ⌃ enclosing_range_end [..] T13#C#get_f().
    end
+#    ⌃ enclosing_range_end [..] T13#C#
  end
+#  ⌃ enclosing_range_end [..] T13#
  
  # Definition in multiple transitively included modules & Self
  
+#⌄ enclosing_range_start [..] T14#
  module T14
 #       ^^^ definition [..] T14#
+#  ⌄ enclosing_range_start [..] T14#M0#
    module M0
 #         ^^ definition [..] T14#M0#
+#    ⌄ enclosing_range_start [..] T14#M0#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T14#M0#set_f_0().
 #                 ^^ definition [..] T14#M0#`@f`.
 #                 ^^^^^^ reference [..] T14#M0#`@f`.
+#                           ⌃ enclosing_range_end [..] T14#M0#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T14#M0#
  
+#  ⌄ enclosing_range_start [..] T14#M1#
    module M1
 #         ^^ definition [..] T14#M1#
+#    ⌄ enclosing_range_start [..] T14#M1#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T14#M1#set_f_1().
 #                 ^^ definition [..] T14#M1#`@f`.
 #                 ^^^^^^ reference [..] T14#M1#`@f`.
+#                           ⌃ enclosing_range_end [..] T14#M1#set_f_1().
    end
+#    ⌃ enclosing_range_end [..] T14#M1#
  
+#  ⌄ enclosing_range_start [..] T14#M2#
    module M2
 #         ^^ definition [..] T14#M2#
      include M0
@@ -620,44 +854,62 @@
 #            ^^ reference [..] T14#M1#
 #            ^^ reference [..] T14#M1#
    end
+#    ⌃ enclosing_range_end [..] T14#M2#
  
+#  ⌄ enclosing_range_start [..] T14#C#
    class C
 #        ^ definition [..] T14#C#
      include M2
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T14#M2#
 #            ^^ reference [..] T14#M2#
+#    ⌄ enclosing_range_start [..] T14#C#set_f_3().
      def set_f_3; @f = 3; end
 #        ^^^^^^^ definition [..] T14#C#set_f_3().
 #                 ^^ definition [..] T14#C#`@f`.
 #                 relation reference=[..] T14#M0#`@f`. reference=[..] T14#M1#`@f`.
 #                 ^^^^^^ reference [..] T14#C#`@f`.
+#                           ⌃ enclosing_range_end [..] T14#C#set_f_3().
+#    ⌄ enclosing_range_start [..] T14#C#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T14#C#get_f().
 #               ^^ reference [..] T14#C#`@f`.
+#                     ⌃ enclosing_range_end [..] T14#C#get_f().
    end
+#    ⌃ enclosing_range_end [..] T14#C#
  end
+#  ⌃ enclosing_range_end [..] T14#
  
  # Definition in multiple transitively included modules only
  
+#⌄ enclosing_range_start [..] T15#
  module T15
 #       ^^^ definition [..] T15#
+#  ⌄ enclosing_range_start [..] T15#M0#
    module M0
 #         ^^ definition [..] T15#M0#
+#    ⌄ enclosing_range_start [..] T15#M0#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T15#M0#set_f_0().
 #                 ^^ definition [..] T15#M0#`@f`.
 #                 ^^^^^^ reference [..] T15#M0#`@f`.
+#                           ⌃ enclosing_range_end [..] T15#M0#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T15#M0#
  
+#  ⌄ enclosing_range_start [..] T15#M1#
    module M1
 #         ^^ definition [..] T15#M1#
+#    ⌄ enclosing_range_start [..] T15#M1#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T15#M1#set_f_1().
 #                 ^^ definition [..] T15#M1#`@f`.
 #                 ^^^^^^ reference [..] T15#M1#`@f`.
+#                           ⌃ enclosing_range_end [..] T15#M1#set_f_1().
    end
+#    ⌃ enclosing_range_end [..] T15#M1#
  
+#  ⌄ enclosing_range_start [..] T15#M2#
    module M2
 #         ^^ definition [..] T15#M2#
      include M0
@@ -669,39 +921,55 @@
 #            ^^ reference [..] T15#M1#
 #            ^^ reference [..] T15#M1#
    end
+#    ⌃ enclosing_range_end [..] T15#M2#
  
+#  ⌄ enclosing_range_start [..] T15#C#
    class C
 #        ^ definition [..] T15#C#
      include M2
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T15#M2#
 #            ^^ reference [..] T15#M2#
+#    ⌄ enclosing_range_start [..] T15#C#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T15#C#get_f().
 #               ^^ reference [..] T15#C#`@f`.
+#                     ⌃ enclosing_range_end [..] T15#C#get_f().
    end
+#    ⌃ enclosing_range_end [..] T15#C#
  end
+#  ⌃ enclosing_range_end [..] T15#
  
  # Definition in multiple directly included modules & Self
  
+#⌄ enclosing_range_start [..] T16#
  module T16
 #       ^^^ definition [..] T16#
+#  ⌄ enclosing_range_start [..] T16#M0#
    module M0
 #         ^^ definition [..] T16#M0#
+#    ⌄ enclosing_range_start [..] T16#M0#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T16#M0#set_f_0().
 #                 ^^ definition [..] T16#M0#`@f`.
 #                 ^^^^^^ reference [..] T16#M0#`@f`.
+#                           ⌃ enclosing_range_end [..] T16#M0#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T16#M0#
  
+#  ⌄ enclosing_range_start [..] T16#M1#
    module M1
 #         ^^ definition [..] T16#M1#
+#    ⌄ enclosing_range_start [..] T16#M1#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T16#M1#set_f_1().
 #                 ^^ definition [..] T16#M1#`@f`.
 #                 ^^^^^^ reference [..] T16#M1#`@f`.
+#                           ⌃ enclosing_range_end [..] T16#M1#set_f_1().
    end
+#    ⌃ enclosing_range_end [..] T16#M1#
  
+#  ⌄ enclosing_range_start [..] T16#C#
    class C
 #        ^ definition [..] T16#C#
      include M0
@@ -712,37 +980,53 @@
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T16#M1#
 #            ^^ reference [..] T16#M1#
+#    ⌄ enclosing_range_start [..] T16#C#set_f_2().
      def set_f_2; @f = 2; end
 #        ^^^^^^^ definition [..] T16#C#set_f_2().
 #                 ^^ definition [..] T16#C#`@f`.
 #                 relation reference=[..] T16#M0#`@f`. reference=[..] T16#M1#`@f`.
 #                 ^^^^^^ reference [..] T16#C#`@f`.
+#                           ⌃ enclosing_range_end [..] T16#C#set_f_2().
+#    ⌄ enclosing_range_start [..] T16#C#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T16#C#get_f().
 #               ^^ reference [..] T16#C#`@f`.
+#                     ⌃ enclosing_range_end [..] T16#C#get_f().
    end
+#    ⌃ enclosing_range_end [..] T16#C#
  end
+#  ⌃ enclosing_range_end [..] T16#
  
  # Definition in multiple directly included modules only
  
+#⌄ enclosing_range_start [..] T17#
  module T17
 #       ^^^ definition [..] T17#
+#  ⌄ enclosing_range_start [..] T17#M0#
    module M0
 #         ^^ definition [..] T17#M0#
+#    ⌄ enclosing_range_start [..] T17#M0#set_f_0().
      def set_f_0; @f = 0; end
 #        ^^^^^^^ definition [..] T17#M0#set_f_0().
 #                 ^^ definition [..] T17#M0#`@f`.
 #                 ^^^^^^ reference [..] T17#M0#`@f`.
+#                           ⌃ enclosing_range_end [..] T17#M0#set_f_0().
    end
+#    ⌃ enclosing_range_end [..] T17#M0#
  
+#  ⌄ enclosing_range_start [..] T17#M1#
    module M1
 #         ^^ definition [..] T17#M1#
+#    ⌄ enclosing_range_start [..] T17#M1#set_f_1().
      def set_f_1; @f = 1; end
 #        ^^^^^^^ definition [..] T17#M1#set_f_1().
 #                 ^^ definition [..] T17#M1#`@f`.
 #                 ^^^^^^ reference [..] T17#M1#`@f`.
+#                           ⌃ enclosing_range_end [..] T17#M1#set_f_1().
    end
+#    ⌃ enclosing_range_end [..] T17#M1#
  
+#  ⌄ enclosing_range_start [..] T17#C#
    class C
 #        ^ definition [..] T17#C#
      include M0
@@ -753,11 +1037,15 @@
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] T17#M1#
 #            ^^ reference [..] T17#M1#
+#    ⌄ enclosing_range_start [..] T17#C#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] T17#C#get_f().
 #               ^^ reference [..] T17#C#`@f`.
+#                     ⌃ enclosing_range_end [..] T17#C#get_f().
    end
+#    ⌃ enclosing_range_end [..] T17#C#
  end
+#  ⌃ enclosing_range_end [..] T17#
  
  # OKAY! Now for the more "weird" situations
  # Before this, all the tests had a definition come "before" use.
@@ -765,40 +1053,56 @@
  
  # Reference in directly included module with def in Self
  
+#⌄ enclosing_range_start [..] W0#
  module W0
 #       ^^ definition [..] W0#
+#  ⌄ enclosing_range_start [..] W0#M#
    module M
 #         ^ definition [..] W0#M#
+#    ⌄ enclosing_range_start [..] W0#M#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] W0#M#get_f().
 #               ^^ reference [..] W0#M#`@f`.
+#                     ⌃ enclosing_range_end [..] W0#M#get_f().
    end
+#    ⌃ enclosing_range_end [..] W0#M#
  
+#  ⌄ enclosing_range_start [..] W0#C#
    class C
 #        ^ definition [..] W0#C#
      include M
 #    ^^^^^^^ reference [..] Module#include().
 #            ^ reference [..] W0#M#
 #            ^ reference [..] W0#M#
+#    ⌄ enclosing_range_start [..] W0#C#set_f().
      def set_f; @f = 0; end
 #        ^^^^^ definition [..] W0#C#set_f().
 #               ^^ definition [..] W0#C#`@f`.
 #               relation reference=[..] W0#M#`@f`.
 #               ^^^^^^ reference [..] W0#C#`@f`.
+#                         ⌃ enclosing_range_end [..] W0#C#set_f().
    end
+#    ⌃ enclosing_range_end [..] W0#C#
  end
+#  ⌃ enclosing_range_end [..] W0#
  
  # Reference in transitively included module with def in Self
  
+#⌄ enclosing_range_start [..] W1#
  module W1
 #       ^^ definition [..] W1#
+#  ⌄ enclosing_range_start [..] W1#M0#
    module M0
 #         ^^ definition [..] W1#M0#
+#    ⌄ enclosing_range_start [..] W1#M0#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] W1#M0#get_f().
 #               ^^ reference [..] W1#M0#`@f`.
+#                     ⌃ enclosing_range_end [..] W1#M0#get_f().
    end
+#    ⌃ enclosing_range_end [..] W1#M0#
    
+#  ⌄ enclosing_range_start [..] W1#M1#
    module M1
 #         ^^ definition [..] W1#M1#
      include M0
@@ -806,40 +1110,56 @@
 #            ^^ reference [..] W1#M0#
 #            ^^ reference [..] W1#M0#
    end
+#    ⌃ enclosing_range_end [..] W1#M1#
  
+#  ⌄ enclosing_range_start [..] W1#C#
    class C
 #        ^ definition [..] W1#C#
      include M1
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] W1#M1#
 #            ^^ reference [..] W1#M1#
+#    ⌄ enclosing_range_start [..] W1#C#set_f().
      def set_f; @f = 0; end
 #        ^^^^^ definition [..] W1#C#set_f().
 #               ^^ definition [..] W1#C#`@f`.
 #               relation reference=[..] W1#M0#`@f`.
 #               ^^^^^^ reference [..] W1#C#`@f`.
+#                         ⌃ enclosing_range_end [..] W1#C#set_f().
    end
+#    ⌃ enclosing_range_end [..] W1#C#
  end
+#  ⌃ enclosing_range_end [..] W1#
  
  # Reference in superclass with def in directly included module
  
+#⌄ enclosing_range_start [..] W2#
  module W2
 #       ^^ definition [..] W2#
+#  ⌄ enclosing_range_start [..] W2#M#
    module M
 #         ^ definition [..] W2#M#
+#    ⌄ enclosing_range_start [..] W2#M#set_f().
      def set_f; @f = 0; end
 #        ^^^^^ definition [..] W2#M#set_f().
 #               ^^ definition [..] W2#M#`@f`.
 #               ^^^^^^ reference [..] W2#M#`@f`.
+#                         ⌃ enclosing_range_end [..] W2#M#set_f().
    end
+#    ⌃ enclosing_range_end [..] W2#M#
  
+#  ⌄ enclosing_range_start [..] W2#C0#
    class C0
 #        ^^ definition [..] W2#C0#
+#    ⌄ enclosing_range_start [..] W2#C0#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] W2#C0#get_f().
 #               ^^ reference [..] W2#C0#`@f`.
+#                     ⌃ enclosing_range_end [..] W2#C0#get_f().
    end
+#    ⌃ enclosing_range_end [..] W2#C0#
  
+#  ⌄ enclosing_range_start [..] W2#C1#
    class C1 < C0
 #        ^^ definition [..] W2#C1#
 #             ^^ reference [..] W2#C0#
@@ -847,32 +1167,46 @@
 #    ^^^^^^^ reference [..] Module#include().
 #            ^ reference [..] W2#M#
 #            ^ reference [..] W2#M#
+#    ⌄ enclosing_range_start [..] W2#C1#get_fp1().
      def get_fp1; @f + 1; end
 #        ^^^^^^^ definition [..] W2#C1#get_fp1().
 #                 ^^ reference [..] W2#C1#`@f`.
 #                 relation definition=[..] W2#C0#`@f`. reference=[..] W2#M#`@f`.
+#                           ⌃ enclosing_range_end [..] W2#C1#get_fp1().
    end
+#    ⌃ enclosing_range_end [..] W2#C1#
  end
+#  ⌃ enclosing_range_end [..] W2#
  
  # Reference in directly included module with def in superclass
  
+#⌄ enclosing_range_start [..] W3#
  module W3
 #       ^^ definition [..] W3#
+#  ⌄ enclosing_range_start [..] W3#M#
    module M
 #         ^ definition [..] W3#M#
+#    ⌄ enclosing_range_start [..] W3#M#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] W3#M#get_f().
 #               ^^ reference [..] W3#M#`@f`.
+#                     ⌃ enclosing_range_end [..] W3#M#get_f().
    end
+#    ⌃ enclosing_range_end [..] W3#M#
  
+#  ⌄ enclosing_range_start [..] W3#C0#
    class C0
 #        ^^ definition [..] W3#C0#
+#    ⌄ enclosing_range_start [..] W3#C0#set_f().
      def set_f; @f = 0; end
 #        ^^^^^ definition [..] W3#C0#set_f().
 #               ^^ definition [..] W3#C0#`@f`.
 #               ^^^^^^ reference [..] W3#C0#`@f`.
+#                         ⌃ enclosing_range_end [..] W3#C0#set_f().
    end
+#    ⌃ enclosing_range_end [..] W3#C0#
  
+#  ⌄ enclosing_range_start [..] W3#C1#
    class C1 < C0
 #        ^^ definition [..] W3#C1#
 #             ^^ reference [..] W3#C0#
@@ -880,67 +1214,95 @@
 #    ^^^^^^^ reference [..] Module#include().
 #            ^ reference [..] W3#M#
 #            ^ reference [..] W3#M#
+#    ⌄ enclosing_range_start [..] W3#C1#get_fp1().
      def get_fp1; @f + 1; end
 #        ^^^^^^^ definition [..] W3#C1#get_fp1().
 #                 ^^ reference [..] W3#C1#`@f`.
 #                 relation definition=[..] W3#C0#`@f`. reference=[..] W3#M#`@f`.
+#                           ⌃ enclosing_range_end [..] W3#C1#get_fp1().
    end
+#    ⌃ enclosing_range_end [..] W3#C1#
  end
+#  ⌃ enclosing_range_end [..] W3#
  
  # Reference in transitively included module with def in in-between module
  
+#⌄ enclosing_range_start [..] W4#
  module W4
 #       ^^ definition [..] W4#
+#  ⌄ enclosing_range_start [..] W4#M0#
    module M0
 #         ^^ definition [..] W4#M0#
+#    ⌄ enclosing_range_start [..] W4#M0#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] W4#M0#get_f().
 #               ^^ reference [..] W4#M0#`@f`.
+#                     ⌃ enclosing_range_end [..] W4#M0#get_f().
    end
+#    ⌃ enclosing_range_end [..] W4#M0#
  
+#  ⌄ enclosing_range_start [..] W4#M1#
    module M1
 #         ^^ definition [..] W4#M1#
      include M0
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] W4#M0#
 #            ^^ reference [..] W4#M0#
+#    ⌄ enclosing_range_start [..] W4#M1#set_f().
      def set_f; @f = 0; end
 #        ^^^^^ definition [..] W4#M1#set_f().
 #               ^^ definition [..] W4#M1#`@f`.
 #               relation reference=[..] W4#M0#`@f`.
 #               ^^^^^^ reference [..] W4#M1#`@f`.
+#                         ⌃ enclosing_range_end [..] W4#M1#set_f().
    end
+#    ⌃ enclosing_range_end [..] W4#M1#
  
+#  ⌄ enclosing_range_start [..] W4#C#
    class C
 #        ^ definition [..] W4#C#
      include M1
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] W4#M1#
 #            ^^ reference [..] W4#M1#
+#    ⌄ enclosing_range_start [..] W4#C#get_fp1().
      def get_fp1; @f + 1; end
 #        ^^^^^^^ definition [..] W4#C#get_fp1().
 #                 ^^ reference [..] W4#C#`@f`.
+#                           ⌃ enclosing_range_end [..] W4#C#get_fp1().
    end
+#    ⌃ enclosing_range_end [..] W4#C#
  end
+#  ⌃ enclosing_range_end [..] W4#
  
  # Reference in one directly included module with def in other directly included module
  
+#⌄ enclosing_range_start [..] W5#
  module W5
 #       ^^ definition [..] W5#
+#  ⌄ enclosing_range_start [..] W5#M0#
    module M0
 #         ^^ definition [..] W5#M0#
+#    ⌄ enclosing_range_start [..] W5#M0#get_f().
      def get_f; @f; end
 #        ^^^^^ definition [..] W5#M0#get_f().
 #               ^^ reference [..] W5#M0#`@f`.
+#                     ⌃ enclosing_range_end [..] W5#M0#get_f().
    end
+#    ⌃ enclosing_range_end [..] W5#M0#
  
+#  ⌄ enclosing_range_start [..] W5#M1#
    module M1
 #         ^^ definition [..] W5#M1#
+#    ⌄ enclosing_range_start [..] W5#M1#set_f().
      def set_f; @f + 1; end
 #        ^^^^^ definition [..] W5#M1#set_f().
 #               ^^ reference [..] W5#M1#`@f`.
+#                         ⌃ enclosing_range_end [..] W5#M1#set_f().
    end
+#    ⌃ enclosing_range_end [..] W5#M1#
  
+#  ⌄ enclosing_range_start [..] W5#C#
    class C
 #        ^ definition [..] W5#C#
      include M0
@@ -951,8 +1313,12 @@
 #    ^^^^^^^ reference [..] Module#include().
 #            ^^ reference [..] W5#M1#
 #            ^^ reference [..] W5#M1#
+#    ⌄ enclosing_range_start [..] W5#C#get_fp1().
      def get_fp1; @f + 1; end
 #        ^^^^^^^ definition [..] W5#C#get_fp1().
 #                 ^^ reference [..] W5#C#`@f`.
+#                           ⌃ enclosing_range_end [..] W5#C#get_fp1().
    end
+#    ⌃ enclosing_range_end [..] W5#C#
  end
+#  ⌃ enclosing_range_end [..] W5#

--- a/test/scip/testdata/module_function.snapshot.rb
+++ b/test/scip/testdata/module_function.snapshot.rb
@@ -1,14 +1,20 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] M#
  module M
 #       ^ definition [..] M#
    sig { returns(T::Boolean) }
 #                   ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] M#b().
    def b
 #      ^ definition [..] M#b().
      true
    end
+#    ⌃ enclosing_range_end [..] M#b().
  
+#  ⌄ enclosing_range_start [..] `<Class:M>`#b().
    module_function :b
 #                  ^^ definition [..] `<Class:M>`#b().
+#                   ⌃ enclosing_range_end [..] `<Class:M>`#b().
  end
+#  ⌃ enclosing_range_end [..] M#

--- a/test/scip/testdata/multifile/basic/def_class1.snapshot.rb
+++ b/test/scip/testdata/multifile/basic/def_class1.snapshot.rb
@@ -1,5 +1,6 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] C1#
  class C1
 #      ^^ definition [..] C1#
    extend T::Sig
@@ -7,8 +8,11 @@
  
    sig { returns(T::Boolean) }
 #                   ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] C1#m1().
    def m1
 #      ^^ definition [..] C1#m1().
      true
    end
+#    ⌃ enclosing_range_end [..] C1#m1().
  end
+#  ⌃ enclosing_range_end [..] C1#

--- a/test/scip/testdata/multifile/gem-map/current.snapshot.rb
+++ b/test/scip/testdata/multifile/gem-map/current.snapshot.rb
@@ -7,6 +7,7 @@
  
  # File missing from gem map; check fallback behavior
  
+#⌄ enclosing_range_start my_current_gem 2 Object#h().
  def h()
 #    ^ definition my_current_gem 2 Object#h().
    f()
@@ -14,3 +15,4 @@
    g()
 #  ^ reference my_upstream_gem 1 Object#g().
  end
+#  ⌃ enclosing_range_end my_current_gem 2 Object#h().

--- a/test/scip/testdata/multifile/gem-map/downstream.snapshot.rb
+++ b/test/scip/testdata/multifile/gem-map/downstream.snapshot.rb
@@ -3,8 +3,10 @@
  require 'upstream'
 #^^^^^^^ reference [..] Kernel#require().
  
+#⌄ enclosing_range_start my_downstream_gem 1 Object#f().
  def f()
 #    ^ definition my_downstream_gem 1 Object#f().
    g()
 #  ^ reference my_upstream_gem 1 Object#g().
  end
+#  ⌃ enclosing_range_end my_downstream_gem 1 Object#f().

--- a/test/scip/testdata/multifile/gem-map/upstream.snapshot.rb
+++ b/test/scip/testdata/multifile/gem-map/upstream.snapshot.rb
@@ -1,7 +1,9 @@
  # typed: true
  
+#⌄ enclosing_range_start my_upstream_gem 1 Object#g().
  def g()
 #    ^ definition my_upstream_gem 1 Object#g().
    puts 'Hello'
 #  ^^^^ reference [..] Kernel#puts().
  end
+#  ⌃ enclosing_range_end my_upstream_gem 1 Object#g().

--- a/test/scip/testdata/multifile/infer-gem-map/current_gem.snapshot.rb
+++ b/test/scip/testdata/multifile/infer-gem-map/current_gem.snapshot.rb
@@ -1,9 +1,13 @@
  # typed: true
  
+#⌄ enclosing_range_start currentgem 77 CurrentGem#
  module CurrentGem
 #       ^^^^^^^^^^ definition currentgem 77 CurrentGem#
+#  ⌄ enclosing_range_start currentgem 77 CurrentGem#gem_fun().
    def gem_fun
 #      ^^^^^^^ definition currentgem 77 CurrentGem#gem_fun().
      puts 'Hello World'
    end
+#    ⌃ enclosing_range_end currentgem 77 CurrentGem#gem_fun().
  end
+#  ⌃ enclosing_range_end currentgem 77 CurrentGem#

--- a/test/scip/testdata/multifile/infer-gem-map/current_gem.snapshot.rbi
+++ b/test/scip/testdata/multifile/infer-gem-map/current_gem.snapshot.rbi
@@ -1,7 +1,11 @@
  # typed: true
  
+#⌄ enclosing_range_start currentgem 77 CurrentGem#
  module CurrentGem
 #       ^^^^^^^^^^ definition currentgem 77 CurrentGem#
+#  ⌄ enclosing_range_start currentgem 77 CurrentGem#gem_fun().
    def gem_fun; end
 #      ^^^^^^^ definition currentgem 77 CurrentGem#gem_fun().
+#                 ⌃ enclosing_range_end currentgem 77 CurrentGem#gem_fun().
  end
+#  ⌃ enclosing_range_end currentgem 77 CurrentGem#

--- a/test/scip/testdata/multifile/infer-gem-map/sorbet/rbi/annotations/annotgem.snapshot.rbi
+++ b/test/scip/testdata/multifile/infer-gem-map/sorbet/rbi/annotations/annotgem.snapshot.rbi
@@ -1,7 +1,11 @@
  # typed: true
  
+#⌄ enclosing_range_start annotgem latest AnnotGem#
  module AnnotGem
 #       ^^^^^^^^ definition annotgem latest AnnotGem#
+#  ⌄ enclosing_range_start annotgem latest AnnotGem#annot_fun().
    def annot_fun; end
 #      ^^^^^^^^^ definition annotgem latest AnnotGem#annot_fun().
+#                   ⌃ enclosing_range_end annotgem latest AnnotGem#annot_fun().
  end
+#  ⌃ enclosing_range_end annotgem latest AnnotGem#

--- a/test/scip/testdata/multifile/infer-gem-map/sorbet/rbi/dsl/railsgem.snapshot.rbi
+++ b/test/scip/testdata/multifile/infer-gem-map/sorbet/rbi/dsl/railsgem.snapshot.rbi
@@ -1,7 +1,11 @@
  # typed: true
  
+#⌄ enclosing_range_start railsgem latest DSLGem#
  module DSLGem
 #       ^^^^^^ definition railsgem latest DSLGem#
+#  ⌄ enclosing_range_start railsgem latest DSLGem#create().
    def create; end
 #      ^^^^^^ definition railsgem latest DSLGem#create().
+#                ⌃ enclosing_range_end railsgem latest DSLGem#create().
  end
+#  ⌃ enclosing_range_end railsgem latest DSLGem#

--- a/test/scip/testdata/multifile/infer-gem-map/sorbet/rbi/gems/extgem@99.snapshot.rbi
+++ b/test/scip/testdata/multifile/infer-gem-map/sorbet/rbi/gems/extgem@99.snapshot.rbi
@@ -1,7 +1,11 @@
  # typed: true
  
+#⌄ enclosing_range_start extgem 99 ExternalGem#
  module ExternalGem
 #       ^^^^^^^^^^^ definition extgem 99 ExternalGem#
+#  ⌄ enclosing_range_start extgem 99 ExternalGem#ext_fun().
    def ext_fun; end
 #      ^^^^^^^ definition extgem 99 ExternalGem#ext_fun().
+#                 ⌃ enclosing_range_end extgem 99 ExternalGem#ext_fun().
  end
+#  ⌃ enclosing_range_end extgem 99 ExternalGem#

--- a/test/scip/testdata/multifile/infer-gem-map/sorbet/rbi/hidden-definitions/hidden.snapshot.rbi
+++ b/test/scip/testdata/multifile/infer-gem-map/sorbet/rbi/hidden-definitions/hidden.snapshot.rbi
@@ -1,7 +1,11 @@
  # typed: true
  
+#⌄ enclosing_range_start currentgem 77 Hidden#
  module Hidden
 #       ^^^^^^ definition currentgem 77 Hidden#
+#  ⌄ enclosing_range_start currentgem 77 Hidden#hidden_fun().
    def hidden_fun; end
 #      ^^^^^^^^^^ definition currentgem 77 Hidden#hidden_fun().
+#                    ⌃ enclosing_range_end currentgem 77 Hidden#hidden_fun().
  end
+#  ⌃ enclosing_range_end currentgem 77 Hidden#

--- a/test/scip/testdata/multifile/infer-gem-map/sorbet/rbi/todo.snapshot.rbi
+++ b/test/scip/testdata/multifile/infer-gem-map/sorbet/rbi/todo.snapshot.rbi
@@ -1,8 +1,10 @@
  # typed: true
  
+#⌄ enclosing_range_start currentgem 77 TODO#
  module TODO
 #       ^^^^ definition currentgem 77 TODO#
    TODO_CONSTANT = 1
 #  ^^^^^^^^^^^^^ definition currentgem 77 TODO#TODO_CONSTANT.
 #  ^^^^^^^^^^^^^^^^^ reference currentgem 77 TODO#TODO_CONSTANT.
  end
+#  ⌃ enclosing_range_end currentgem 77 TODO#

--- a/test/scip/testdata/multifile/typed-false-mix/def_untyped.snapshot.rb
+++ b/test/scip/testdata/multifile/typed-false-mix/def_untyped.snapshot.rb
@@ -1,5 +1,7 @@
  # typed: false
  
+#⌄ enclosing_range_start [..] C#
  class C
 #      ^ definition [..] C#
  end
+#  ⌃ enclosing_range_end [..] C#

--- a/test/scip/testdata/multifile/typed-false-mix/use_untyped.snapshot.rb
+++ b/test/scip/testdata/multifile/typed-false-mix/use_untyped.snapshot.rb
@@ -3,10 +3,14 @@
  require 'def_untyped'
 #^^^^^^^ reference [..] Kernel#require().
  
+#⌄ enclosing_range_start [..] N#
  module N
 #       ^ definition [..] N#
+#  ⌄ enclosing_range_start [..] N#D#
    class D < C
 #        ^ definition [..] N#D#
 #            ^ reference [..] C#
    end
+#    ⌃ enclosing_range_end [..] N#D#
  end
+#  ⌃ enclosing_range_end [..] N#

--- a/test/scip/testdata/nested_constants.snapshot.rb
+++ b/test/scip/testdata/nested_constants.snapshot.rb
@@ -3,30 +3,45 @@
  # 3+-level constant qualifier walks in class names, ancestors, and references.
  # Exercises the recursion in saveQualifierReferences.
  
+#⌄ enclosing_range_start [..] Outer#
  module Outer
 #       ^^^^^ definition [..] Outer#
+#  ⌄ enclosing_range_start [..] Outer#Inner#
    module Inner
 #         ^^^^^ definition [..] Outer#Inner#
+#    ⌄ enclosing_range_start [..] Outer#Inner#Deep#
      module Deep
 #           ^^^^ definition [..] Outer#Inner#Deep#
+#      ⌄ enclosing_range_start [..] Outer#Inner#Deep#Base#
        class Base
 #            ^^^^ definition [..] Outer#Inner#Deep#Base#
+#        ⌄ enclosing_range_start [..] Outer#Inner#Deep#Base#m().
          def m; end
 #            ^ definition [..] Outer#Inner#Deep#Base#m().
+#                 ⌃ enclosing_range_end [..] Outer#Inner#Deep#Base#m().
        end
+#        ⌃ enclosing_range_end [..] Outer#Inner#Deep#Base#
  
+#      ⌄ enclosing_range_start [..] Outer#Inner#Deep#Mixin#
        module Mixin
 #             ^^^^^ definition [..] Outer#Inner#Deep#Mixin#
+#        ⌄ enclosing_range_start [..] Outer#Inner#Deep#Mixin#helper().
          def helper
 #            ^^^^^^ definition [..] Outer#Inner#Deep#Mixin#helper().
            "h"
          end
+#          ⌃ enclosing_range_end [..] Outer#Inner#Deep#Mixin#helper().
        end
+#        ⌃ enclosing_range_end [..] Outer#Inner#Deep#Mixin#
      end
+#      ⌃ enclosing_range_end [..] Outer#Inner#Deep#
    end
+#    ⌃ enclosing_range_end [..] Outer#Inner#
  end
+#  ⌃ enclosing_range_end [..] Outer#
  
  # 4-level qualifier in class header and in superclass position.
+#⌄ enclosing_range_start [..] Outer#Inner#Deep#Derived#
  class Outer::Inner::Deep::Derived < Outer::Inner::Deep::Base
 #      ^^^^^ reference [..] Outer#
 #             ^^^^^ reference [..] Outer#Inner#
@@ -37,8 +52,10 @@
 #                                                  ^^^^ reference [..] Outer#Inner#Deep#
 #                                                        ^^^^ reference [..] Outer#Inner#Deep#Base#
  end
+#  ⌃ enclosing_range_end [..] Outer#Inner#Deep#Derived#
  
  # Qualified include in an ancestor expression.
+#⌄ enclosing_range_start [..] WithDeepMixin#
  class WithDeepMixin
 #      ^^^^^^^^^^^^^ definition [..] WithDeepMixin#
    include Outer::Inner::Deep::Mixin
@@ -51,7 +68,9 @@
 #                              ^^^^^ reference [..] Outer#Inner#Deep#Mixin#
 #                              ^^^^^ reference [..] Outer#Inner#Deep#Mixin#
  end
+#  ⌃ enclosing_range_end [..] WithDeepMixin#
  
+#⌄ enclosing_range_start [..] Object#use_nested().
  def use_nested
 #    ^^^^^^^^^^ definition [..] Object#use_nested().
    _ = Outer::Inner::Deep::Base.new
@@ -68,3 +87,4 @@
 #                        ^^^^^^ reference [..] Outer#Inner#Deep#Mixin#helper().
    return
  end
+#  ⌃ enclosing_range_end [..] Object#use_nested().

--- a/test/scip/testdata/non_existent.snapshot.rb
+++ b/test/scip/testdata/non_existent.snapshot.rb
@@ -1,10 +1,14 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] D#
  class D
 #      ^ definition [..] D#
  end
+#  ⌃ enclosing_range_end [..] D#
  
+#⌄ enclosing_range_start [..] C#
  class C < ::D
 #      ^ definition [..] C#
 #            ^ reference [..] D#
  end
+#  ⌃ enclosing_range_end [..] C#

--- a/test/scip/testdata/opus.snapshot.rb
+++ b/test/scip/testdata/opus.snapshot.rb
@@ -1,16 +1,20 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] Opus#Base#
  class Opus::Base
 #      ^^^^ reference [..] Opus#
 #            ^^^^ definition [..] Opus#Base#
  end
+#  ⌃ enclosing_range_end [..] Opus#Base#
  
+#⌄ enclosing_range_start [..] Opus#Derived#
  class Opus::Derived < Opus::Base
 #      ^^^^ reference [..] Opus#
 #            ^^^^^^^ definition [..] Opus#Derived#
 #                      ^^^^ reference [..] Opus#
 #                            ^^^^ reference [..] Opus#Base#
  end
+#  ⌃ enclosing_range_end [..] Opus#Derived#
  
  TYPES = T.let({ derived: -> { Opus::Derived } }, T::Hash[Symbol, T.proc.returns(T.class_of(Opus::Base))])
 #^^^^^ definition [..] TYPES.
@@ -30,6 +34,7 @@
 #                                                                                                 ^^^^^^^ definition local 4$119448696
 #                                                                                                 ^^^^^^^^ reference [..] TYPES.
  
+#⌄ enclosing_range_start [..] ABC#
  module ABC
 #       ^^^ definition [..] ABC#
    TYPES_IN_MODULE = T.let({ derived: -> { Opus::Derived } }, T::Hash[Symbol, T.proc.returns(T.class_of(Opus::Base))])
@@ -44,7 +49,9 @@
 #                                                                                                             ^^^^^^^ definition local 4$119448696
 #                                                                                                             ^^^^^^^^ reference [..] ABC#TYPES_IN_MODULE.
  end
+#  ⌃ enclosing_range_end [..] ABC#
  
+#⌄ enclosing_range_start [..] Other#
  class Other
 #      ^^^^^ definition [..] Other#
    TYPES_IN_CLASS = T.let({ derived: -> { Opus::Derived } }, T::Hash[Symbol, T.proc.returns(T.class_of(Opus::Base))])
@@ -59,3 +66,4 @@
 #                                                                                                            ^^^^^^^ definition local 4$119448696
 #                                                                                                            ^^^^^^^^ reference [..] Other#TYPES_IN_CLASS.
  end
+#  ⌃ enclosing_range_end [..] Other#

--- a/test/scip/testdata/prepend_extend.snapshot.rb
+++ b/test/scip/testdata/prepend_extend.snapshot.rb
@@ -5,44 +5,61 @@
  # field-inheritance / mixin-transitive code paths get a chance to surface
  # `is_reference` relationships for prepend/extend.
  
+#⌄ enclosing_range_start [..] Greeter#
  module Greeter
 #       ^^^^^^^ definition [..] Greeter#
+#  ⌄ enclosing_range_start [..] Greeter#hello().
    def hello
 #      ^^^^^ definition [..] Greeter#hello().
      "hi"
    end
+#    ⌃ enclosing_range_end [..] Greeter#hello().
  
+#  ⌄ enclosing_range_start [..] Greeter#set_via_greeter().
    def set_via_greeter
 #      ^^^^^^^^^^^^^^^ definition [..] Greeter#set_via_greeter().
      @field = "g"
 #    ^^^^^^ definition [..] Greeter#`@field`.
 #    ^^^^^^^^^^^^ reference [..] Greeter#`@field`.
    end
+#    ⌃ enclosing_range_end [..] Greeter#set_via_greeter().
  end
+#  ⌃ enclosing_range_end [..] Greeter#
  
+#⌄ enclosing_range_start [..] PrependedMod#
  module PrependedMod
 #       ^^^^^^^^^^^^ definition [..] PrependedMod#
+#  ⌄ enclosing_range_start [..] PrependedMod#hello().
    def hello
 #      ^^^^^ definition [..] PrependedMod#hello().
      "prepended " + super
    end
+#    ⌃ enclosing_range_end [..] PrependedMod#hello().
  
+#  ⌄ enclosing_range_start [..] PrependedMod#set_via_prepend().
    def set_via_prepend
 #      ^^^^^^^^^^^^^^^ definition [..] PrependedMod#set_via_prepend().
      @field = "p"
 #    ^^^^^^ definition [..] PrependedMod#`@field`.
 #    ^^^^^^^^^^^^ reference [..] PrependedMod#`@field`.
    end
+#    ⌃ enclosing_range_end [..] PrependedMod#set_via_prepend().
  end
+#  ⌃ enclosing_range_end [..] PrependedMod#
  
+#⌄ enclosing_range_start [..] ClassyMethods#
  module ClassyMethods
 #       ^^^^^^^^^^^^^ definition [..] ClassyMethods#
+#  ⌄ enclosing_range_start [..] ClassyMethods#klass_hi().
    def klass_hi
 #      ^^^^^^^^ definition [..] ClassyMethods#klass_hi().
      "class hi"
    end
+#    ⌃ enclosing_range_end [..] ClassyMethods#klass_hi().
  end
+#  ⌃ enclosing_range_end [..] ClassyMethods#
  
+#⌄ enclosing_range_start [..] CombinedMix#
  class CombinedMix
 #      ^^^^^^^^^^^ definition [..] CombinedMix#
    include Greeter
@@ -56,13 +73,17 @@
 #  ^^^^^^ reference [..] Kernel#extend().
 #         ^^^^^^^^^^^^^ reference [..] ClassyMethods#
  
+#  ⌄ enclosing_range_start [..] CombinedMix#read_field().
    def read_field
 #      ^^^^^^^^^^ definition [..] CombinedMix#read_field().
      @field
 #    ^^^^^^ reference [..] CombinedMix#`@field`.
    end
+#    ⌃ enclosing_range_end [..] CombinedMix#read_field().
  end
+#  ⌃ enclosing_range_end [..] CombinedMix#
  
+#⌄ enclosing_range_start [..] Object#use_combined().
  def use_combined
 #    ^^^^^^^^^^^^ definition [..] Object#use_combined().
    c = CombinedMix.new
@@ -88,3 +109,4 @@
 #                  ^^^^^^^^ reference [..] ClassyMethods#klass_hi().
    return
  end
+#  ⌃ enclosing_range_end [..] Object#use_combined().

--- a/test/scip/testdata/prop.snapshot.rb
+++ b/test/scip/testdata/prop.snapshot.rb
@@ -1,5 +1,6 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] SomeODM#
  class SomeODM
 #      ^^^^^^^ definition [..] SomeODM#
      extend T::Sig
@@ -9,13 +10,18 @@
 #            ^ reference [..] T#
 #               ^^^^^ reference [..] T#Props#
  
+#    ⌄ enclosing_range_start [..] SomeODM#`foo=`().
+#    ⌄ enclosing_range_start [..] SomeODM#foo().
      prop :foo, String
 #          ^^^ definition [..] SomeODM#`foo=`().
 #          ^^^ definition [..] SomeODM#foo().
 #               ^^^^^^ reference [..] String#
+#                    ⌃ enclosing_range_end [..] SomeODM#`foo=`().
+#                    ⌃ enclosing_range_end [..] SomeODM#foo().
  
      sig {returns(T.nilable(String))}
 #                           ^^^^^^ reference [..] String#
+#    ⌄ enclosing_range_start [..] SomeODM#foo2().
      def foo2; T.cast(T.unsafe(nil), T.nilable(String)); end
 #        ^^^^ definition [..] SomeODM#foo2().
 #                     ^ reference [..] T#
@@ -24,60 +30,99 @@
 #                                    ^^^^^^^^^^^^^^^^^ definition local 1$1867563647
 #                                      ^^^^^^^ reference [..] `<Class:T>`#nilable().
 #                                              ^^^^^^ reference [..] String#
+#                                                          ⌃ enclosing_range_end [..] SomeODM#foo2().
      sig {params(arg0: String).returns(String)}
 #                      ^^^^^^ reference [..] String#
 #                                      ^^^^^^ reference [..] String#
+#    ⌄ enclosing_range_start [..] SomeODM#`foo2=`().
      def foo2=(arg0); T.cast(nil, String); end
 #        ^^^^^ definition [..] SomeODM#`foo2=`().
 #                                 ^^^^^^ definition local 1$2116144614
 #                                 ^^^^^^ reference [..] String#
+#                                            ⌃ enclosing_range_end [..] SomeODM#`foo2=`().
  end
+#  ⌃ enclosing_range_end [..] SomeODM#
  
+#⌄ enclosing_range_start [..] ForeignClass#
  class ForeignClass
 #      ^^^^^^^^^^^^ definition [..] ForeignClass#
  end
+#  ⌃ enclosing_range_end [..] ForeignClass#
  
+#⌄ enclosing_range_start [..] AdvancedODM#
  class AdvancedODM
 #      ^^^^^^^^^^^ definition [..] AdvancedODM#
      include T::Props
 #    ^^^^^^^ reference [..] Module#include().
 #            ^ reference [..] T#
 #               ^^^^^ reference [..] T#Props#
+#    ⌄ enclosing_range_start [..] AdvancedODM#`default=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#default().
      prop :default, String, default: ""
 #          ^^^^^^^ definition [..] AdvancedODM#`default=`().
 #          ^^^^^^^ definition [..] AdvancedODM#default().
 #                   ^^^^^^ reference [..] String#
+#                                     ⌃ enclosing_range_end [..] AdvancedODM#`default=`().
+#                                     ⌃ enclosing_range_end [..] AdvancedODM#default().
+#    ⌄ enclosing_range_start [..] AdvancedODM#`t_nilable=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#t_nilable().
      prop :t_nilable, T.nilable(String)
 #          ^^^^^^^^^ definition [..] AdvancedODM#`t_nilable=`().
 #          ^^^^^^^^^ definition [..] AdvancedODM#t_nilable().
 #                               ^^^^^^ reference [..] String#
+#                                     ⌃ enclosing_range_end [..] AdvancedODM#`t_nilable=`().
+#                                     ⌃ enclosing_range_end [..] AdvancedODM#t_nilable().
  
+#    ⌄ enclosing_range_start [..] AdvancedODM#`array=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#array().
      prop :array, Array
 #          ^^^^^ definition [..] AdvancedODM#`array=`().
 #          ^^^^^ definition [..] AdvancedODM#array().
 #                 ^^^^^ reference [..] Array#
+#                     ⌃ enclosing_range_end [..] AdvancedODM#`array=`().
+#                     ⌃ enclosing_range_end [..] AdvancedODM#array().
+#    ⌄ enclosing_range_start [..] AdvancedODM#`t_array=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#t_array().
      prop :t_array, T::Array[String]
 #          ^^^^^^^ definition [..] AdvancedODM#`t_array=`().
 #          ^^^^^^^ definition [..] AdvancedODM#t_array().
 #                            ^^^^^^ reference [..] String#
+#                                  ⌃ enclosing_range_end [..] AdvancedODM#`t_array=`().
+#                                  ⌃ enclosing_range_end [..] AdvancedODM#t_array().
+#    ⌄ enclosing_range_start [..] AdvancedODM#`hash_of=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#hash_of().
      prop :hash_of, T::Hash[Symbol, String]
 #          ^^^^^^^ definition [..] AdvancedODM#`hash_of=`().
 #          ^^^^^^^ definition [..] AdvancedODM#hash_of().
 #                           ^^^^^^ reference [..] Symbol#
 #                                   ^^^^^^ reference [..] String#
+#                                         ⌃ enclosing_range_end [..] AdvancedODM#`hash_of=`().
+#                                         ⌃ enclosing_range_end [..] AdvancedODM#hash_of().
  
+#    ⌄ enclosing_range_start [..] AdvancedODM#const_explicit().
      prop :const_explicit, String, immutable: true
 #          ^^^^^^^^^^^^^^ definition [..] AdvancedODM#const_explicit().
 #                          ^^^^^^ reference [..] String#
+#                                                ⌃ enclosing_range_end [..] AdvancedODM#const_explicit().
+#    ⌄ enclosing_range_start [..] AdvancedODM#const().
      const :const, String
 #           ^^^^^ definition [..] AdvancedODM#const().
 #                  ^^^^^^ reference [..] String#
+#                       ⌃ enclosing_range_end [..] AdvancedODM#const().
  
+#    ⌄ enclosing_range_start [..] AdvancedODM#`enum_prop=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#enum_prop().
      prop :enum_prop, String, enum: ["hello", "goodbye"]
 #          ^^^^^^^^^ definition [..] AdvancedODM#`enum_prop=`().
 #          ^^^^^^^^^ definition [..] AdvancedODM#enum_prop().
 #                     ^^^^^^ reference [..] String#
+#                                                      ⌃ enclosing_range_end [..] AdvancedODM#`enum_prop=`().
+#                                                      ⌃ enclosing_range_end [..] AdvancedODM#enum_prop().
  
+#    ⌄ enclosing_range_start [..] AdvancedODM#`foreign_lazy=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#`foreign_lazy_!`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#foreign_lazy().
+#    ⌄ enclosing_range_start [..] AdvancedODM#foreign_lazy_().
      prop :foreign_lazy, String, foreign: -> {ForeignClass}
 #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Boolean.
 #          ^^^^^^^^^^^^ definition [..] AdvancedODM#`foreign_lazy=`().
@@ -88,6 +133,14 @@
 #                                         ^^ reference [..] Kernel#
 #                                         ^^ reference [..] Kernel#lambda().
 #                                             ^^^^^^^^^^^^ reference [..] ForeignClass#
+#                                                         ⌃ enclosing_range_end [..] AdvancedODM#`foreign_lazy=`().
+#                                                         ⌃ enclosing_range_end [..] AdvancedODM#`foreign_lazy_!`().
+#                                                         ⌃ enclosing_range_end [..] AdvancedODM#foreign_lazy().
+#                                                         ⌃ enclosing_range_end [..] AdvancedODM#foreign_lazy_().
+#    ⌄ enclosing_range_start [..] AdvancedODM#`foreign_proc=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#`foreign_proc_!`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#foreign_proc().
+#    ⌄ enclosing_range_start [..] AdvancedODM#foreign_proc_().
      prop :foreign_proc, String, foreign: proc {ForeignClass}
 #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Boolean.
 #          ^^^^^^^^^^^^ definition [..] AdvancedODM#`foreign_proc=`().
@@ -97,6 +150,14 @@
 #                        ^^^^^^ reference [..] String#
 #                                         ^^^^ reference [..] Kernel#proc().
 #                                               ^^^^^^^^^^^^ reference [..] ForeignClass#
+#                                                           ⌃ enclosing_range_end [..] AdvancedODM#`foreign_proc=`().
+#                                                           ⌃ enclosing_range_end [..] AdvancedODM#`foreign_proc_!`().
+#                                                           ⌃ enclosing_range_end [..] AdvancedODM#foreign_proc().
+#                                                           ⌃ enclosing_range_end [..] AdvancedODM#foreign_proc_().
+#    ⌄ enclosing_range_start [..] AdvancedODM#`foreign_invalid=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#`foreign_invalid_!`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#foreign_invalid().
+#    ⌄ enclosing_range_start [..] AdvancedODM#foreign_invalid_().
      prop :foreign_invalid, String, foreign: proc { :not_a_type }
 #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] T#Boolean.
 #          ^^^^^^^^^^^^^^^ definition [..] AdvancedODM#`foreign_invalid=`().
@@ -105,69 +166,117 @@
 #          ^^^^^^^^^^^^^^^ definition [..] AdvancedODM#foreign_invalid_().
 #                           ^^^^^^ reference [..] String#
 #                                            ^^^^ reference [..] Kernel#proc().
+#                                                               ⌃ enclosing_range_end [..] AdvancedODM#`foreign_invalid=`().
+#                                                               ⌃ enclosing_range_end [..] AdvancedODM#`foreign_invalid_!`().
+#                                                               ⌃ enclosing_range_end [..] AdvancedODM#foreign_invalid().
+#                                                               ⌃ enclosing_range_end [..] AdvancedODM#foreign_invalid_().
  
+#    ⌄ enclosing_range_start [..] AdvancedODM#`ifunset=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#ifunset().
      prop :ifunset, String, ifunset: ''
 #          ^^^^^^^ definition [..] AdvancedODM#`ifunset=`().
 #          ^^^^^^^ definition [..] AdvancedODM#ifunset().
 #                   ^^^^^^ reference [..] String#
+#                                     ⌃ enclosing_range_end [..] AdvancedODM#`ifunset=`().
+#                                     ⌃ enclosing_range_end [..] AdvancedODM#ifunset().
+#    ⌄ enclosing_range_start [..] AdvancedODM#`ifunset_nilable=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#ifunset_nilable().
      prop :ifunset_nilable, T.nilable(String), ifunset: ''
 #          ^^^^^^^^^^^^^^^ definition [..] AdvancedODM#`ifunset_nilable=`().
 #          ^^^^^^^^^^^^^^^ definition [..] AdvancedODM#ifunset_nilable().
 #                                     ^^^^^^ reference [..] String#
+#                                                        ⌃ enclosing_range_end [..] AdvancedODM#`ifunset_nilable=`().
+#                                                        ⌃ enclosing_range_end [..] AdvancedODM#ifunset_nilable().
  
+#    ⌄ enclosing_range_start [..] AdvancedODM#`empty_hash_rules=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#empty_hash_rules().
      prop :empty_hash_rules, String, {}
 #          ^^^^^^^^^^^^^^^^ definition [..] AdvancedODM#`empty_hash_rules=`().
 #          ^^^^^^^^^^^^^^^^ definition [..] AdvancedODM#empty_hash_rules().
 #                            ^^^^^^ reference [..] String#
+#                                     ⌃ enclosing_range_end [..] AdvancedODM#`empty_hash_rules=`().
+#                                     ⌃ enclosing_range_end [..] AdvancedODM#empty_hash_rules().
+#    ⌄ enclosing_range_start [..] AdvancedODM#`hash_rules=`().
+#    ⌄ enclosing_range_start [..] AdvancedODM#hash_rules().
      prop :hash_rules, String, { enum: ["hello", "goodbye" ] }
 #          ^^^^^^^^^^ definition [..] AdvancedODM#`hash_rules=`().
 #          ^^^^^^^^^^ definition [..] AdvancedODM#hash_rules().
 #                      ^^^^^^ reference [..] String#
+#                                                            ⌃ enclosing_range_end [..] AdvancedODM#`hash_rules=`().
+#                                                            ⌃ enclosing_range_end [..] AdvancedODM#hash_rules().
  end
+#  ⌃ enclosing_range_end [..] AdvancedODM#
  
+#⌄ enclosing_range_start [..] PropHelpers#
  class PropHelpers
 #      ^^^^^^^^^^^ definition [..] PropHelpers#
    include T::Props
 #  ^^^^^^^ reference [..] Module#include().
 #          ^ reference [..] T#
 #             ^^^^^ reference [..] T#Props#
+#  ⌄ enclosing_range_start [..] `<Class:PropHelpers>`#token_prop().
    def self.token_prop(opts={}); end
 #           ^^^^^^^^^^ definition [..] `<Class:PropHelpers>`#token_prop().
+#                                  ⌃ enclosing_range_end [..] `<Class:PropHelpers>`#token_prop().
+#  ⌄ enclosing_range_start [..] `<Class:PropHelpers>`#created_prop().
    def self.created_prop(opts={}); end
 #           ^^^^^^^^^^^^ definition [..] `<Class:PropHelpers>`#created_prop().
+#                                    ⌃ enclosing_range_end [..] `<Class:PropHelpers>`#created_prop().
+#  ⌄ enclosing_range_start [..] PropHelpers#`token=`().
+#  ⌄ enclosing_range_start [..] PropHelpers#token().
    token_prop
 #  ^^^^^ definition [..] PropHelpers#`token=`().
 #  ^^^^^ definition [..] PropHelpers#token().
 #  ^^^^^^^^^^ reference [..] `<Class:PropHelpers>`#token_prop().
 #  ^^^^^^^^^^ reference [..] String#
+#           ⌃ enclosing_range_end [..] PropHelpers#`token=`().
+#           ⌃ enclosing_range_end [..] PropHelpers#token().
+#  ⌄ enclosing_range_start [..] PropHelpers#`created=`().
+#  ⌄ enclosing_range_start [..] PropHelpers#created().
    created_prop
 #  ^^^^^^^ definition [..] PropHelpers#`created=`().
 #  ^^^^^^^ definition [..] PropHelpers#created().
 #  ^^^^^^^^^^^^ reference [..] `<Class:PropHelpers>`#created_prop().
 #  ^^^^^^^^^^^^ reference [..] Float#
+#             ⌃ enclosing_range_end [..] PropHelpers#`created=`().
+#             ⌃ enclosing_range_end [..] PropHelpers#created().
  end
+#  ⌃ enclosing_range_end [..] PropHelpers#
  
+#⌄ enclosing_range_start [..] PropHelpers2#
  class PropHelpers2
 #      ^^^^^^^^^^^^ definition [..] PropHelpers2#
    include T::Props
 #  ^^^^^^^ reference [..] Module#include().
 #          ^ reference [..] T#
 #             ^^^^^ reference [..] T#Props#
+#  ⌄ enclosing_range_start [..] `<Class:PropHelpers2>`#timestamped_token_prop().
    def self.timestamped_token_prop(opts={}); end
 #           ^^^^^^^^^^^^^^^^^^^^^^ definition [..] `<Class:PropHelpers2>`#timestamped_token_prop().
+#                                              ⌃ enclosing_range_end [..] `<Class:PropHelpers2>`#timestamped_token_prop().
+#  ⌄ enclosing_range_start [..] `<Class:PropHelpers2>`#created_prop().
    def self.created_prop(opts={}); end
 #           ^^^^^^^^^^^^ definition [..] `<Class:PropHelpers2>`#created_prop().
+#                                    ⌃ enclosing_range_end [..] `<Class:PropHelpers2>`#created_prop().
+#  ⌄ enclosing_range_start [..] PropHelpers2#`token=`().
+#  ⌄ enclosing_range_start [..] PropHelpers2#token().
    timestamped_token_prop
 #  ^^^^^^^^^^^^^^^^^^^^^^ reference [..] `<Class:PropHelpers2>`#timestamped_token_prop().
 #  ^^^^^^^^^^^^^^^^^^^^^^ reference [..] String#
 #              ^^^^^ definition [..] PropHelpers2#`token=`().
 #              ^^^^^ definition [..] PropHelpers2#token().
+#                       ⌃ enclosing_range_end [..] PropHelpers2#`token=`().
+#                       ⌃ enclosing_range_end [..] PropHelpers2#token().
+#  ⌄ enclosing_range_start [..] PropHelpers2#created().
    created_prop(immutable: true)
 #  ^^^^^^^^^^^^ reference [..] `<Class:PropHelpers2>`#created_prop().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] PropHelpers2#created().
 #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ reference [..] Float#
+#                              ⌃ enclosing_range_end [..] PropHelpers2#created().
  end
+#  ⌃ enclosing_range_end [..] PropHelpers2#
  
+#⌄ enclosing_range_start [..] Object#main().
  def main
 #    ^^^^ definition [..] Object#main().
      SomeODM.new.foo
@@ -310,3 +419,4 @@
 #                ^^^ reference [..] Class#new().
 #                    ^^^^^^^^^^^^^^^^^ reference [..] AdvancedODM#`ifunset_nilable=`().
  end
+#  ⌃ enclosing_range_end [..] Object#main().

--- a/test/scip/testdata/requires.snapshot.rb
+++ b/test/scip/testdata/requires.snapshot.rb
@@ -10,9 +10,11 @@
  require_relative 'non_existent_helper'
 #^^^^^^^^^^^^^^^^ reference [..] Kernel#require_relative().
  
+#⌄ enclosing_range_start [..] Object#lazy_load().
  def lazy_load
 #    ^^^^^^^^^ definition [..] Object#lazy_load().
    require 'csv'
 #  ^^^^^^^ reference [..] Kernel#require().
    return
  end
+#  ⌃ enclosing_range_end [..] Object#lazy_load().

--- a/test/scip/testdata/requires_ancestor.snapshot.rb
+++ b/test/scip/testdata/requires_ancestor.snapshot.rb
@@ -2,6 +2,7 @@
  
  # Exercises T::Helpers `requires_ancestor { ... }`.
  
+#⌄ enclosing_range_start [..] Greetable#
  module Greetable
 #       ^^^^^^^^^ definition [..] Greetable#
    extend T::Helpers
@@ -15,17 +16,23 @@
  
    sig { abstract.returns(String) }
 #                         ^^^^^^ reference [..] String#
+#  ⌄ enclosing_range_start [..] Greetable#name().
    def name; end
 #      ^^^^ definition [..] Greetable#name().
+#              ⌃ enclosing_range_end [..] Greetable#name().
  
    sig { void }
+#  ⌄ enclosing_range_start [..] Greetable#greet().
    def greet
 #      ^^^^^ definition [..] Greetable#greet().
      puts("Hello, " + name)
 #                     ^^^^ reference [..] Greetable#name().
    end
+#    ⌃ enclosing_range_end [..] Greetable#greet().
  end
+#  ⌃ enclosing_range_end [..] Greetable#
  
+#⌄ enclosing_range_start [..] GreetableClass#
  class GreetableClass
 #      ^^^^^^^^^^^^^^ definition [..] GreetableClass#
    extend T::Sig
@@ -37,8 +44,11 @@
  
    sig { override.returns(String) }
 #                         ^^^^^^ reference [..] String#
+#  ⌄ enclosing_range_start [..] GreetableClass#name().
    def name
 #      ^^^^ definition [..] GreetableClass#name().
      "World"
    end
+#    ⌃ enclosing_range_end [..] GreetableClass#name().
  end
+#  ⌃ enclosing_range_end [..] GreetableClass#

--- a/test/scip/testdata/rescue.snapshot.rb
+++ b/test/scip/testdata/rescue.snapshot.rb
@@ -1,10 +1,13 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] MyError#
  class MyError < StandardError
 #      ^^^^^^^ definition [..] MyError#
 #                ^^^^^^^^^^^^^ reference [..] StandardError#
  end
+#  ⌃ enclosing_range_end [..] MyError#
  
+#⌄ enclosing_range_start [..] Object#handle().
  def handle(e)
 #    ^^^^^^ definition [..] Object#handle().
 #           ^ definition local 1$780127187
@@ -14,7 +17,9 @@
 #         ^^^^^^^ reference [..] Kernel#inspect().
 #                 ^^^^ reference [..] Kernel#to_s().
  end
+#  ⌃ enclosing_range_end [..] Object#handle().
  
+#⌄ enclosing_range_start [..] Object#f().
  def f
 #    ^ definition [..] Object#f().
    begin
@@ -34,3 +39,4 @@
 #           ^^ reference local 4$3809224601
    end
  end
+#  ⌃ enclosing_range_end [..] Object#f().

--- a/test/scip/testdata/singleton.snapshot.rb
+++ b/test/scip/testdata/singleton.snapshot.rb
@@ -1,5 +1,6 @@
  # typed: true
  
+#⌄ enclosing_range_start [..] A#
  class A
 #      ^ definition [..] A#
    include Singleton
@@ -7,12 +8,16 @@
 #          ^^^^^^^^^ reference [..] Singleton#
 #          ^^^^^^^^^ reference [..] Singleton#
  end
+#  ⌃ enclosing_range_end [..] A#
  
  # Singleton supports inheritance, turning the sub-class into a singleton as well.
+#⌄ enclosing_range_start [..] B#
  class B < A; end
 #      ^ definition [..] B#
 #          ^ reference [..] A#
+#               ⌃ enclosing_range_end [..] B#
  
+#⌄ enclosing_range_start [..] C#
  class C
 #      ^ definition [..] C#
    include Singleton
@@ -23,7 +28,9 @@
 #  ^^^^^^ reference [..] Kernel#extend().
    final!
  end
+#  ⌃ enclosing_range_end [..] C#
  
+#⌄ enclosing_range_start [..] Object#f().
  def f
 #    ^ definition [..] Object#f().
    return [A.instance, B.instance, C.instance]
@@ -34,3 +41,4 @@
 #                                  ^ reference [..] C#
 #                                    ^^^^^^^^ reference [..] Singleton#SingletonClassMethods#instance().
  end
+#  ⌃ enclosing_range_end [..] Object#f().

--- a/test/scip/testdata/singleton_class.snapshot.rb
+++ b/test/scip/testdata/singleton_class.snapshot.rb
@@ -5,29 +5,42 @@
  # in field_inheritance.rb. This fixture captures the current behavior so a
  # future fix has a regression target.
  
+#⌄ enclosing_range_start [..] K#
  class K
 #      ^ definition [..] K#
+#  ⌄ enclosing_range_start [..] `<Class:K>`#
    class << self
 #           ^^^^ definition [..] `<Class:K>`#
+#    ⌄ enclosing_range_start [..] `<Class:K>`#class_method().
      def class_method
 #        ^^^^^^^^^^^^ definition [..] `<Class:K>`#class_method().
        @counter = 0
 #      ^^^^^^^^ definition [..] `<Class:K>`#`@counter`.
 #      ^^^^^^^^^^^^ reference [..] `<Class:K>`#`@counter`.
      end
+#      ⌃ enclosing_range_end [..] `<Class:K>`#class_method().
  
+#    ⌄ enclosing_range_start [..] `<Class:K>`#read_counter().
      def read_counter
 #        ^^^^^^^^^^^^ definition [..] `<Class:K>`#read_counter().
        @counter
 #      ^^^^^^^^ reference [..] `<Class:K>`#`@counter`.
      end
+#      ⌃ enclosing_range_end [..] `<Class:K>`#read_counter().
  
+#    ⌄ enclosing_range_start [..] `<Class:K>`#`name=`().
+#    ⌄ enclosing_range_start [..] `<Class:K>`#name().
      attr_accessor :name
 #                   ^^^^ definition [..] `<Class:K>`#`name=`().
 #                   ^^^^ definition [..] `<Class:K>`#name().
+#                      ⌃ enclosing_range_end [..] `<Class:K>`#`name=`().
+#                      ⌃ enclosing_range_end [..] `<Class:K>`#name().
    end
+#    ⌃ enclosing_range_end [..] `<Class:K>`#
  end
+#  ⌃ enclosing_range_end [..] K#
  
+#⌄ enclosing_range_start [..] Object#use_K().
  def use_K
 #    ^^^^^ definition [..] Object#use_K().
    K.class_method
@@ -46,3 +59,4 @@
 #        ^^^^ reference [..] `<Class:K>`#name().
    return
  end
+#  ⌃ enclosing_range_end [..] Object#use_K().

--- a/test/scip/testdata/struct.snapshot.rb
+++ b/test/scip/testdata/struct.snapshot.rb
@@ -1,23 +1,36 @@
  # typed: true
  
  # From Sorbet docs https://sorbet.org/docs/tstruct
+#⌄ enclosing_range_start [..] S#
+#⌄ enclosing_range_start [..] S#initialize().
  class S < T::Struct
 #      ^ definition [..] S#
 #      ^ definition [..] S#initialize().
 #          ^ reference [..] T#
 #             ^^^^^^ reference [..] T#Struct#
+#  ⌄ enclosing_range_start [..] S#`prop_i=`().
+#  ⌄ enclosing_range_start [..] S#prop_i().
    prop :prop_i, Integer
 #        ^^^^^^ definition [..] S#`prop_i=`().
 #        ^^^^^^ definition [..] S#prop_i().
 #                ^^^^^^^ reference [..] Integer#
+#                      ⌃ enclosing_range_end [..] S#`prop_i=`().
+#                      ⌃ enclosing_range_end [..] S#prop_i().
+#  ⌄ enclosing_range_start [..] S#const_s().
    const :const_s, T.nilable(String)
 #         ^^^^^^^ definition [..] S#const_s().
 #                            ^^^^^^ reference [..] String#
+#                                  ⌃ enclosing_range_end [..] S#const_s().
+#  ⌄ enclosing_range_start [..] S#const_f().
    const :const_f, Float, default: 0.5
 #         ^^^^^^^ definition [..] S#const_f().
 #                  ^^^^^ reference [..] Float#
+#                                    ⌃ enclosing_range_end [..] S#const_f().
  end
+#  ⌃ enclosing_range_end [..] S#
+#  ⌃ enclosing_range_end [..] S#initialize().
  
+#⌄ enclosing_range_start [..] Object#f().
  def f
 #    ^ definition [..] Object#f().
    s = S.new(prop_i: 3)
@@ -45,7 +58,14 @@
 #    ^^^^^^^^ reference [..] S#`prop_i=`().
    return
  end
+#  ⌃ enclosing_range_end [..] Object#f().
  
+#⌄ enclosing_range_start [..] POINT#
+#⌄ enclosing_range_start [..] POINT#
+#                    ⌄ enclosing_range_start [..] POINT#`x=`().
+#                    ⌄ enclosing_range_start [..] POINT#x().
+#                        ⌄ enclosing_range_start [..] POINT#`y=`().
+#                        ⌄ enclosing_range_start [..] POINT#y().
  POINT = Struct.new(:x, :y) do
 #^^^^^ reference [..] POINT#
 #^^^^^ definition [..] POINT#
@@ -56,14 +76,23 @@
 #                        ^ definition [..] POINT#`y=`().
 #                        ^ definition [..] POINT#y().
 #                        ^ reference [..] BasicObject#
+#                    ⌃ enclosing_range_end [..] POINT#`x=`().
+#                    ⌃ enclosing_range_end [..] POINT#x().
+#                        ⌃ enclosing_range_end [..] POINT#`y=`().
+#                        ⌃ enclosing_range_end [..] POINT#y().
+#  ⌄ enclosing_range_start [..] POINT#array().
    def array
 #      ^^^^^ definition [..] POINT#array().
      [x, y]
 #     ^ reference [..] POINT#x().
 #        ^ reference [..] POINT#y().
    end
+#    ⌃ enclosing_range_end [..] POINT#array().
  end
+#  ⌃ enclosing_range_end [..] POINT#
+#  ⌃ enclosing_range_end [..] POINT#
  
+#⌄ enclosing_range_start [..] Object#g().
  def g
 #    ^ definition [..] Object#g().
    p = POINT.new(0, 1)
@@ -80,3 +109,4 @@
 #         ^ reference [..] POINT#x().
    return
  end
+#  ⌃ enclosing_range_end [..] Object#g().

--- a/test/scip/testdata/super_call.snapshot.rb
+++ b/test/scip/testdata/super_call.snapshot.rb
@@ -3,30 +3,40 @@
  # Explicit-arg super (as opposed to implicit-arg, which is implicit_super_arg.rb)
  # Documents whether scip-ruby emits a reference to the parent method at `super`.
  
+#⌄ enclosing_range_start [..] Parent#
  class Parent
 #      ^^^^^^ definition [..] Parent#
+#  ⌄ enclosing_range_start [..] Parent#greet().
    def greet(name)
 #      ^^^^^ definition [..] Parent#greet().
 #            ^^^^ definition local 1$4213039946
      "Hi, " + name
 #             ^^^^ reference local 1$4213039946
    end
+#    ⌃ enclosing_range_end [..] Parent#greet().
  end
+#  ⌃ enclosing_range_end [..] Parent#
  
+#⌄ enclosing_range_start [..] Child#
  class Child < Parent
 #      ^^^^^ definition [..] Child#
 #              ^^^^^^ reference [..] Parent#
+#  ⌄ enclosing_range_start [..] Child#greet().
    def greet(name)
 #      ^^^^^ definition [..] Child#greet().
 #            ^^^^ definition local 1$4213039946
      super(name)
 #          ^^^^ reference local 1$4213039946
    end
+#    ⌃ enclosing_range_end [..] Child#greet().
  end
+#  ⌃ enclosing_range_end [..] Child#
  
+#⌄ enclosing_range_start [..] GrandChild#
  class GrandChild < Child
 #      ^^^^^^^^^^ definition [..] GrandChild#
 #                   ^^^^^ reference [..] Child#
+#  ⌄ enclosing_range_start [..] GrandChild#greet().
    def greet(name)
 #      ^^^^^ definition [..] GrandChild#greet().
 #            ^^^^ definition local 1$4213039946
@@ -36,8 +46,11 @@
      base + "!"
 #    ^^^^ reference local 2$4213039946
    end
+#    ⌃ enclosing_range_end [..] GrandChild#greet().
  end
+#  ⌃ enclosing_range_end [..] GrandChild#
  
+#⌄ enclosing_range_start [..] Object#trigger().
  def trigger
 #    ^^^^^^^ definition [..] Object#trigger().
    _ = GrandChild.new.greet("x")
@@ -47,3 +60,4 @@
 #                     ^^^^^ reference [..] GrandChild#greet().
    return
  end
+#  ⌃ enclosing_range_end [..] Object#trigger().

--- a/test/scip/testdata/t_helpers.snapshot.rb
+++ b/test/scip/testdata/t_helpers.snapshot.rb
@@ -3,6 +3,7 @@
  # T.must, T.assert_type!, T.absurd, T.bind. Other T.* operations
  # (T.let, T.cast, T.unsafe, T.reveal_type) are already covered elsewhere.
  
+#⌄ enclosing_range_start [..] Container#
  class Container
 #      ^^^^^^^^^ definition [..] Container#
    extend T::Sig
@@ -11,6 +12,7 @@
    sig { params(x: T.nilable(String)).returns(Integer) }
 #                            ^^^^^^ reference [..] String#
 #                                             ^^^^^^^ reference [..] Integer#
+#  ⌄ enclosing_range_start [..] Container#use_must().
    def use_must(x)
 #      ^^^^^^^^ definition [..] Container#use_must().
 #               ^ definition local 1$2138952860
@@ -20,9 +22,11 @@
 #           ^ reference local 1$2138952860
 #              ^^^^^^ reference [..] String#length().
    end
+#    ⌃ enclosing_range_end [..] Container#use_must().
  
    sig { params(x: T.untyped).returns(Integer) }
 #                                     ^^^^^^^ reference [..] Integer#
+#  ⌄ enclosing_range_start [..] Container#use_assert_type().
    def use_assert_type(x)
 #      ^^^^^^^^^^^^^^^ definition [..] Container#use_assert_type().
 #                      ^ definition local 1$3012239264
@@ -33,6 +37,7 @@
      x + 1
 #    ^ reference local 1$3012239264
    end
+#    ⌃ enclosing_range_end [..] Container#use_assert_type().
  
    Variant = T.type_alias { T.any(Integer, String) }
 #  ^^^^^^^ definition [..] Container#Variant.
@@ -42,6 +47,7 @@
    sig { params(x: Variant).returns(Integer) }
 #                  ^^^^^^^ reference [..] Container#Variant.
 #                                   ^^^^^^^ reference [..] Integer#
+#  ⌄ enclosing_range_start [..] Container#use_absurd().
    def use_absurd(x)
 #      ^^^^^^^^^^ definition [..] Container#use_absurd().
 #                 ^ definition local 1$4004738816
@@ -59,8 +65,10 @@
        T.absurd(x)
      end
    end
+#    ⌃ enclosing_range_end [..] Container#use_absurd().
  
    sig { returns(T.proc.void) }
+#  ⌄ enclosing_range_start [..] Container#use_bind().
    def use_bind
 #      ^^^^^^^^ definition [..] Container#use_bind().
      proc do
@@ -74,4 +82,6 @@
        nil
      end
    end
+#    ⌃ enclosing_range_end [..] Container#use_bind().
  end
+#  ⌃ enclosing_range_end [..] Container#

--- a/test/scip/testdata/test_case.snapshot.rb
+++ b/test/scip/testdata/test_case.snapshot.rb
@@ -1,10 +1,13 @@
  # typed: strict
  
+#⌄ enclosing_range_start [..] ActiveSupport#TestCase#
  class ActiveSupport::TestCase
 #      ^^^^^^^^^^^^^ reference [..] ActiveSupport#
 #                     ^^^^^^^^ definition [..] ActiveSupport#TestCase#
  end
+#  ⌃ enclosing_range_end [..] ActiveSupport#TestCase#
  
+#⌄ enclosing_range_start [..] MyTest#
  class MyTest < ActiveSupport::TestCase
 #      ^^^^^^ definition [..] MyTest#
 #               ^^^^^^^^^^^^^ reference [..] ActiveSupport#
@@ -14,18 +17,23 @@
    # Helper instance method
    sig { params(test: T.untyped).returns(T::Boolean) }
 #                                           ^^^^^^^ reference [..] T#Boolean.
+#  ⌄ enclosing_range_start [..] MyTest#assert().
    def assert(test)
 #      ^^^^^^ definition [..] MyTest#assert().
 #             ^^^^ definition local 1$2774883451
      test ? true : false
    end
+#    ⌃ enclosing_range_end [..] MyTest#assert().
  
    # Helper method to direct calls to `test` instead of Kernel#test
    sig { params(args: T.untyped, block: T.nilable(T.proc.void)).void }
+#  ⌄ enclosing_range_start [..] `<Class:MyTest>`#test().
    def self.test(*args, &block)
 #           ^^^^ definition [..] `<Class:MyTest>`#test().
    end
+#    ⌃ enclosing_range_end [..] `<Class:MyTest>`#test().
  
+#  ⌄ enclosing_range_start [..] MyTest#`<before>`().
    setup do
 #  ^^^^^ definition [..] MyTest#`<before>`().
      @a = T.let(1, Integer)
@@ -34,17 +42,24 @@
 #                  ^^^^^^^ definition local 1$2938098190
 #                  ^^^^^^^ reference [..] Integer#
    end
+#    ⌃ enclosing_range_end [..] MyTest#`<before>`().
  
+#  ⌄ enclosing_range_start [..] MyTest#test_valid_method_call().
    test "valid method call" do
 #       ^^^^^^^^^^^^^^^^^^^ definition [..] MyTest#test_valid_method_call().
    end
+#    ⌃ enclosing_range_end [..] MyTest#test_valid_method_call().
  
+#  ⌄ enclosing_range_start [..] MyTest#test_block_is_evaluated_in_the_context_of_an_instance().
    test "block is evaluated in the context of an instance" do
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] MyTest#test_block_is_evaluated_in_the_context_of_an_instance().
      assert true
    end
+#    ⌃ enclosing_range_end [..] MyTest#test_block_is_evaluated_in_the_context_of_an_instance().
  end
+#  ⌃ enclosing_range_end [..] MyTest#
  
+#⌄ enclosing_range_start [..] NoMatchTest#
  class NoMatchTest < ActiveSupport::TestCase
 #      ^^^^^^^^^^^ definition [..] NoMatchTest#
 #                    ^^^^^^^^^^^^^ reference [..] ActiveSupport#
@@ -53,31 +68,44 @@
 #  ^^^^^^ reference [..] Kernel#extend().
  
    sig { params(block: T.proc.void).void }
+#  ⌄ enclosing_range_start [..] `<Class:NoMatchTest>`#setup().
    def self.setup(&block); end
 #           ^^^^^ definition [..] `<Class:NoMatchTest>`#setup().
+#                            ⌃ enclosing_range_end [..] `<Class:NoMatchTest>`#setup().
  
    sig { params(block: T.proc.void).void }
+#  ⌄ enclosing_range_start [..] `<Class:NoMatchTest>`#teardown().
    def self.teardown(&block); end
 #           ^^^^^^^^ definition [..] `<Class:NoMatchTest>`#teardown().
+#                               ⌃ enclosing_range_end [..] `<Class:NoMatchTest>`#teardown().
  end
+#  ⌃ enclosing_range_end [..] NoMatchTest#
  
+#⌄ enclosing_range_start [..] NoParentClass#
  class NoParentClass
 #      ^^^^^^^^^^^^^ definition [..] NoParentClass#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
  
    sig { params(block: T.proc.void).void }
+#  ⌄ enclosing_range_start [..] `<Class:NoParentClass>`#setup().
    def self.setup(&block); end
 #           ^^^^^ definition [..] `<Class:NoParentClass>`#setup().
+#                            ⌃ enclosing_range_end [..] `<Class:NoParentClass>`#setup().
  
    sig { params(block: T.proc.void).void }
+#  ⌄ enclosing_range_start [..] `<Class:NoParentClass>`#teardown().
    def self.teardown(&block); end
 #           ^^^^^^^^ definition [..] `<Class:NoParentClass>`#teardown().
+#                               ⌃ enclosing_range_end [..] `<Class:NoParentClass>`#teardown().
  
    sig { params(a: T.untyped, b: T.untyped).void }
+#  ⌄ enclosing_range_start [..] NoParentClass#assert_equal().
    def assert_equal(a, b); end
 #      ^^^^^^^^^^^^ definition [..] NoParentClass#assert_equal().
+#                            ⌃ enclosing_range_end [..] NoParentClass#assert_equal().
  
+#  ⌄ enclosing_range_start [..] NoParentClass#`<before>`().
    setup do
 #  ^^^^^ definition [..] NoParentClass#`<before>`().
      @a = T.let(1, Integer)
@@ -86,16 +114,22 @@
 #                  ^^^^^^^ definition local 1$2938098190
 #                  ^^^^^^^ reference [..] Integer#
    end
+#    ⌃ enclosing_range_end [..] NoParentClass#`<before>`().
  
+#  ⌄ enclosing_range_start [..] NoParentClass#test_it_works().
    test "it works" do
 #       ^^^^^^^^^^ definition [..] NoParentClass#test_it_works().
      assert_equal 1, @a
    end
+#    ⌃ enclosing_range_end [..] NoParentClass#test_it_works().
  
+#  ⌄ enclosing_range_start [..] NoParentClass#teardown().
    teardown do
 #  ^^^^^^^^ definition [..] NoParentClass#teardown().
      @a = 5
 #    ^^ definition [..] NoParentClass#`@a`.
 #    ^^^^^^ reference [..] NoParentClass#`@a`.
    end
+#    ⌃ enclosing_range_end [..] NoParentClass#teardown().
  end
+#  ⌃ enclosing_range_end [..] NoParentClass#

--- a/test/scip/testdata/type_change.snapshot.rb
+++ b/test/scip/testdata/type_change.snapshot.rb
@@ -1,6 +1,7 @@
  # typed: true
  # options: showDocs
  
+#⌄ enclosing_range_start [..] Object#assign_different_branches().
  def assign_different_branches(b)
 #    ^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] Object#assign_different_branches().
 #    documentation
@@ -30,7 +31,9 @@
    end
    return
  end
+#  ⌃ enclosing_range_end [..] Object#assign_different_branches().
  
+#⌄ enclosing_range_start [..] Object#change_different_branches().
  def change_different_branches(b)
 #    ^^^^^^^^^^^^^^^^^^^^^^^^^ definition [..] Object#change_different_branches().
 #    documentation
@@ -66,7 +69,9 @@
    end
    return
  end
+#  ⌃ enclosing_range_end [..] Object#change_different_branches().
  
+#⌄ enclosing_range_start [..] Object#loop_type_change().
  def loop_type_change(bs)
 #    ^^^^^^^^^^^^^^^^ definition [..] Object#loop_type_change().
 #    documentation
@@ -123,7 +128,9 @@
    end
    return
  end
+#  ⌃ enclosing_range_end [..] Object#loop_type_change().
  
+#⌄ enclosing_range_start [..] C#
  class C
 #      ^ definition [..] C#
 #      documentation
@@ -137,6 +144,7 @@
 #  | @k (T.untyped)
 #  | ```
  
+#  ⌄ enclosing_range_start [..] C#change_type().
    def change_type(b)
 #      ^^^^^^^^^^^ definition [..] C#change_type().
 #      documentation
@@ -205,8 +213,11 @@
 #      | ```
      end
    end
+#    ⌃ enclosing_range_end [..] C#change_type().
  end
+#  ⌃ enclosing_range_end [..] C#
  
+#⌄ enclosing_range_start [..] D#
  class D < C
 #      ^ definition [..] D#
 #      documentation
@@ -214,6 +225,7 @@
 #      | class D < C
 #      | ```
 #          ^ reference [..] C#
+#  ⌄ enclosing_range_start [..] D#change_type().
    def change_type(b)
 #      ^^^^^^^^^^^ definition [..] D#change_type().
 #      documentation
@@ -278,4 +290,6 @@
 #      relation definition=[..] C#`@k`.
      end
    end
+#    ⌃ enclosing_range_end [..] D#change_type().
  end
+#  ⌃ enclosing_range_end [..] D#

--- a/test/scip/testdata/type_docs.snapshot.rb
+++ b/test/scip/testdata/type_docs.snapshot.rb
@@ -1,6 +1,7 @@
  # typed: true
  # options: showDocs
  
+#⌄ enclosing_range_start [..] M#
  module M
 #       ^ definition [..] M#
 #       documentation
@@ -13,6 +14,7 @@
 #                  ^^^^^^^ reference [..] Integer#
 #                              ^^^^^^ reference [..] String#
 #                                              ^^^^^^ reference [..] String#
+#  ⌄ enclosing_range_start [..] M#js_add().
    def js_add(x, y)
 #      ^^^^^^ definition [..] M#js_add().
 #      documentation
@@ -54,4 +56,6 @@
 #    | return ret (T.noreturn)
 #    | ```
    end
+#    ⌃ enclosing_range_end [..] M#js_add().
  end
+#  ⌃ enclosing_range_end [..] M#

--- a/test/scip/testdata/typed_false.snapshot.rb
+++ b/test/scip/testdata/typed_false.snapshot.rb
@@ -1,14 +1,18 @@
  # typed: false
  
+#⌄ enclosing_range_start [..] C#
  class C
 #      ^ definition [..] C#
+#  ⌄ enclosing_range_start [..] C#f().
    def f
 #      ^ definition [..] C#f().
      @f = 0
 #    ^^ definition [..] C#`@f`.
 #    ^^^^^^ reference [..] C#`@f`.
    end
+#    ⌃ enclosing_range_end [..] C#f().
  
+#  ⌄ enclosing_range_start [..] C#g().
    def g(x)
 #      ^ definition [..] C#g().
 #        ^ definition local 1$3792446982
@@ -17,4 +21,6 @@
 #        ^^ reference [..] C#`@f`.
 #             ^ reference [..] C#f().
    end
+#    ⌃ enclosing_range_end [..] C#g().
  end
+#  ⌃ enclosing_range_end [..] C#

--- a/test/scip/testdata/typed_ignore.snapshot.rb
+++ b/test/scip/testdata/typed_ignore.snapshot.rb
@@ -3,15 +3,19 @@
  # `typed: ignore` files are parsed but not typechecked. This locks in what
  # (if anything) the indexer emits for such files.
  
+#⌄ enclosing_range_start [..] IgnoredKlass#
  class IgnoredKlass
 #      ^^^^^^^^^^^^ definition [..] IgnoredKlass#
+#  ⌄ enclosing_range_start [..] IgnoredKlass#m().
    def m
 #      ^ definition [..] IgnoredKlass#m().
      @field = 1
 #    ^^^^^^ definition [..] IgnoredKlass#`@field`.
 #    ^^^^^^^^^^ reference [..] IgnoredKlass#`@field`.
    end
+#    ⌃ enclosing_range_end [..] IgnoredKlass#m().
  end
+#  ⌃ enclosing_range_end [..] IgnoredKlass#
  
  IgnoredKlass.new.m
 #^^^^^^^^^^^^ reference [..] IgnoredKlass#

--- a/test/scip/testdata/typed_strong.snapshot.rb
+++ b/test/scip/testdata/typed_strong.snapshot.rb
@@ -3,6 +3,7 @@
  # At `typed: strong` Sorbet requires that nothing be T.untyped. Locks in
  # indexer behavior for fully-typed code.
  
+#⌄ enclosing_range_start [..] StrongClass#
  class StrongClass
 #      ^^^^^^^^^^^ definition [..] StrongClass#
    extend T::Sig
@@ -11,6 +12,7 @@
    sig { params(x: Integer).returns(Integer) }
 #                  ^^^^^^^ reference [..] Integer#
 #                                   ^^^^^^^ reference [..] Integer#
+#  ⌄ enclosing_range_start [..] StrongClass#add_one().
    def add_one(x)
 #      ^^^^^^^ definition [..] StrongClass#add_one().
 #              ^ definition local 1$272034907
@@ -18,10 +20,12 @@
 #    ^ reference local 1$272034907
 #      ^ reference [..] Integer#+().
    end
+#    ⌃ enclosing_range_end [..] StrongClass#add_one().
  
    sig { params(x: String).returns(String) }
 #                  ^^^^^^ reference [..] String#
 #                                  ^^^^^^ reference [..] String#
+#  ⌄ enclosing_range_start [..] StrongClass#shout().
    def shout(x)
 #      ^^^^^ definition [..] StrongClass#shout().
 #            ^ definition local 1$3089998242
@@ -29,14 +33,18 @@
 #    ^ reference local 1$3089998242
 #      ^^^^^^ reference [..] String#upcase().
    end
+#    ⌃ enclosing_range_end [..] StrongClass#shout().
  end
+#  ⌃ enclosing_range_end [..] StrongClass#
  
+#⌄ enclosing_range_start [..] StrongUse#
  class StrongUse
 #      ^^^^^^^^^ definition [..] StrongUse#
    extend T::Sig
 #  ^^^^^^ reference [..] Kernel#extend().
  
    sig { void }
+#  ⌄ enclosing_range_start [..] StrongUse#call_them().
    def call_them
 #      ^^^^^^^^^ definition [..] StrongUse#call_them().
      s = StrongClass.new
@@ -53,4 +61,6 @@
 #          ^^^^^ reference [..] StrongClass#shout().
      nil
    end
+#    ⌃ enclosing_range_end [..] StrongUse#call_them().
  end
+#  ⌃ enclosing_range_end [..] StrongUse#

--- a/test/scip/testdata/yield_block.snapshot.rb
+++ b/test/scip/testdata/yield_block.snapshot.rb
@@ -4,6 +4,7 @@
  # in SCIPIndexer.cc treats YieldLoadArg / LoadYieldParams / YieldParamPresent
  # as no-ops.
  
+#⌄ enclosing_range_start [..] Object#with_yield().
  def with_yield(x)
 #    ^^^^^^^^^^ definition [..] Object#with_yield().
 #               ^ definition local 1$1452685967
@@ -12,13 +13,17 @@
    yield x + 1
 #        ^ reference local 1$1452685967
  end
+#  ⌃ enclosing_range_end [..] Object#with_yield().
  
+#⌄ enclosing_range_start [..] Object#with_yield_no_args().
  def with_yield_no_args
 #    ^^^^^^^^^^^^^^^^^^ definition [..] Object#with_yield_no_args().
    yield
    yield
  end
+#  ⌃ enclosing_range_end [..] Object#with_yield_no_args().
  
+#⌄ enclosing_range_start [..] Object#use_blocks().
  def use_blocks
 #    ^^^^^^^^^^ definition [..] Object#use_blocks().
    total = 0
@@ -40,3 +45,4 @@
    total
 #  ^^^^^ reference local 1$1737801135
  end
+#  ⌃ enclosing_range_end [..] Object#use_blocks().

--- a/test/scip_test_runner.cc
+++ b/test/scip_test_runner.cc
@@ -330,6 +330,11 @@ struct FormatOptions {
     bool showDocs;
 };
 
+struct EnclosingMarker {
+    SCIPRange range;
+    string symbol;
+};
+
 void formatSnapshot(const scip::Document &document, FormatOptions options, std::ostream &out) {
     UnorderedMap<string, scip::SymbolInformation> symbolTable{};
     symbolTable.reserve(document.symbols_size());
@@ -351,6 +356,29 @@ void formatSnapshot(const scip::Document &document, FormatOptions options, std::
                                             {"ruby latest", "[..]"},                          // core and stdlib
                                             {"_global_ latest", "[global]"}});
     };
+    UnorderedMap<int32_t, vector<EnclosingMarker>> enclosingByStartLine{};
+    UnorderedMap<int32_t, vector<EnclosingMarker>> enclosingByEndLine{};
+    for (auto &occ : occurrences) {
+        if (occ.enclosing_range_size() == 0) {
+            continue;
+        }
+        EnclosingMarker marker{SCIPRange(occ.enclosing_range()), occ.symbol()};
+        enclosingByStartLine[marker.range.start.line].push_back(marker);
+        enclosingByEndLine[marker.range.end.line].push_back(marker);
+    }
+    for (auto &entry : enclosingByStartLine) {
+        fast_sort(entry.second, [](const EnclosingMarker &a, const EnclosingMarker &b) -> bool {
+            return a.range.start.column != b.range.start.column ? a.range.start.column < b.range.start.column
+                                                               : a.symbol < b.symbol;
+        });
+    }
+    for (auto &entry : enclosingByEndLine) {
+        fast_sort(entry.second, [](const EnclosingMarker &a, const EnclosingMarker &b) -> bool {
+            return a.range.end.column != b.range.end.column ? a.range.end.column < b.range.end.column
+                                                           : a.symbol < b.symbol;
+        });
+    }
+
     size_t occ_i = 0;
     std::ifstream input(document.relative_path());
     ENFORCE(input.is_open(), "failed to open document to read source code");
@@ -359,6 +387,12 @@ void formatSnapshot(const scip::Document &document, FormatOptions options, std::
     for (string line; getline(input, line); lineNumber++) {
         if (!line.empty() && line.back() == '\r') {
             line.pop_back();
+        }
+        if (auto it = enclosingByStartLine.find(lineNumber); it != enclosingByStartLine.end()) {
+            for (auto &marker : it->second) {
+                out << '#' << string(marker.range.start.column - 1, ' ') << "⌄ enclosing_range_start "
+                    << formatSymbol(marker.symbol) << '\n';
+            }
         }
         out << ' '; // For '#'
         out << absl::StrReplaceAll(line, {{"\t", " "}});
@@ -438,6 +472,12 @@ void formatSnapshot(const scip::Document &document, FormatOptions options, std::
                     }
                 }
                 out << '\n';
+            }
+        }
+        if (auto it = enclosingByEndLine.find(lineNumber); it != enclosingByEndLine.end()) {
+            for (auto &marker : it->second) {
+                out << '#' << string(marker.range.end.column >= 2 ? marker.range.end.column - 2 : 0, ' ')
+                    << "⌃ enclosing_range_end " << formatSymbol(marker.symbol) << '\n';
             }
         }
     }


### PR DESCRIPTION
Adding enclosing_range to Occurences to capture the whole span of definitions.

Test: regold snapshots 
