### PR TITLE
fix: set name locations for after/before in the minitest rewriter

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -225,14 +225,14 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
             ((send->fun == core::Names::before() || send->fun == core::Names::after()) && send->numPosArgs() == 0 &&
              correctBlockArity)) {
             core::NameRef name;
-            auto arg0Loc = core::LocOffsets::none();
+            auto nameLoc = send->funLoc;
             if (send->fun == core::Names::before()) {
                 name = core::Names::beforeAngles();
             } else if (send->fun == core::Names::after()) {
                 name = core::Names::afterAngles();
             } else {
                 // we use this for the name of our test
-                arg0Loc = send->getPosArg(0).loc();
+                nameLoc = send->getPosArg(0).loc();
                 auto argString = to_s(ctx, send->getPosArg(0));
                 name = ctx.state.enterNameUTF8("<it '" + argString + "'>");
             }
@@ -266,7 +266,7 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
                                             send->loc.copyWithZeroLength(), move(blk));
             // put that into a method def named the appropriate thing
             auto declLoc = declLocForSendWithBlock(*send);
-            auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, declLoc, arg0Loc, move(name), move(each)));
+            auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, declLoc, nameLoc, move(name), move(each)));
             // add back any moved constants
             return constantMover.addConstantsToExpression(send->loc, move(method));
         } else if (send->fun == core::Names::describe() && send->numPosArgs() == 1 && correctBlockArity) {

--- a/test/scip/testdata/minitest_3.rb
+++ b/test/scip/testdata/minitest_3.rb
@@ -11,6 +11,10 @@ class Test
   test_each([[1,2], [3,4]]) do |(a,b)|
 
     describe "d" do
+      before do
+      end
+      after do
+      end
       it "b" do
         T.reveal_type(a) # error: Revealed type: `Integer`
       end

--- a/test/scip/testdata/minitest_3.snapshot.rb
+++ b/test/scip/testdata/minitest_3.snapshot.rb
@@ -31,6 +31,16 @@
 #                                   ^ definition local 2$416088458
  
      describe "d" do
+#      ⌄ enclosing_range_start [..] Test#`<before>`().
+       before do
+#      ^^^^^^ definition [..] Test#`<before>`().
+       end
+#        ⌃ enclosing_range_end [..] Test#`<before>`().
+#      ⌄ enclosing_range_start [..] Test#`<after>`().
+       after do
+#      ^^^^^ definition [..] Test#`<after>`().
+       end
+#        ⌃ enclosing_range_end [..] Test#`<after>`().
 #      ⌄ enclosing_range_start [..] Test#`<it 'b'>`().
        it "b" do
 #         ^^^ definition [..] Test#`<it 'b'>`().


### PR DESCRIPTION
Make sure the minitest rewriter emits valid locations. For nodes like `before/after`, which aren't follow by a name/argument we emitted the `none` span which caused crashes downstream.

### Test plan
Updated snapshot test

@emidoots I hope this is a cleaner fix for the issue we observed