### PR TITLE
fix: skip SCIP generation of occurrences with empty locations

### DIFF
--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -119,7 +119,12 @@ InlinedVector<int32_t, 4> fromSorbetLoc(const core::GlobalState &gs, core::Loc l
 }
 
 core::Loc trimColonColonPrefix(const core::GlobalState &gs, core::Loc baseLoc) {
-    ENFORCE(!baseLoc.empty());
+    // Sorbet can assign empty locations to synthesized AST nodes. There is no
+    // source prefix to trim in that case, and callers will skip emitting an
+    // occurrence because SCIP ranges must be non-empty.
+    if (!baseLoc.exists() || baseLoc.empty()) {
+        return baseLoc;
+    }
     auto source = baseLoc.source(gs);
     if (!source.has_value()) {
         return baseLoc;
@@ -291,6 +296,9 @@ private:
                                     const SmallVec<scip::Relationship> &rels,
                                     optional<core::Loc> enclosingLoc = nullopt) {
         ENFORCE(!symbolString.empty());
+        if (!occLoc.exists() || occLoc.empty()) {
+            return absl::OkStatus();
+        }
         occLoc = trimColonColonPrefix(gs, occLoc);
         auto range = sorbet::scip_indexer::fromSorbetLoc(gs, occLoc);
         if (range.size() == 4) {
@@ -328,7 +336,11 @@ private:
     void saveReferenceImpl(const core::GlobalState &gs, core::FileRef file, const string &symbolString,
                            const SmallVec<string> &overrideDocs, core::LocOffsets occLocOffsets, int32_t symbol_roles) {
         ENFORCE(!symbolString.empty());
-        auto occLoc = trimColonColonPrefix(gs, core::Loc(file, occLocOffsets));
+        auto occLoc = core::Loc(file, occLocOffsets);
+        if (!occLoc.exists() || occLoc.empty()) {
+            return;
+        }
+        occLoc = trimColonColonPrefix(gs, occLoc);
         scip::Occurrence occurrence;
         occurrence.set_symbol(symbolString);
         occurrence.set_symbol_roles(symbol_roles);

--- a/test/scip/testdata/minitest_3.rb
+++ b/test/scip/testdata/minitest_3.rb
@@ -11,6 +11,10 @@ class Test
   test_each([[1,2], [3,4]]) do |(a,b)|
 
     describe "d" do
+      # `before` inside `test_each` has a synthesized method name with an empty
+      # source location. The indexer should skip that definition occurrence.
+      before do
+      end
       it "b" do
         T.reveal_type(a) # error: Revealed type: `Integer`
       end

--- a/test/scip/testdata/minitest_3.snapshot.rb
+++ b/test/scip/testdata/minitest_3.snapshot.rb
@@ -31,6 +31,10 @@
 #                                   ^ definition local 2$416088458
  
      describe "d" do
+       # `before` inside `test_each` has a synthesized method name with an empty
+       # source location. The indexer should skip that definition occurrence.
+       before do
+       end
 #      ⌄ enclosing_range_start [..] Test#`<it 'b'>`().
        it "b" do
 #         ^^^ definition [..] Test#`<it 'b'>`().


### PR DESCRIPTION
In prod we observed a segfault / failing assertion `SCIPIndexer.cc:122 enforced condition !baseLoc.empty()`; this PR fixes that:

Sorbet can assign empty locations to synthesized AST nodes, including Minitest `before` hooks inside `test_each`. Passing these locations to `trimColonColonPrefix` triggers an assertion in debug builds and can segfault in release builds as we've seen in prod.

This PR fixes it by skipping definitions and references with empty locations before converting them to SCIP ranges.

### Test plan

The first commit of this PR adds a regression test which fails with the same error seen in prod, the second commit fixes it.

I also did a basic index of `Homebrew/brew` and `stripe/stripe-ruby` repositories, and both resulting SCIP indexes appear valid.