### PR TITLE
chore: prepare v0.4.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ allowing consumers to attribute references to their enclosing definitions.
 (https://github.com/sourcegraph/scip-ruby/pull/250)
 
 Fixes a crash when Sorbet assigns empty source locations to synthesized
-definitions, including Minitest `before` hooks inside `test_each`.
-(https://github.com/sourcegraph/scip-ruby/pull/254)
+definitions particularly with Minitest `before` hooks inside `test_each`.
+(https://github.com/sourcegraph/scip-ruby/pull/256)
 
 ## v0.4.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v0.4.8
+
+Adds enclosing ranges to SCIP class and method definition occurrences,
+allowing consumers to attribute references to their enclosing definitions.
+(https://github.com/sourcegraph/scip-ruby/pull/250)
+
+Fixes a crash when Sorbet assigns empty source locations to synthesized
+definitions, including Minitest `before` hooks inside `test_each`.
+(https://github.com/sourcegraph/scip-ruby/pull/254)
+
 ## v0.4.7
 
 Changes the internal symbol structure for local variables

--- a/scip_indexer/SCIPIndexer.cc
+++ b/scip_indexer/SCIPIndexer.cc
@@ -61,7 +61,7 @@ static uint32_t fnv1a_32(const string &s) {
     return h;
 }
 
-const char scip_ruby_version[] = "0.4.7";
+const char scip_ruby_version[] = "0.4.8";
 
 // Last updated: https://github.com/sourcegraph/scip-ruby/pull/217
 const char scip_ruby_sync_upstream_sorbet_sha[] = "0a7b175bc0bb41e2672369554f74364e83711a84";


### PR DESCRIPTION
### Motivation

Cut new release, particularly for https://github.com/sourcegraph/scip-ruby/pull/256 which is currently blocking a major SCIP consumer.

This also helps https://github.com/sourcegraph/scip-ruby/issues/253

### Test plan

This PR supersedes https://github.com/sourcegraph/scip-ruby/pull/248

In that PR, we had [deferred the release](https://github.com/sourcegraph/scip-ruby/pull/248#issuecomment-3849692499) due to some concerns, specifically:

1. #246 added questionable `T::Enum` behavior.
2. ..but I investigated and found that #249 subsequently reverted it completely.
3. Current master therefore retains the old `T::Enum` behavior.
4. #248 predates that revert and is stale. This PR supersedes it.
5. Ultimately, since v0.4.7, the only meaningful indexer behavior remaining on master is enclosing_range from #250 (https://github.com/sourcegraph/scip-ruby/pull/250), which has tests. 
